### PR TITLE
.github: stop trying to send commit message

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -81,10 +81,8 @@ jobs:
         id: deployment
         run: |
           fullName="${{ github.repository }}"
-          commitMessage="$( jq --raw-output '.[0].message' <<<"${{ github.event.commits }}" )"
           vercel deploy --yes --prebuilt --target=preview \
             --meta='githubCommitAuthorName=${{ github.event.pusher.name }}' \
-            --meta='githubCommitMessage=${commitMessage}' \
             --meta='githubCommitOrg=${{ github.repository_owner }}' \
             --meta='githubCommitRef=${{ github.head_ref }}' \
             --meta="githubCommitRepo=${fullName##*/}" \

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -82,10 +82,8 @@ jobs:
         id: deployment
         run: |
           fullName="${{ github.repository }}"
-          commitMessage="$( jq --raw-output '.[0].message' <<<"${{ github.event.commits }}" )"
           vercel deploy --yes --prebuilt --target=production \
             --meta='githubCommitAuthorName=${{ github.event.pusher.name }}' \
-            --meta='githubCommitMessage=${commitMessage}' \
             --meta='githubCommitOrg=${{ github.repository_owner }}' \
             --meta='githubCommitRef=${{ github.head_ref }}' \
             --meta="githubCommitRepo=${fullName##*/}" \


### PR DESCRIPTION
For whatever reason, the commits array resolves to literal 'Array' string. Not providing this is ok - maybe just impacts some UI in the Vercel ecosystem.