### PR TITLE
.github: hard code meta tags for ref

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -84,7 +84,7 @@ jobs:
           vercel deploy --yes --prebuilt --target=preview \
             --meta='githubCommitAuthorName=${{ github.event.pusher.name }}' \
             --meta='githubCommitOrg=${{ github.repository_owner }}' \
-            --meta='githubCommitRef=${{ github.head_ref }}' \
+            --meta='githubCommitRef=main' \
             --meta="githubCommitRepo=${fullName##*/}" \
             --meta='githubCommitSha=${{ github.sha }}' \
             --meta='githubDeployment=1' \

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -85,7 +85,7 @@ jobs:
           vercel deploy --yes --prebuilt --target=production \
             --meta='githubCommitAuthorName=${{ github.event.pusher.name }}' \
             --meta='githubCommitOrg=${{ github.repository_owner }}' \
-            --meta='githubCommitRef=${{ github.head_ref }}' \
+            --meta='githubCommitRef=release' \
             --meta="githubCommitRepo=${fullName##*/}" \
             --meta='githubCommitSha=${{ github.sha }}' \
             --meta='githubDeployment=1' \


### PR DESCRIPTION
The GitHub context doesn't guarantee the branch name on push events, but we can just hard-code these since we just handle one branch per job.