### PR TITLE
Update blog permissions

### DIFF
--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -15,7 +15,6 @@ import { fileURLToPath } from 'url'
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 
-// TODO: why does importing this break?
 type BeforeOperationHook = Exclude<
   Exclude<CollectionConfig['hooks'], undefined>['beforeOperation'],
   undefined

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -288,8 +288,12 @@ export const seed = async ({
       name: 'Contributor',
       rules: [
         {
-          collections: ['posts', 'pages', 'media', 'tenants'],
+          collections: ['posts', 'pages', 'media'],
           actions: ['*'],
+        },
+        {
+          collections: ['tenants'],
+          actions: ['read'],
         },
       ],
     },

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -288,7 +288,7 @@ export const seed = async ({
       name: 'Contributor',
       rules: [
         {
-          collections: ['posts', 'pages', 'media'],
+          collections: ['posts', 'pages', 'media', 'tenants'],
           actions: ['*'],
         },
       ],

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -280,7 +280,7 @@ export const seed = async ({
       rules: [
         {
           collections: ['roleAssignments'],
-          actions: ['create', 'update'],
+          actions: ['create', 'read', 'update'],
         },
       ],
     },
@@ -289,7 +289,7 @@ export const seed = async ({
       rules: [
         {
           collections: ['posts', 'pages', 'media'],
-          actions: ['create', 'update'],
+          actions: ['*'],
         },
       ],
     },


### PR DESCRIPTION
### Description
This PR solves 2 issues I recognized when trying to create a blog post from `contributor@nwac.us`.
* **Add read access to roles**
    * When logging in as `contributor@nwac.us` `media`, `pages` and `posts` were missing from the admin panel. I added `read` permissions to the roles and the collections then showed in the admin panel. 
    * I updated the `roleAssignments` permissions since the same issue will occur. I also added `delete` permissions because it seems like a bad experience not to be able to delete a post. 
* **Add `tenant` to contributor permissions**
    * When uploading media as `contributor@nwac.us`, the upload would fail and show the error `The following field is invalid: Avalanche Center`. Upon further debugging, it appeared `tenantField` did not populate making [prefixFilename](https://github.com/NWACus/web/blob/main/src/collections/Media.ts#L23) error out since it is looking for `tenant in media` and `tenant` was not even passed as a property. When I updated the permissions to include `tenant` access in the role, and I debugged `prefixFilename`, the media passed had `tenant: 1`. 
    * This is confusing because we are giving [tenant read access to all users](https://github.com/NWACus/web/blob/main/src/collections/Tenants/index.ts#L49-L51), so it must not be behaving how we intend it to be? I also tried updating the tenant access config to include `create: () => true` and/or `update: () => true` but it still did not populate the tenant filed on media upload. 
    * I do not think this is the right solution but here is the problem since it would be very easy for someone to remove tenant access from permission, but I am out of my depth
    * I believe this is the same problem noted in the [TODO in the Media config.](https://github.com/NWACus/web/blob/main/src/collections/Media.ts#L18) 