### PR TITLE
endpoints: catch only at top level, fail on errors

### DIFF
--- a/src/app/next/bootstrap/route.ts
+++ b/src/app/next/bootstrap/route.ts
@@ -1,7 +1,7 @@
-import { Role } from '@/payload-types'
+import { bootstrap } from '@/endpoints/bootstrap'
 import config from '@payload-config'
 import { headers } from 'next/headers'
-import { getPayload, RequiredDataFromCollectionSlug } from 'payload'
+import { getPayload } from 'payload'
 
 export const maxDuration = 240 // seconds
 
@@ -17,84 +17,10 @@ export async function POST(): Promise<Response> {
   }
 
   try {
-    payload.logger.info(`— Seeding role...`)
-
-    const roleData: RequiredDataFromCollectionSlug<'roles'>[] = [
-      {
-        name: 'Admin',
-        rules: [
-          {
-            collections: ['*'],
-            actions: ['*'],
-          },
-        ],
-      },
-    ]
-    const roles: Record<string, Role> = {}
-    for (const data of roleData) {
-      payload.logger.info(`Creating ${data.name} role...`)
-      const role = await payload
-        .create({
-          collection: 'roles',
-          data: data,
-        })
-        .catch((e) => payload.logger.error(e))
-
-      if (!role) {
-        payload.logger.error(`Creating ${data.name} role returned null...`)
-        return new Response('Error seeding data.', { status: 500 })
-      }
-      roles[data.name] = role
-    }
-
-    payload.logger.info(`— Seeding global role assignments...`)
-
-    await payload
-      .create({
-        collection: 'globalRoleAssignments',
-        data: {
-          roles: [roles['Admin']],
-          user: user,
-        },
-      })
-      .catch((e) => payload.logger.error(e))
-
-    payload.logger.info(`— Seeding tenants...`)
-
-    const tenantData: RequiredDataFromCollectionSlug<'tenants'>[] = [
-      {
-        name: 'Northwest Avalanche Center',
-        slug: 'nwac',
-        domains: [{ domain: 'nwac.us' }],
-      },
-      {
-        name: 'Sierra Avalanche Center',
-        slug: 'sac',
-        domains: [{ domain: 'sierraavalanchecenter.org' }],
-      },
-      {
-        name: 'Sawtooth Avalanche Center',
-        slug: 'snfac',
-        domains: [{ domain: 'sawtoothavalanche.com' }],
-      },
-    ]
-    for (const data of tenantData) {
-      payload.logger.info(`Creating ${data.name} tenant returned...`)
-      const tenant = await payload
-        .create({
-          collection: 'tenants',
-          data: data,
-        })
-        .catch((e) => payload.logger.error(e))
-
-      if (!tenant) {
-        payload.logger.error(`Creating ${data.name} tenant returned null...`)
-        return new Response('Error seeding data.', { status: 500 })
-      }
-    }
-
+    await bootstrap({ payload, user })
     return Response.json({ success: true })
-  } catch {
+  } catch (e) {
+    payload.logger.error(e)
     return new Response('Error seeding data.', { status: 500 })
   }
 }

--- a/src/app/next/incremental/route.ts
+++ b/src/app/next/incremental/route.ts
@@ -24,7 +24,8 @@ export async function POST(): Promise<Response> {
     await seed({ payload, req: payloadReq, incremental: true })
 
     return Response.json({ success: true })
-  } catch {
+  } catch (e) {
+    payload.logger.error(e)
     return new Response('Error seeding data.', { status: 500 })
   }
 }

--- a/src/app/next/seed/route.ts
+++ b/src/app/next/seed/route.ts
@@ -24,7 +24,8 @@ export async function POST(): Promise<Response> {
     await seed({ payload, req: payloadReq, incremental: false })
 
     return Response.json({ success: true })
-  } catch {
+  } catch (e) {
+    payload.logger.error(e)
     return new Response('Error seeding data.', { status: 500 })
   }
 }

