### PR TITLE
scripts: fail on >400 HTTP codes in curl

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,5 +10,5 @@ trap cleanup EXIT
 setup_dev_server
 
 echo "[INFO] Creating the bootstrap user and running a minimal seed on the database..."
-curl -s -H 'Content-Type: application/json' -H 'Accept: application/json' -X POST http://localhost:3000/api/users/first-register --data '{"email":"bootstrap@avy.com","password":"localpass","confirm-password":"localpass","name":"Bootstrap User"}' > login.json
-curl -H "Authorization: Bearer $( jq --raw-output .token <login.json )" -X POST http://localhost:3000/next/bootstrap
+curl -s -H 'Content-Type: application/json' -H 'Accept: application/json' -X POST --fail-with-body http://localhost:3000/api/users/first-register --data '{"email":"bootstrap@avy.com","password":"localpass","confirm-password":"localpass","name":"Bootstrap User"}' > login.json
+curl -H "Authorization: Bearer $( jq --raw-output .token <login.json )" -X POST --fail-with-body http://localhost:3000/next/bootstrap

--- a/reseed.sh
+++ b/reseed.sh
@@ -13,5 +13,5 @@ echo "[INFO] Logging in with the bootstrap user and incrementally re-seeding the
 if ! curl -s http://localhost:3000 >/dev/null 2>&1; then
   echo "[ERROR] Couldn't contact the server at localhost:3000 - make sure you have 'pnpm dev' running in another terminal."
 fi
-curl -s -H 'Content-Type: application/json' -H 'Accept: application/json' -X POST http://localhost:3000/api/users/login --data '{"email":"admin@avy.com","password":"localpass"}' > login.json
-curl -H "Authorization: Bearer $( jq --raw-output .token <login.json )" -X POST http://localhost:3000/next/incremental
+curl -s -H 'Content-Type: application/json' -H 'Accept: application/json' -X POST --fail-with-body http://localhost:3000/api/users/login --data '{"email":"admin@avy.com","password":"localpass"}' > login.json
+curl -H "Authorization: Bearer $( jq --raw-output .token <login.json )" -X POST --fail-with-body http://localhost:3000/next/incremental

--- a/seed.sh
+++ b/seed.sh
@@ -14,5 +14,5 @@ trap cleanup EXIT
 setup_dev_server
 
 echo "[INFO] Creating the bootstrap user and seeding the database..."
-curl -s -H 'Content-Type: application/json' -H 'Accept: application/json' -X POST http://localhost:3000/api/users/first-register --data '{"email":"bootstrap@avy.com","password":"test","confirm-password":"test","name":"Bootstrap User"}' > login.json
-curl -H "Authorization: Bearer $( jq --raw-output .token <login.json )" -X POST http://localhost:3000/next/seed
+curl -s -H 'Content-Type: application/json' -H 'Accept: application/json' -X POST --fail-with-body http://localhost:3000/api/users/first-register --data '{"email":"bootstrap@avy.com","password":"test","confirm-password":"test","name":"Bootstrap User"}' > login.json
+curl -H "Authorization: Bearer $( jq --raw-output .token <login.json )" -X POST --fail-with-body http://localhost:3000/next/seed


### PR DESCRIPTION
We previously would not fail when the endpoints we hit sent us something
>400.