### PR TITLE
disabling all deployments on Vercel for now

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
Our deployment is still a WIP. Disabling all deployments for now. 

@stevekuznetsov If we still want merges into main to deploy we could change this to:
```
{
  "git": {
    "deploymentEnabled": {
      "*/*": false
    }
  }
}
```

and always follow the pattern you were using for branch names which I also like and adopted which is {gh username (or abbreviated)}/{descriptive branch name} for our feature branches. This config would still deploy main (and anything without a slash). 