### PR TITLE
.github: start a db shell after creating db

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -17,7 +17,7 @@ jobs:
           ref="${{ github.event.ref }}"
           branch="${ref##refs/heads/}"
           name="payloadcms-preview-${branch//[^a-z0-9\-]/x}"
+          echo "[INFO] Deleting databse ${name}"
           /home/runner/.turso/turso db destroy --yes "${name}"
         env:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
-# TODO: clean up Vercel deployment?

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -24,7 +24,9 @@ jobs:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
       - name: Create a new database for the preview
         id: database
-        run: /home/runner/.turso/turso db create payloadcms-dev --wait
+        run: |
+          /home/runner/.turso/turso db create payloadcms-dev --wait
+          /home/runner/.turso/turso db shell payloadcms-dev .tables
         env:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
       - name: Record database connection URI and token

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -25,6 +25,7 @@ jobs:
             /home/runner/.turso/turso db destroy "${name}" --yes
           fi
           /home/runner/.turso/turso db create "${name}" --wait
+          /home/runner/.turso/turso db shell "${name}" .tables
           echo "name=${name}" >> "${GITHUB_OUTPUT}"
         env:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -25,7 +25,9 @@ jobs:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
       - name: Create a new database
         id: database
-        run: /home/runner/.turso/turso db create payloadcms-prod --wait
+        run: |
+          /home/runner/.turso/turso db create payloadcms-prod --wait
+          /home/runner/.turso/turso db shell payloadcms-prod .tables
         env:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
       - name: Record database connection URI and token


### PR DESCRIPTION
We notice sporadic issues connecting to the database in the seed stage of our pipelines, but `turso db create --wait` should have solved that. This commit attempts to create a DB shell connection to wait fo the database to be reachable and functional before we move on.

Might fix https://github.com/NWACus/web/issues/160