### PR TITLE
scripts: remove all database files when cleaning up

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ When changes to the schema or seed data need to occur, simply start with a new d
 
 ## First time setup
 
+### Short-cut Bootstrapping
+
+Run the `./bootstrap.sh` script, which will create a new database file for you, add a `boostrap@avy.com` user, and grant them super-admin rights to three tenants. Then, run `pnpm dev` and start work straight away by logging in as that first user.
+
 ### Creating a new database
 
 Start a new database with:
@@ -61,6 +65,15 @@ Once a database file is chosen and the development server is started, navigate t
 This repo uses [Husky](https://typicode.github.io/husky/) and [lint-staged](https://github.com/lint-staged/lint-staged) to run a pre-commit hook that affects staged files. Our pre-commit hook formats staged files before committing. The `pnpm prepare` script should be automatically run after `pnpm install` which will configure the pre-commit hook to run on `git commit`.
 
 If the pre-commit hook isn't running on your commits you can manually run `pnpm prepare`.
+
+### Reviewing Pull Requests
+
+Running the seed script may take a while - when reviewing a pull request, you can [download](https://docs.turso.tech/cli/installation) the `turso` CLI, [initialize the client](https://docs.turso.tech/cli/introduction) and clone the preview database locally instead:
+
+```shell
+# branch names may have illegal characters for turso database names, hence the shell magic
+branch="skuznets/some-feature-thing" turso db shell payloadcms-preview-"${branch//[^a-z0-9\-]/x}" .dump | sqlite3 dev.db
+```
 
 ## Git
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Running the seed script may take a while - when reviewing a pull request, you ca
 
 ```shell
 # branch names may have illegal characters for turso database names, hence the shell magic
-branch="skuznets/some-feature-thing" turso db shell payloadcms-preview-"${branch//[^a-z0-9\-]/x}" .dump | sqlite3 dev.db
+branch="skuznets/some-feature-thing"; turso db shell "payloadcms-preview-${branch//[^a-z0-9\-]/x}" .dump | sqlite3 dev.db
 ```
 
 ## Git

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,20 +3,19 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-set -o xtrace
 
 function cleanup() {
+  rm -f login.json
   for job in $( jobs -p ); do
-    kill -SIGTERM "${job}"
+    kill -SIGKILL "${job}"
     wait "${job}"
   done
-  rm -f login.json
   echo "[INFO] dev.db bootstrapped run 'pnpm dev' and log in with user bootstrap@avy.com, password localpass"
 }
 trap cleanup EXIT
 
 echo "[INFO] Starting the development server..."
-rm -rf dev.db
+rm -rf dev.db dev.db-shm dev.db-wal
 sqlite3 dev.db -- 'PRAGMA journal_mode=WAL;'
 set +o errexit
 pnpm dev &

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,6 +11,7 @@ function cleanup() {
     wait "${job}"
   done
   rm -f login.json
+  echo "[INFO] dev.db bootstrapped run 'pnpm dev' and log in with user bootstrap@avy.com, password localpass"
 }
 trap cleanup EXIT
 
@@ -30,18 +31,5 @@ for (( i = 0; i < 10; i++ )); do
 done
 
 echo "[INFO] Creating the bootstrap user and seeding the database..."
-curl -s -H 'Content-Type: application/json' -H 'Accept: application/json' -X POST http://localhost:3000/api/users/first-register --data '{"email":"bootstrap@avy.com","password":"test","confirm-password":"test","name":"Bootstrap User"}' > login.json
-curl -H "Authorization: Bearer $( jq --raw-output .token <login.json )" -X POST http://localhost:3000/next/seed
-
-echo "[INFO] Stopping the development server..."
-set +o errexit
-cleanup
-set -o errexit
-
-if [[ -n "${SKIP_BUILD:-}" ]]; then
-  echo "[INFO] Skipping build..."
-  exit 0
-fi
-
-echo "[INFO] Running a production build using the seeded database..."
-pnpm build
+curl -s -H 'Content-Type: application/json' -H 'Accept: application/json' -X POST http://localhost:3000/api/users/first-register --data '{"email":"bootstrap@avy.com","password":"localpass","confirm-password":"localpass","name":"Bootstrap User"}' > login.json
+curl -H "Authorization: Bearer $( jq --raw-output .token <login.json )" -X POST http://localhost:3000/next/bootstrap

--- a/seed-build.sh
+++ b/seed-build.sh
@@ -15,7 +15,7 @@ function cleanup() {
 trap cleanup EXIT
 
 echo "[INFO] Starting the development server..."
-rm -rf dev.db
+rm -rf dev.db dev.db-shm dev.db-wal
 sqlite3 dev.db -- 'PRAGMA journal_mode=WAL;'
 set +o errexit
 pnpm dev &

--- a/seed-build.sh
+++ b/seed-build.sh
@@ -10,11 +10,13 @@ function cleanup() {
     kill -SIGTERM "${job}"
     wait "${job}"
   done
+  rm -f login.json
 }
 trap cleanup EXIT
 
 echo "[INFO] Starting the development server..."
 rm -rf dev.db
+sqlite3 dev.db -- 'PRAGMA journal_mode=WAL;'
 set +o errexit
 pnpm dev &
 set -o errexit

--- a/src/app/next/bootstrap/route.ts
+++ b/src/app/next/bootstrap/route.ts
@@ -1,0 +1,100 @@
+import { Role } from '@/payload-types'
+import config from '@payload-config'
+import { headers } from 'next/headers'
+import { getPayload, RequiredDataFromCollectionSlug } from 'payload'
+
+export const maxDuration = 120 // seconds
+
+export async function POST(): Promise<Response> {
+  const payload = await getPayload({ config })
+  const requestHeaders = await headers()
+
+  // Authenticate by passing request headers
+  const { user } = await payload.auth({ headers: requestHeaders })
+
+  if (!user) {
+    return new Response('Action forbidden.', { status: 403 })
+  }
+
+  try {
+    payload.logger.info(`— Seeding role...`)
+
+    const roleData: RequiredDataFromCollectionSlug<'roles'>[] = [
+      {
+        name: 'Admin',
+        rules: [
+          {
+            collections: ['*'],
+            actions: ['*'],
+          },
+        ],
+      },
+    ]
+    const roles: Record<string, Role> = {}
+    for (const data of roleData) {
+      payload.logger.info(`Creating ${data.name} role...`)
+      const role = await payload
+        .create({
+          collection: 'roles',
+          data: data,
+        })
+        .catch((e) => payload.logger.error(e))
+
+      if (!role) {
+        payload.logger.error(`Creating ${data.name} role returned null...`)
+        return new Response('Error seeding data.', { status: 500 })
+      }
+      roles[data.name] = role
+    }
+
+    payload.logger.info(`— Seeding global role assignments...`)
+
+    const _superAdminRoleAssignment = await payload
+      .create({
+        collection: 'globalRoleAssignments',
+        data: {
+          roles: [roles['Admin']],
+          user: user,
+        },
+      })
+      .catch((e) => payload.logger.error(e))
+
+    payload.logger.info(`— Seeding tenants...`)
+
+    const tenantData: RequiredDataFromCollectionSlug<'tenants'>[] = [
+      {
+        name: 'Northwest Avalanche Center',
+        slug: 'nwac',
+        domains: [{ domain: 'nwac.us' }],
+      },
+      {
+        name: 'Sierra Avalanche Center',
+        slug: 'sac',
+        domains: [{ domain: 'sierraavalanchecenter.org' }],
+      },
+      {
+        name: 'Sawtooth Avalanche Center',
+        slug: 'snfac',
+        domains: [{ domain: 'sawtoothavalanche.com' }],
+      },
+    ]
+    for (const data of tenantData) {
+      payload.logger.info(`Creating ${data.name} tenant returned...`)
+      const tenant = await payload
+        .create({
+          collection: 'tenants',
+          data: data,
+        })
+        .catch((e) => payload.logger.error(e))
+
+      if (!tenant) {
+        payload.logger.error(`Creating ${data.name} tenant returned null...`)
+        return new Response('Error seeding data.', { status: 500 })
+      }
+    }
+
+    return Response.json({ success: true })
+  } catch {
+    return new Response('Error seeding data.', { status: 500 })
+  }
+}


### PR DESCRIPTION
Revert "Merge pull request #149 from NWACus/fix-seed-script"

This reverts commit 892215418b23b704a1a21f3c117f9b04334d4372, reversing
changes made to 60b1f40fccec96cf870318b6337b7dd382109684.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

Revert "Merge pull request #148 from NWACus/revert-145-skuznets/bootstrap"

This reverts commit 60b1f40fccec96cf870318b6337b7dd382109684, reversing
changes made to 6610dcb46c41290320c4bf5c79a61c0fa1be75a6.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

scripts: remove all database files when cleaning up

Using WAL mode creates other ancillary files alongside the main database
store, which we need to clean up when we're removing the database.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

