### PR TITLE
reseed.sh: spit out a useful error message

### DIFF
--- a/reseed.sh
+++ b/reseed.sh
@@ -10,5 +10,8 @@ function cleanup() {
 trap cleanup EXIT
 
 echo "[INFO] Logging in with the bootstrap user and incrementally re-seeding the database..."
+if ! curl -s http://localhost:3000 >/dev/null 2>&1; then
+  echo "[ERROR] Couldn't contact the server at localhost:3000 - make sure you have 'pnpm dev' running in another terminal."
+fi
 curl -s -H 'Content-Type: application/json' -H 'Accept: application/json' -X POST http://localhost:3000/api/users/login --data '{"email":"admin@avy.com","password":"localpass"}' > login.json
 curl -H "Authorization: Bearer $( jq --raw-output .token <login.json )" -X POST http://localhost:3000/next/incremental


### PR DESCRIPTION
Before:

```
$ pnpm reseed

> web@1.0.0 reseed /home/stevekuznetsov/code/nwacus/web/src/github.com/nwacus/web
> ./reseed.sh

[INFO] Logging in with the bootstrap user and incrementally re-seeding the database...
 ELIFECYCLE  Command failed with exit code 7.
````

After:
```
$ pnpm reseed

> web@1.0.0 reseed /home/stevekuznetsov/code/nwacus/web/src/github.com/nwacus/web
> ./reseed.sh

[INFO] Logging in with the bootstrap user and incrementally re-seeding the database...
[ERROR] Couldn't contact the server at localhost:3000 - make sure you have 'pnpm dev' running in another terminal.
 ELIFECYCLE  Command failed with exit code 7.
```