--- a/src/endpoints/bootstrap/index.ts
+++ b/src/endpoints/bootstrap/index.ts
@@ -1,0 +1,79 @@
+import { Role, User } from '@/payload-types'
+import { Payload, RequiredDataFromCollectionSlug } from 'payload'
+
+export const bootstrap = async ({
+  payload,
+  user,
+}: {
+  payload: Payload
+  user: User
+}): Promise<void> => {
+  payload.logger.info(`— Seeding role...`)
+
+  const roleData: RequiredDataFromCollectionSlug<'roles'>[] = [
+    {
+      name: 'Admin',
+      rules: [
+        {
+          collections: ['*'],
+          actions: ['*'],
+        },
+      ],
+    },
+  ]
+  const roles: Record<string, Role> = {}
+  for (const data of roleData) {
+    payload.logger.info(`Creating ${data.name} role...`)
+    const role = await payload.create({
+      collection: 'roles',
+      data: data,
+    })
+
+    if (!role) {
+      throw new Error(`Creating ${data.name} role returned null...`)
+    }
+    roles[data.name] = role
+  }
+
+  payload.logger.info(`— Seeding global role assignments...`)
+
+  // Super admin role assignment
+  await payload.create({
+    collection: 'globalRoleAssignments',
+    data: {
+      roles: [roles['Admin']],
+      user: user,
+    },
+  })
+
+  payload.logger.info(`— Seeding tenants...`)
+
+  const tenantData: RequiredDataFromCollectionSlug<'tenants'>[] = [
+    {
+      name: 'Northwest Avalanche Center',
+      slug: 'nwac',
+      domains: [{ domain: 'nwac.us' }],
+    },
+    {
+      name: 'Sierra Avalanche Center',
+      slug: 'sac',
+      domains: [{ domain: 'sierraavalanchecenter.org' }],
+    },
+    {
+      name: 'Sawtooth Avalanche Center',
+      slug: 'snfac',
+      domains: [{ domain: 'sawtoothavalanche.com' }],
+    },
+  ]
+  for (const data of tenantData) {
+    payload.logger.info(`Creating ${data.name} tenant returned...`)
+    const tenant = await payload.create({
+      collection: 'tenants',
+      data: data,
+    })
+
+    if (!tenant) {
+      throw new Error(`Creating ${data.name} tenant returned null...`)
+    }
+  }
+}

