### PR TITLE
middleware: remove Payload query

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,7 +13,6 @@ export const config = {
   ],
 }
 
-// TODO: remove this if payload query works well, or just hard-code it for speed?
 export const AvalancheCenterWebsites: { slug: string; domain: string }[] = [
   { slug: 'nwac', domain: 'nwac.us' },
   { slug: 'bac', domain: 'bridgeportavalanchecenter.org' },
@@ -39,28 +38,6 @@ export const AvalancheCenterWebsites: { slug: string; domain: string }[] = [
 export default async function middleware(req: NextRequest) {
   const host = new URL(process.env.NEXT_PUBLIC_SERVER_URL)?.host
   const requestedHost = req.headers.get('host')
-
-  // const payload = await getPayload({ config: configPromise })
-  // const tenants = await payload.find({
-  //   collection: 'tenants',
-  //   draft: false,
-  //   overrideAccess: true,
-  //   pagination: false,
-  //   select: {
-  //     slug: true,
-  //     domains: true,
-  //   },
-  // })
-  // const tenantDomains: { slug: string; domains: string[] }[] = []
-  // for (const tenant of tenants.docs) {
-  //   const domains: string[] = []
-  //   if (tenant.domains) {
-  //     for (const domain of tenant.domains) {
-  //       domains.push(domain.domain)
-  //     }
-  //   }
-  //   tenantDomains.push({ slug: tenant.slug, domains: domains })
-  // }
 
   if (host && requestedHost) {
     // we want to encode the center outside the domain, but allow users to continue going to


### PR DESCRIPTION
We need the middleware to be as fast as possible, as it is in the critical path for every request. Instead of bothering to dynamically look up tenants from the CMS, we can hard-code the values we need. The list of avalanche centers in the US or their web properites is unlikely to change, so we do not risk correctness issues.