### PR TITLE
Update tsconfig to include noUnusedLocals

### DIFF
--- a/src/Header/Component.tsx
+++ b/src/Header/Component.tsx
@@ -22,7 +22,7 @@ export async function Header({ center }: { center?: string }) {
     return <></>
   }
 
-  const _nav = await payload.find({
+  await payload.find({
     collection: 'navigations',
     depth: 1000,
     draft,

--- a/src/app/next/bootstrap/route.ts
+++ b/src/app/next/bootstrap/route.ts
@@ -49,7 +49,7 @@ export async function POST(): Promise<Response> {
 
     payload.logger.info(`— Seeding global role assignments...`)
 
-    const _superAdminRoleAssignment = await payload
+    await payload
       .create({
         collection: 'globalRoleAssignments',
         data: {

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -425,7 +425,8 @@ export const innerSeed = async ({
     sac: 'Blue',
     snfac: 'Zinc',
   }
-  const _brands = await upsert(
+  // Brands
+  await upsert(
     'brands',
     payload,
     incremental,
@@ -497,7 +498,8 @@ export const innerSeed = async ({
       user: user.id,
     })
   }
-  const _superAdminRoleAssignment = await upsertGlobals(
+  // SuperAdminRoleAssignment
+  await upsertGlobals(
     'globalRoleAssignments',
     payload,
     incremental,
@@ -505,7 +507,8 @@ export const innerSeed = async ({
     globalRoleAssignments,
   )
 
-  const _roles = await upsert(
+  // Roles
+  await upsert(
     'roleAssignments',
     payload,
     incremental,
@@ -602,7 +605,8 @@ export const innerSeed = async ({
       .flat(),
   )
 
-  const _categories = await upsert(
+  // Categories
+  await upsert(
     'categories',
     payload,
     incremental,
@@ -908,7 +912,8 @@ export const innerSeed = async ({
       .flat(),
   )
 
-  const _navigations = await upsert(
+  // Navigations
+  await upsert(
     'navigations',
     payload,
     incremental,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,18 +9,19 @@
       "ES2022"
     ],
     "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
     "incremental": true,
+    "isolatedModules": true,
     "jsx": "preserve",
     "module": "esnext",
     "moduleResolution": "bundler",
+    "noEmit": true,
+    "noUnusedLocals": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "sourceMap": true,
-    "isolatedModules": true,
+    "strict": true,
+    "strictNullChecks": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
In a PR we noticed the linter wasn't catching unused code. This PR enables `noUnusedLocal` in `tsconfig.json` and removes unused variables.