### PR TITLE
Middleware fix

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,7 +11,7 @@ export const config = {
      * 4. all root files inside /public (e.g. /favicon.ico)
      * 5. /media and /thumbnail (inside /public)
      */
-    '/((?!api|_next|_static|_vercel|[\\w-]+\\.\\w+).*)|media|thumbnail',
+    '/((?!api|_next|_static|_vercel|media|thumbnail|[\\w-]+\\.\\w+).*)',
   ],
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,7 +11,7 @@ export const config = {
      * 4. all root files inside /public (e.g. /favicon.ico)
      * 5. /media and /thumbnail (inside /public)
      */
-    '/((?!api|_next|_static|_vercel|media|thumbnail|[\\w-]+\\.\\w+).*)',
+    '/((?!api|_next|_static|_vercel|[\\w-]+\\.\\w+|media|thumbnail).*)',
   ],
 }
 


### PR DESCRIPTION
I had tested with media|thumbnail inside the negative lookahead in the matcher pattern and then decided it would look more logical to re-order them but accidentally added them outside of the negative lookahead and didn't do a full regression test of navigating from the root domain to a subdomain 🤦 

This moves them back inside the negative lookahead, fixing a bug where we can't navigate to subdomains from the root domain. 