### PR TITLE
Admin bar package updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@libsql/client": "^0.15.4",
+    "@payloadcms/admin-bar": "^3.42.0",
     "@payloadcms/db-sqlite": "3.33.0",
     "@payloadcms/live-preview-react": "3.33.0",
     "@payloadcms/next": "3.33.0",
@@ -66,7 +67,6 @@
     "next": "^15.2.4",
     "next-sitemap": "^4.2.3",
     "payload": "3.33.0",
-    "payload-admin-bar": "^1.0.6",
     "pino": "^9.6.0",
     "pluralize": "^8.0.0",
     "prism-react-renderer": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
       '@libsql/client':
         specifier: ^0.15.4
         version: 0.15.4
+      '@payloadcms/admin-bar':
+        specifier: ^3.42.0
+        version: 3.42.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@payloadcms/db-sqlite':
         specifier: 3.33.0
         version: 3.33.0(@types/react@19.0.1)(payload@3.33.0(graphql@16.10.0)(typescript@5.7.2))(react@19.1.0)
@@ -118,9 +121,6 @@ importers:
       payload:
         specifier: 3.33.0
         version: 3.33.0(graphql@16.10.0)(typescript@5.7.2)
-      payload-admin-bar:
-        specifier: ^1.0.6
-        version: 1.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       pino:
         specifier: ^9.6.0
         version: 9.6.0
@@ -2227,6 +2227,15 @@ packages:
         integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==,
       }
     engines: { node: '>=12.4.0' }
+
+  '@payloadcms/admin-bar@3.42.0':
+    resolution:
+      {
+        integrity: sha512-Upmf0B2r2nijvwtejM1L0NMSnsdgVk73R18Qy+l2n0gNWrU+q3Te4bKHVFUgoROG31TUTUSpMCZOQslj5N/Ejw==,
+      }
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@payloadcms/db-sqlite@3.33.0':
     resolution:
@@ -7043,15 +7052,6 @@ packages:
       }
     engines: { node: '>=8' }
 
-  payload-admin-bar@1.0.7:
-    resolution:
-      {
-        integrity: sha512-eY/FjfCGkyXOxRupv4IPZ+HFh8CQnJBQS++VItgTXe/g9H0B4RqxfdpU3g3tART3e8MzmZYGOBxV5EGGO2+jbg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   payload@3.33.0:
     resolution:
       {
@@ -10151,6 +10151,11 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@payloadcms/admin-bar@3.42.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   '@payloadcms/db-sqlite@3.33.0(@types/react@19.0.1)(payload@3.33.0(graphql@16.10.0)(typescript@5.7.2))(react@19.1.0)':
     dependencies:
@@ -13632,11 +13637,6 @@ snapshots:
   path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
-
-  payload-admin-bar@1.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
 
   payload@3.33.0(graphql@16.10.0)(typescript@5.7.2):
     dependencies:

--- a/src/app/next/exit-preview/GET.ts
+++ b/src/app/next/exit-preview/GET.ts
@@ -1,0 +1,7 @@
+import { draftMode } from 'next/headers'
+
+export async function GET(): Promise<Response> {
+  const draft = await draftMode()
+  draft.disable()
+  return new Response('Draft mode is disabled')
+}

--- a/src/app/next/exit-preview/route.ts
+++ b/src/app/next/exit-preview/route.ts
@@ -1,0 +1,7 @@
+import { draftMode } from 'next/headers'
+
+export async function GET(): Promise<Response> {
+  const draft = await draftMode()
+  draft.disable()
+  return new Response('Draft mode is disabled')
+}

--- a/src/components/AdminBar/index.scss
+++ b/src/components/AdminBar/index.scss
@@ -5,3 +5,9 @@
     display: none;
   }
 }
+
+@media (max-width: 768px) {
+  .admin-bar {
+    display: block;
+  }
+}

--- a/src/components/AdminBar/index.tsx
+++ b/src/components/AdminBar/index.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import type { PayloadAdminBarProps, PayloadMeUser } from 'payload-admin-bar'
+import type { PayloadAdminBarProps, PayloadMeUser } from '@payloadcms/admin-bar'
 
 import { cn } from '@/utilities/ui'
-import { useRouter, useSelectedLayoutSegments } from 'next/navigation'
-import { PayloadAdminBar } from 'payload-admin-bar'
-import plural from 'pluralize'
+import { PayloadAdminBar } from '@payloadcms/admin-bar'
+import { usePathname, useRouter } from 'next/navigation'
 import React, { useState } from 'react'
 
 import './index.scss'
@@ -14,11 +13,10 @@ import { getClientSideURL } from '@/utilities/getURL'
 
 const baseClass = 'admin-bar'
 
-const Title = () => <span>Dashboard</span>
+const Title = () => <span>AvyFx Admin Panel</span>
 
 export const AdminBar = (props: { adminBarProps?: PayloadAdminBarProps }) => {
   const { adminBarProps } = props || {}
-  const segments = useSelectedLayoutSegments()
   const [show, setShow] = useState(false)
   const router = useRouter()
 
@@ -26,16 +24,14 @@ export const AdminBar = (props: { adminBarProps?: PayloadAdminBarProps }) => {
     setShow(!!user?.id)
   }, [])
 
-  let collection: string = 'Unknown'
-  if (segments && segments.length > 1) {
-    collection = segments[1].charAt(0).toUpperCase() + segments[1].slice(1)
-  }
+  const pathname = usePathname()
 
   return (
     <div
       className={cn(baseClass, 'py-2 bg-black text-white z-50', {
         block: show,
         hidden: !show,
+        'bg-red-500': adminBarProps?.preview,
       })}
     >
       <div className="container">
@@ -48,16 +44,11 @@ export const AdminBar = (props: { adminBarProps?: PayloadAdminBarProps }) => {
             user: 'text-white',
           }}
           cmsURL={getClientSideURL()}
-          collection={collection}
-          collectionLabels={{
-            plural: plural(collection),
-            singular: collection,
-          }}
           logo={<Title />}
           onAuthChange={onAuthChange}
           onPreviewExit={() => {
             fetch('/next/exit-preview').then(() => {
-              router.push('/')
+              router.push(pathname)
               router.refresh()
             })
           }}


### PR DESCRIPTION
Updated admin bar package based on a commit to the Payload website template: https://github.com/payloadcms/payload/commit/7cef8900a74e20c886b1ba9b027ecdef10ce6f14 

I realized that the way we were determining the collection was flawed and figured it would be fine to just remove the "create new {collection}" functionality for now. 

I also realized that the exit preview mode wasn't working when previewing docs from the root domain. Currently we can't use draft mode across sub domains. We actually aren't sharing the payload-token across subdomains right now either but we could by modifying the cookie domain in the [users collection's auth config](https://payloadcms.com/docs/authentication/overview#config-options). But we don't get that control with the cookie used by Next.js as far as I can figure out. So I just added duplicate /exit-preview routes outside of the [center] scoped routes to be used during root domain previews. 

This PR also makes it more obvious that you're viewing a draft/preview page by making the admin bar red when in preview mode: 
![CleanShot 2025-06-09 at 19 49 41](https://github.com/user-attachments/assets/4342452c-12d9-4b8c-be56-9432476faa74)
 