### PR TITLE
fixing scroll lock bug + making payload admin bar fixed

### DIFF
--- a/src/components/AdminBar/index.tsx
+++ b/src/components/AdminBar/index.tsx
@@ -30,39 +30,48 @@ export const AdminBar = (props: { adminBarProps?: PayloadAdminBarProps }) => {
   const hostname = getHostnameFromTenant(tenant)
 
   return (
-    <div
-      className={cn(baseClass, 'py-2 bg-black text-white z-50', {
-        block: show,
-        hidden: !show,
-        'bg-red-500': adminBarProps?.preview,
-      })}
-    >
-      <div className="container">
-        <PayloadAdminBar
-          {...adminBarProps}
-          className="py-2 text-white"
-          classNames={{
-            controls: 'font-medium text-white',
-            logo: 'text-white',
-            user: 'text-white',
-          }}
-          cmsURL={getURL(hostname)}
-          logo={<Title />}
-          onAuthChange={onAuthChange}
-          onPreviewExit={() => {
-            fetch('/next/exit-preview').then(() => {
-              router.push(pathname)
-              router.refresh()
-            })
-          }}
-          style={{
-            backgroundColor: 'transparent',
-            padding: 0,
-            position: 'relative',
-            zIndex: 'unset',
-          }}
-        />
+    <>
+      <div
+        className={cn(baseClass, 'fixed top-0 inset-x-0 bg-black text-white z-50', {
+          'block py-2': show,
+          hidden: !show,
+          'bg-red-500': adminBarProps?.preview,
+        })}
+      >
+        <div className="container">
+          <PayloadAdminBar
+            {...adminBarProps}
+            className="py-2 text-white"
+            classNames={{
+              controls: 'font-medium text-white',
+              logo: 'text-white',
+              user: 'text-white',
+            }}
+            cmsURL={getURL(hostname)}
+            logo={<Title />}
+            onAuthChange={onAuthChange}
+            onPreviewExit={() => {
+              fetch('/next/exit-preview').then(() => {
+                router.push(pathname)
+                router.refresh()
+              })
+            }}
+            style={{
+              backgroundColor: 'transparent',
+              padding: 0,
+              position: 'relative',
+              zIndex: 'unset',
+            }}
+          />
+        </div>
       </div>
-    </div>
+      {/* content padding for mobile nav */}
+      <div
+        className={cn('h-[36px] bg-background', {
+          block: show,
+          hidden: !show,
+        })}
+      />
+    </>
   )
 }

--- a/src/components/Header/MobileNav.client.tsx
+++ b/src/components/Header/MobileNav.client.tsx
@@ -52,20 +52,10 @@ export const MobileNav = ({
   useEffect(
     function manageScrollLock() {
       if (mobileNavOpen) {
-        const scrollY = window.scrollY
-
-        document.body.style.position = 'fixed'
-        document.body.style.top = `-${scrollY}px`
-        document.body.style.width = '100%'
         document.body.style.overflow = 'hidden'
 
         return () => {
-          document.body.style.position = ''
-          document.body.style.top = ''
-          document.body.style.width = ''
-          document.body.style.overflow = ''
-
-          window.scrollTo(0, scrollY)
+          document.body.style.overflow = 'unset'
         }
       }
     },


### PR DESCRIPTION
Resolves #264 

The issue was related to how I was disabling scroll when the mobile nav bar was open. 

I also made the payload admin bar fixed because it helped resolve this issue but I also think it's a desirable behavior on desktop as well (you still know you're previewing / logged in to the admin panel when you've scrolled). 

![CleanShot 2025-06-23 at 15 28 29](https://github.com/user-attachments/assets/8fd8bef2-533b-44d3-b2de-9307d73d43a7)

![CleanShot 2025-06-23 at 15 29 01](https://github.com/user-attachments/assets/5a4aaa4b-06c7-4481-8fd2-fb38db4f250b)

![CleanShot 2025-06-23 at 15 29 36](https://github.com/user-attachments/assets/8e4ec080-2353-4b8b-a326-7748b15bc2fd)