--- a/src/endpoints/seed/biographies.ts
+++ b/src/endpoints/seed/biographies.ts
@@ -14,10 +14,9 @@ export const seedStaff = async (
 
   const placeholder = await fetchFileByURL(
     'https://upload.wikimedia.org/wikipedia/commons/f/f8/Profile_photo_placeholder_square.svg',
-  ).catch((e) => payload.logger.error(e))
+  )
   if (!placeholder) {
-    payload.logger.error(`Downloading placeholder photo returned null...`)
-    return {}
+    throw new Error(`Downloading placeholder photo returned null...`)
   }
   const placeholders = await upsert('media', payload, incremental, tenantsById, (obj) => obj.alt, [
     ...Object.values(tenants).map(
@@ -38,10 +37,9 @@ export const seedStaff = async (
 
   const headshotData: { data: RequiredDataFromCollectionSlug<'media'>; file: File }[] = []
   for (const photo of headshots(tenants)) {
-    const image = await fetchFileByURL(photo.url).catch((e) => payload.logger.error(e))
+    const image = await fetchFileByURL(photo.url)
     if (!image) {
-      payload.logger.error(`Downloading ${photo.alt} photo returned null...`)
-      return {}
+      throw new Error(`Downloading ${photo.alt} photo returned null...`)
     }
     headshotData.push({
       data: {

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -59,22 +59,6 @@ export const seed = async ({
   req: PayloadRequest
   incremental: boolean
 }): Promise<void> => {
-  try {
-    await innerSeed({ payload, req, incremental })
-  } catch (error) {
-    payload.logger.error(error)
-  }
-}
-
-export const innerSeed = async ({
-  payload,
-  req,
-  incremental,
-}: {
-  payload: Payload
-  req: PayloadRequest
-  incremental: boolean
-}): Promise<void> => {
   payload.logger.info('Seeding database...')
   if (!incremental) {
     payload.logger.info(`— Clearing collections and globals...`)
@@ -100,13 +84,13 @@ export const innerSeed = async ({
         payload.logger.info(`Deleting collection: ${collection}`)
         return payload.db.deleteMany({ collection, req, where: {} })
       }),
-    ).catch((e) => payload.logger.error(e))
+    )
 
     await Promise.all(
       collections
         .filter((collection) => Boolean(payload.collections[collection].config.versions))
         .map((collection) => payload.db.deleteVersions({ collection, req, where: {} })),
-    ).catch((e) => payload.logger.error(e))
+    )
 
     payload.logger.info(`— Clearing users...`)
 
@@ -380,20 +364,16 @@ export const innerSeed = async ({
       const logo = await fetchFileByURL(
         'https://raw.githubusercontent.com/NWACus/avy/refs/heads/main/assets/logos/' +
           logoFiles[tenantSlug],
-      ).catch((e) => payload.logger.error(e))
+      )
       if (!logo) {
-        payload.logger.error(`Downloading logo for tenant ${tenantSlug} returned null...`)
-        return
+        throw new Error(`Downloading logo for tenant ${tenantSlug} returned null...`)
       }
       logos[tenantSlug] = logo
     }
     if (tenantSlug in bannerFiles) {
-      const banner = await fetchFileByURL(bannerFiles[tenantSlug]).catch((e) =>
-        payload.logger.error(e),
-      )
+      const banner = await fetchFileByURL(bannerFiles[tenantSlug])
       if (!banner) {
-        payload.logger.error(`Downloading banner for tenant ${tenantSlug} returned null...`)
-        return
+        throw new Error(`Downloading banner for tenant ${tenantSlug} returned null...`)
       }
       banners[tenantSlug] = banner
     }
@@ -679,17 +659,15 @@ export const innerSeed = async ({
       payload.logger.info(
         `Updating posts['${tenantsById[typeof post.tenant === 'number' ? post.tenant : post.tenant.id].slug}']['${post.slug}']...`,
       )
-      await payload
-        .update({
-          id: post.id,
-          collection: 'posts',
-          data: {
-            relatedPosts: Object.values(posts[tenant])
-              .filter((p) => p.id !== post.id)
-              .map((p) => p.id),
-          },
-        })
-        .catch(() => payload.logger.error)
+      await payload.update({
+        id: post.id,
+        collection: 'posts',
+        data: {
+          relatedPosts: Object.values(posts[tenant])
+            .filter((p) => p.id !== post.id)
+            .map((p) => p.id),
+        },
+      })
     }
   }
 
@@ -698,17 +676,14 @@ export const innerSeed = async ({
   const contactForms: Record<string, Form> = {}
   for (const tenant of Object.values(tenants)) {
     payload.logger.info(`Creating contact form for tenant ${tenant.name}...`)
-    const contactForm = await payload
-      .create({
-        collection: 'forms',
-        depth: 0,
-        data: { ...contactFormData, tenant: tenant.id },
-      })
-      .catch((e) => payload.logger.error(e))
+    const contactForm = await payload.create({
+      collection: 'forms',
+      depth: 0,
+      data: { ...contactFormData, tenant: tenant.id },
+    })
 
     if (!contactForm) {
-      payload.logger.error(`Creating contact form for tenant ${tenant.name} returned null...`)
-      return
+      throw new Error(`Creating contact form for tenant ${tenant.name} returned null...`)
     }
     contactForms[tenant.name] = contactForm
   }

--- a/src/endpoints/seed/upsert.ts
+++ b/src/endpoints/seed/upsert.ts
@@ -58,8 +58,7 @@ export async function upsertGlobals<TSlug extends GlobalCollectionWithHash>(
     const key = keyFunc(item)
     const representation = stringify(removeNonDeterministicKeys(JSON.parse(JSON.stringify(item))))
     if (!representation) {
-      payload.logger.error(`Creating stable serialization of ${collection}['${key}'] failed...`)
-      throw new Error()
+      throw new Error(`Creating stable serialization of ${collection}['${key}'] failed...`)
     }
     const hash = crypto.createHash('sha256').update(representation).digest('hex')
     item.contentHash = hash
@@ -73,22 +72,19 @@ export async function upsertGlobals<TSlug extends GlobalCollectionWithHash>(
           `Updating ${key} ${collection} as previous hash ${existing[key].contentHash} does not match current hash ${hash}...`,
         )
         payload.logger.info(representation)
-        const updated = await payload
-          .update({
-            id: existing[key].id,
-            collection: collection,
-            data: merge(existing[key], item) as ByIDOptions<
-              TSlug,
-              SelectFromCollectionSlug<TSlug>
-            >['data'],
-          })
-          .catch((e) => payload.logger.error(e))
+        const updated = await payload.update({
+          id: existing[key].id,
+          collection: collection,
+          data: merge(existing[key], item) as ByIDOptions<
+            TSlug,
+            SelectFromCollectionSlug<TSlug>
+          >['data'],
+        })
 
         if (!updated) {
-          payload.logger.error(
+          throw new Error(
             `Updating ${key} ${collection} returned no object: ${JSON.stringify(updated)}...`,
           )
-          throw new Error()
         }
         output[key] = updated
         continue
@@ -97,16 +93,13 @@ export async function upsertGlobals<TSlug extends GlobalCollectionWithHash>(
     payload.logger.info(
       `Creating ${collection}['${key}'] with hash ${item.contentHash.slice(0, 8)}...`,
     )
-    const created = await payload
-      .create({
-        collection: collection,
-        data: item,
-      })
-      .catch((e) => payload.logger.error(e))
+    const created = await payload.create({
+      collection: collection,
+      data: item,
+    })
 
     if (!created) {
-      payload.logger.error(`Creating ${collection}['${key}'] returned null...`)
-      throw new Error()
+      throw new Error(`Creating ${collection}['${key}'] returned null...`)
     }
     output[key] = created
   }
@@ -167,10 +160,9 @@ export async function upsert<TSlug extends TenantScopedCollectionWithHash>(
     }
     const representation = stringify(removeNonDeterministicKeys(JSON.parse(JSON.stringify(item))))
     if (!representation) {
-      payload.logger.error(
+      throw new Error(
         `Creating stable serialization of ${collection}['${tenant}']['${key}'] failed...`,
       )
-      throw new Error()
     }
     const hash = crypto.createHash('sha256').update(representation).digest('hex')
     item.contentHash = hash
@@ -195,22 +187,19 @@ export async function upsert<TSlug extends TenantScopedCollectionWithHash>(
           `Updating ${collection}['${tenant}']['${key}'] as previous hash ${existing[tenant][key].contentHash} does not match current hash ${hash}...`,
         )
         payload.logger.info(representation)
-        const updated = await payload
-          .update({
-            id: existing[tenant][key].id,
-            collection: collection,
-            data: merge(existing[tenant][key], item) as ByIDOptions<
-              TSlug,
-              SelectFromCollectionSlug<TSlug>
-            >['data'],
-          })
-          .catch((e) => payload.logger.error(e))
+        const updated = await payload.update({
+          id: existing[tenant][key].id,
+          collection: collection,
+          data: merge(existing[tenant][key], item) as ByIDOptions<
+            TSlug,
+            SelectFromCollectionSlug<TSlug>
+          >['data'],
+        })
 
         if (!updated) {
-          payload.logger.error(
+          throw new Error(
             `Updating ${collection}['${tenant}']['${key}'] returned no object: ${JSON.stringify(updated)}...`,
           )
-          throw new Error()
         }
         if (!(tenant in output)) {
           output[tenant] = {}
@@ -222,17 +211,14 @@ export async function upsert<TSlug extends TenantScopedCollectionWithHash>(
     payload.logger.info(
       `Creating ${collection}['${tenant}']['${key}'] with hash ${item.contentHash.slice(0, 8)}...`,
     )
-    const created = await payload
-      .create({
-        collection: collection,
-        data: item,
-        file: file,
-      })
-      .catch((e) => payload.logger.error(e))
+    const created = await payload.create({
+      collection: collection,
+      data: item,
+      file: file,
+    })
 
     if (!created) {
-      payload.logger.error(`Creating ${collection}['${tenant}']['${key}'] returned null...`)
-      throw new Error()
+      throw new Error(`Creating ${collection}['${tenant}']['${key}'] returned null...`)
     }
     if (!(tenant in output)) {
       output[tenant] = {}

--- a/utilities.sh
+++ b/utilities.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 function cleanup() {
+  return_code="$?"
   echo "[INFO] Stopping the development server..."
   for job in $( jobs -p ); do
     kill -SIGTERM "${job}"
@@ -9,7 +10,11 @@ function cleanup() {
     fi
   done
   rm -f login.json
-  echo "[INFO] Database at dev.db seeded!"
+  if [[ "${return_code}" = "0" ]]; then
+    echo "[INFO] Database at dev.db seeded!"
+  else
+    echo "[FAIL] Database at dev.db failed to seed!"
+  fi
 }
 
 


### PR DESCRIPTION
Our intermediate `catch{}` to log the error was making failures in seed not result in HTTP 500s.