### PR TITLE
Bug: Fixes load error on page or post without a slug

### DIFF
--- a/src/app/(frontend)/[center]/(sitemaps)/pages-sitemap.xml/route.ts
+++ b/src/app/(frontend)/[center]/(sitemaps)/pages-sitemap.xml/route.ts
@@ -12,7 +12,6 @@ const getPagesSitemap = unstable_cache(
     const results = await payload.find({
       collection: 'pages',
       overrideAccess: false,
-      draft: false,
       depth: 0,
       limit: 1000,
       pagination: false,

--- a/src/app/(frontend)/[center]/(sitemaps)/posts-sitemap.xml/route.ts
+++ b/src/app/(frontend)/[center]/(sitemaps)/posts-sitemap.xml/route.ts
@@ -12,7 +12,6 @@ const getPostsSitemap = unstable_cache(
     const results = await payload.find({
       collection: 'posts',
       overrideAccess: false,
-      draft: false,
       depth: 0,
       limit: 1000,
       pagination: false,

--- a/src/app/(frontend)/[center]/[...segments]/page.tsx
+++ b/src/app/(frontend)/[center]/[...segments]/page.tsx
@@ -14,9 +14,7 @@ export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const pages = await payload.find({
     collection: 'pages',
-    draft: false,
     limit: 1000,
-    overrideAccess: true,
     pagination: false,
     depth: 2,
     select: {

--- a/src/app/(frontend)/[center]/[...segments]/page.tsx
+++ b/src/app/(frontend)/[center]/[...segments]/page.tsx
@@ -120,6 +120,11 @@ const queryPageBySlug = cache(async ({ center, slug }: { center: string; slug: s
             equals: slug,
           },
         },
+        {
+          _status: {
+            equals: 'published',
+          },
+        },
       ],
     },
   })

--- a/src/app/(frontend)/[center]/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/[slug]/page.tsx
@@ -25,6 +25,11 @@ export async function generateStaticParams() {
       tenant: true,
       slug: true,
     },
+    where: {
+      _status: {
+        equals: 'published',
+      },
+    },
   })
 
   const params: PathArgs[] = []
@@ -33,7 +38,7 @@ export async function generateStaticParams() {
       payload.logger.error(`got number for page tenant: ${JSON.stringify(page.tenant)}`)
       continue
     }
-    if (page.tenant && page.slug) {
+    if (page.tenant) {
       params.push({ center: page.tenant.slug, slug: page.slug })
     }
   }

--- a/src/app/(frontend)/[center]/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/[slug]/page.tsx
@@ -18,7 +18,6 @@ export async function generateStaticParams() {
     collection: 'pages',
     draft: false, // does not remove posts with _status: 'draft'
     limit: 1000,
-    overrideAccess: true,
     pagination: false,
     depth: 2,
     select: {

--- a/src/app/(frontend)/[center]/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/[slug]/page.tsx
@@ -16,7 +16,6 @@ export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const pages = await payload.find({
     collection: 'pages',
-    draft: false, // does not remove posts with _status: 'draft'
     limit: 1000,
     pagination: false,
     depth: 2,

--- a/src/app/(frontend)/[center]/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/[slug]/page.tsx
@@ -16,7 +16,7 @@ export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const pages = await payload.find({
     collection: 'pages',
-    draft: false,
+    draft: false, // does not remove posts with _status: 'draft'
     limit: 1000,
     overrideAccess: true,
     pagination: false,
@@ -28,13 +28,13 @@ export async function generateStaticParams() {
   })
 
   const params: PathArgs[] = []
-  for (const post of pages.docs) {
-    if (typeof post.tenant === 'number') {
-      payload.logger.error(`got number for page tenant: ${JSON.stringify(post.tenant)}`)
+  for (const page of pages.docs) {
+    if (typeof page.tenant === 'number') {
+      payload.logger.error(`got number for page tenant: ${JSON.stringify(page.tenant)}`)
       continue
     }
-    if (post.tenant) {
-      params.push({ center: post.tenant.slug, slug: post.slug })
+    if (page.tenant && page.slug) {
+      params.push({ center: page.tenant.slug, slug: page.slug })
     }
   }
 

--- a/src/app/(frontend)/[center]/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/[slug]/page.tsx
@@ -23,6 +23,7 @@ export async function generateStaticParams() {
       tenant: true,
       slug: true,
     },
+    // Need where clause to ignore autosave bug (https://github.com/NWACus/web/pull/204)
     where: {
       _status: {
         equals: 'published',
@@ -123,6 +124,11 @@ const queryPageBySlug = cache(async ({ center, slug }: { center: string; slug: s
         {
           slug: {
             equals: slug,
+          },
+        },
+        {
+          _status: {
+            equals: 'published',
           },
         },
       ],

--- a/src/app/(frontend)/[center]/forecasts/avalanche/[zone]/page.tsx
+++ b/src/app/(frontend)/[center]/forecasts/avalanche/[zone]/page.tsx
@@ -16,9 +16,7 @@ export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const tenants = await payload.find({
     collection: 'tenants',
-    draft: false,
     limit: 1000,
-    overrideAccess: true,
     select: {
       slug: true,
     },
@@ -71,7 +69,6 @@ export async function generateMetadata({ params }: Args): Promise<Metadata> {
   const { center, zone } = await params
   const tenant = await payload.find({
     collection: 'tenants',
-    overrideAccess: true,
     select: {
       name: true,
     },

--- a/src/app/(frontend)/[center]/forecasts/avalanche/page.tsx
+++ b/src/app/(frontend)/[center]/forecasts/avalanche/page.tsx
@@ -16,9 +16,7 @@ export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const tenants = await payload.find({
     collection: 'tenants',
-    draft: false,
     limit: 1000,
-    overrideAccess: true,
     select: {
       slug: true,
     },
@@ -68,7 +66,6 @@ export async function generateMetadata({ params }: Args): Promise<Metadata> {
   const { center } = await params
   const tenant = await payload.find({
     collection: 'tenants',
-    overrideAccess: true,
     select: {
       name: true,
     },

--- a/src/app/(frontend)/[center]/layout.tsx
+++ b/src/app/(frontend)/[center]/layout.tsx
@@ -20,9 +20,7 @@ export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const tenants = await payload.find({
     collection: 'tenants',
-    draft: false,
     limit: 1000,
-    overrideAccess: true,
     pagination: false,
     select: {
       slug: true,

--- a/src/app/(frontend)/[center]/observations/page.tsx
+++ b/src/app/(frontend)/[center]/observations/page.tsx
@@ -15,9 +15,7 @@ export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const tenants = await payload.find({
     collection: 'tenants',
-    draft: false,
     limit: 1000,
-    overrideAccess: true,
     select: {
       slug: true,
     },
@@ -67,7 +65,6 @@ export async function generateMetadata({ params }: Args): Promise<Metadata> {
   const { center } = await params
   const tenant = await payload.find({
     collection: 'tenants',
-    overrideAccess: true,
     select: {
       name: true,
     },

--- a/src/app/(frontend)/[center]/page.tsx
+++ b/src/app/(frontend)/[center]/page.tsx
@@ -15,9 +15,7 @@ export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const tenants = await payload.find({
     collection: 'tenants',
-    draft: false,
     limit: 1000,
-    overrideAccess: true,
     select: {
       slug: true,
     },
@@ -68,7 +66,6 @@ export async function generateMetadata({ params }: Args): Promise<Metadata> {
   const { center } = await params
   const tenant = await payload.find({
     collection: 'tenants',
-    overrideAccess: true,
     select: {
       name: true,
     },

--- a/src/app/(frontend)/[center]/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/posts/[slug]/page.tsx
@@ -15,7 +15,6 @@ export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const posts = await payload.find({
     collection: 'posts',
-    draft: false, // does not remove posts with _status: 'draft'
     limit: 1000,
     pagination: false,
     depth: 3,

--- a/src/app/(frontend)/[center]/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/posts/[slug]/page.tsx
@@ -17,7 +17,6 @@ export async function generateStaticParams() {
     collection: 'posts',
     draft: false, // does not remove posts with _status: 'draft'
     limit: 1000,
-    overrideAccess: true,
     pagination: false,
     depth: 3,
     select: {

--- a/src/app/(frontend)/[center]/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/posts/[slug]/page.tsx
@@ -24,6 +24,11 @@ export async function generateStaticParams() {
       tenant: true,
       slug: true,
     },
+    where: {
+      _status: {
+        equals: 'published',
+      },
+    },
   })
 
   const params: PathArgs[] = []
@@ -32,7 +37,7 @@ export async function generateStaticParams() {
       payload.logger.error(`got number for post tenant`)
       continue
     }
-    if (post.tenant && post.slug) {
+    if (post.tenant) {
       params.push({ center: post.tenant.slug, slug: post.slug })
     }
   }

--- a/src/app/(frontend)/[center]/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/posts/[slug]/page.tsx
@@ -15,7 +15,7 @@ export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const posts = await payload.find({
     collection: 'posts',
-    draft: false,
+    draft: false, // does not remove posts with _status: 'draft'
     limit: 1000,
     overrideAccess: true,
     pagination: false,
@@ -32,7 +32,7 @@ export async function generateStaticParams() {
       payload.logger.error(`got number for post tenant`)
       continue
     }
-    if (post.tenant) {
+    if (post.tenant && post.slug) {
       params.push({ center: post.tenant.slug, slug: post.slug })
     }
   }

--- a/src/app/(frontend)/[center]/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/posts/[slug]/page.tsx
@@ -22,6 +22,7 @@ export async function generateStaticParams() {
       tenant: true,
       slug: true,
     },
+    // Need where clause to ignore autosave bug (https://github.com/NWACus/web/pull/204)
     where: {
       _status: {
         equals: 'published',

--- a/src/app/(frontend)/[center]/posts/page.tsx
+++ b/src/app/(frontend)/[center]/posts/page.tsx
@@ -25,7 +25,6 @@ export default async function Page({ params }: Args) {
     collection: 'posts',
     depth: 1,
     limit: 12,
-    overrideAccess: true,
     select: {
       title: true,
       slug: true,

--- a/src/app/(frontend)/[center]/search/page.tsx
+++ b/src/app/(frontend)/[center]/search/page.tsx
@@ -28,7 +28,6 @@ export default async function Page({
     collection: 'search',
     depth: 1,
     limit: 12,
-    overrideAccess: true,
     select: {
       title: true,
       slug: true,

--- a/src/app/(frontend)/[center]/theme-preview/page.tsx
+++ b/src/app/(frontend)/[center]/theme-preview/page.tsx
@@ -47,9 +47,7 @@ export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const tenants = await payload.find({
     collection: 'tenants',
-    draft: false,
     limit: 1000,
-    overrideAccess: true,
     select: {
       slug: true,
     },
@@ -553,7 +551,6 @@ export async function generateMetadata({ params }: Args): Promise<Metadata> {
   const { center } = await params
   const tenant = await payload.find({
     collection: 'tenants',
-    overrideAccess: true,
     select: {
       name: true,
     },

--- a/src/app/(frontend)/[center]/weather/stations/map/page.tsx
+++ b/src/app/(frontend)/[center]/weather/stations/map/page.tsx
@@ -15,9 +15,7 @@ export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })
   const tenants = await payload.find({
     collection: 'tenants',
-    draft: false,
     limit: 1000,
-    overrideAccess: true,
     select: {
       slug: true,
     },
@@ -69,7 +67,6 @@ export async function generateMetadata({ params }: Args): Promise<Metadata> {
   const { center } = await params
   const tenant = await payload.find({
     collection: 'tenants',
-    overrideAccess: true,
     select: {
       name: true,
     },

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -16,9 +16,7 @@ export default async function LandingPage() {
   const payload = await getPayload({ config: configPromise })
   const tenants = await payload.find({
     collection: 'tenants',
-    draft: false,
     limit: 1000,
-    overrideAccess: true,
     select: {
       slug: true,
       name: true,

--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -28,7 +28,6 @@ const prefixFilename: BeforeOperationHook = async ({ req }) => {
       req.payload.logger.debug(`media: fetching slug for tenant ${media.tenant}`)
       const tenant = await req.payload.find({
         collection: 'tenants',
-        overrideAccess: true,
         select: {
           slug: true,
         },

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -39,7 +39,6 @@ export async function Header({ center }: { center: string }) {
     collection: 'navigations',
     depth: 99,
     draft,
-    overrideAccess: true,
     where: {
       'tenant.slug': {
         equals: center,


### PR DESCRIPTION
### Description
I kept randomly getting an error 
```bash
Error: A required parameter (slug) was not provided as a string received object in generateStaticParams for /[center]/[slug]
``` 

### Steps to recreate
Create a new `page`/`post` and navigate away.  
Visit and `page`/`post` with the `[slug]` pattern.
See the error above/ it wont compile


### Why this is an issue
When an admin user goes to create a `page`/`post` and navigates away without filling anthing in, the `page`/`post` will auto save both of these every 100ms (We chose these settings to optimize for live preview and can be found in the `page`/`post` config settings.
The error occurs when we are loading `pages` and `posts` with `payload.find()`. Although we set `draft: false`, according the the [payload website](https://payloadcms.com/docs/versions/drafts#reading-drafts-vs-published-documents) 
> **Important**: the draft argument on its own will not restrict documents with `_status: 'draft'` from being returned from the API. 

Yes - this means it will then return ghost pages/posts with no slug.

### The fix
For now, I added a check to when we mapping the `page`/`post` to see if a slug exists on any `[slug]` files. 