### PR TITLE
Rendering the first second-level nav item with sub items as open by default

### DIFF
--- a/src/components/AdminBar/index.tsx
+++ b/src/components/AdminBar/index.tsx
@@ -33,7 +33,7 @@ export const AdminBar = (props: { adminBarProps?: PayloadAdminBarProps }) => {
 
   return (
     <div
-      className={cn(baseClass, 'py-2 bg-black text-white', {
+      className={cn(baseClass, 'py-2 bg-black text-white z-50', {
         block: show,
         hidden: !show,
       })}

--- a/src/components/Header/DesktopNav.client.tsx
+++ b/src/components/Header/DesktopNav.client.tsx
@@ -46,6 +46,10 @@ export const DesktopNav = ({
             )
           }
 
+          const firstNavItemWithSubItems = navItem.items.find(
+            (item) => item.items && item.items.length > 0,
+          )
+
           return (
             <NavigationMenuItem key={label} value={label}>
               <NavigationMenuTrigger className="data-[state=open]:text-header-foreground-highlight font-medium">
@@ -56,6 +60,7 @@ export const DesktopNav = ({
                   type="single"
                   collapsible
                   className="grid min-w-max px-4 pt-2 pb-5 gap-2"
+                  defaultValue={firstNavItemWithSubItems?.id}
                 >
                   {navItem.items.map((item) => {
                     const hasSubItems = item.items && item.items.length > 0

--- a/src/components/Header/MobileNav.client.tsx
+++ b/src/components/Header/MobileNav.client.tsx
@@ -10,7 +10,7 @@ import {
   DialogTrigger,
 } from '@radix-ui/react-dialog'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import invariant from 'tiny-invariant'
 import { ImageMedia } from '../Media/ImageMedia'
 import { Accordion } from '../ui/accordion'
@@ -29,6 +29,25 @@ export const MobileNav = ({
   banner?: Media
 }) => {
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
+  const [headerHeight, setHeaderHeight] = useState(64) // fallback to the expected height of the mobile nav bar
+  const headerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const updateHeaderHeight = () => {
+      if (headerRef.current) {
+        const rect = headerRef.current.getBoundingClientRect()
+        setHeaderHeight(rect.bottom)
+      }
+    }
+
+    updateHeaderHeight()
+
+    window.addEventListener('resize', updateHeaderHeight)
+
+    return () => {
+      window.removeEventListener('resize', updateHeaderHeight)
+    }
+  }, [mobileNavOpen])
 
   useEffect(
     function manageScrollLock() {
@@ -55,7 +74,7 @@ export const MobileNav = ({
 
   return (
     <Dialog open={mobileNavOpen} onOpenChange={setMobileNavOpen} modal={false}>
-      <div className="lg:hidden fixed z-50 inset-x-0 py-3 bg-header shadow-sm">
+      <div ref={headerRef} className="lg:hidden fixed z-50 inset-x-0 py-3 bg-header shadow-sm">
         <div className="container flex justify-between items-center gap-5">
           <DialogTrigger className="p-2">
             <div className="flex w-6 h-6 flex-col items-center justify-center space-y-[5px] overflow-hidden outline-none">
@@ -99,7 +118,10 @@ export const MobileNav = ({
           className={cn('lg:hidden fixed inset-0', mobileNavOpen && 'pointer-events-none')}
           onClick={() => setMobileNavOpen(false)}
         />
-        <DialogContent className="lg:hidden max-h-[calc(100vh-64px)] overflow-y-auto fixed z-40 bg-header text-header-foreground pb-2 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 inset-x-0 top-[64px] border-b border-b-header-foreground-highlight data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top">
+        <DialogContent
+          className="lg:hidden max-h-[calc(100vh-64px)] overflow-y-auto fixed z-40 bg-header text-header-foreground pb-2 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 inset-x-0 border-b border-b-header-foreground-highlight data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top"
+          style={{ top: `${headerHeight}px` }}
+        >
           <DialogTitle className="sr-only">menu</DialogTitle>
           <DialogDescription className="sr-only">navigation menu</DialogDescription>
           <Accordion type="single" collapsible asChild>

--- a/src/components/Header/MobileNavItem.tsx
+++ b/src/components/Header/MobileNavItem.tsx
@@ -36,6 +36,8 @@ export const MobileNavItem = ({
     )
   }
 
+  const firstNavItemWithSubItems = navItem.items.find((item) => item.items && item.items.length > 0)
+
   return (
     <AccordionItem
       value={label}
@@ -50,7 +52,12 @@ export const MobileNavItem = ({
         {navItem.link ? navItem.link.label : label}
       </AccordionTrigger>
       <AccordionContent className="pt-0 pb-2">
-        <Accordion type="single" collapsible className="pl-4">
+        <Accordion
+          type="single"
+          collapsible
+          defaultValue={firstNavItemWithSubItems?.id}
+          className="pl-4"
+        >
           {navItem.items.map((item) => {
             if (!item.items || item.items.length === 0) {
               return item.link ? (
@@ -67,7 +74,7 @@ export const MobileNavItem = ({
 
             if (item.link?.label) {
               return (
-                <AccordionItem key={item.id} value={item.link.label} className="border-0">
+                <AccordionItem key={item.id} value={item.id} className="border-0">
                   <AccordionTrigger
                     className="py-2 text-base font-normal hover:no-underline -mb-1.5"
                     chevronClassName="h-6 w-6 text-inherit"

--- a/src/components/Header/utils.ts
+++ b/src/components/Header/utils.ts
@@ -236,50 +236,76 @@ export const getTopLevelNavItems = async ({
     )
 
     if (activeZones.length > 0) {
-      const zoneLinks: NavItem[] = activeZones
-        .sort((zoneA, zoneB) => (zoneA.rank ?? Infinity) - (zoneB.rank ?? Infinity))
-        .map(({ name, url }) => {
-          const lastPathPart = url.split('/').filter(Boolean).pop()
+      if (activeZones.length === 1) {
+        const zoneSlug = activeZones[0].url.split('/').filter(Boolean).pop()
 
-          return {
-            id: lastPathPart || name,
-            link: {
-              type: 'internal',
-              label: name,
-              url: lastPathPart ? `/forecasts/avalanche/${lastPathPart}` : '/forecasts/avalanche',
+        forecastsNavItem = {
+          label: 'Forecasts',
+          items: [
+            {
+              id: 'zone',
+              link: {
+                type: 'internal',
+                label: 'Avalanche',
+                url: `/forecasts/avalanche/${zoneSlug}`,
+              },
             },
-          }
-        })
+            {
+              id: 'archive',
+              link: {
+                type: 'internal',
+                label: 'Forecast Archive',
+                url: '/forecasts/avalanche/#/archive/forecast',
+              },
+            },
+          ],
+        }
+      } else {
+        const zoneLinks: NavItem[] = activeZones
+          .sort((zoneA, zoneB) => (zoneA.rank ?? Infinity) - (zoneB.rank ?? Infinity))
+          .map(({ name, url }) => {
+            const zoneSlug = url.split('/').filter(Boolean).pop()
 
-      forecastsNavItem = {
-        label: 'Forecasts',
-        items: [
-          {
-            id: 'all',
-            link: {
-              type: 'internal',
-              label: 'All Forecasts',
-              url: '/forecasts/avalanche',
+            return {
+              id: zoneSlug || name,
+              link: {
+                type: 'internal',
+                label: name,
+                url: zoneSlug ? `/forecasts/avalanche/${zoneSlug}` : '/forecasts/avalanche',
+              },
+            }
+          })
+
+        forecastsNavItem = {
+          label: 'Forecasts',
+          items: [
+            {
+              id: 'all',
+              link: {
+                type: 'internal',
+                label: 'All Forecasts',
+                url: '/forecasts/avalanche',
+              },
             },
-          },
-          {
-            id: 'zones',
-            items: zoneLinks,
-            link: {
-              type: 'internal',
-              label: 'Zones',
-              url: '/forecasts/avalanche',
+            {
+              id: 'zones',
+              items: zoneLinks,
+              link: {
+                type: 'internal',
+                label: 'Zones',
+                url: '/forecasts/avalanche',
+              },
             },
-          },
-          {
-            id: 'archive',
-            link: {
-              type: 'internal',
-              label: 'Forecast Archive',
-              url: '/forecasts/avalanche/#/archive/forecast',
+            {
+              id: 'archive',
+              link: {
+                type: 'internal',
+                label: 'Forecast Archive',
+                url: '/forecasts/avalanche/#/archive/forecast',
+              },
             },
-          },
-        ],
+          ],
+        }
       }
     }
   }


### PR DESCRIPTION
Resolves #4 

This PR:
- Renders the first second-level nav item with sub items as open by default. I.e.: 
![CleanShot 2025-06-05 at 17 27 51](https://github.com/user-attachments/assets/f0cff4bc-3858-426a-b9a7-7e3fa2be1574)
and 
![CleanShot 2025-06-05 at 17 27 38](https://github.com/user-attachments/assets/71854106-d3fe-438b-aa09-254b8ff43553)
- Handles rendering just a single link for center's with a single zone:
![CleanShot 2025-06-05 at 17 28 35](https://github.com/user-attachments/assets/7a986e5d-9442-4d9f-8fdf-3a8c3a50fd9d)
(need to fix the header highlight color for Sierra in another PR)
- Fixes issue on mobile where the Payload admin bar was causing the mobile nav bar dropdown to be partially hidden