### PR TITLE
minimal changes from slate for the sawtooth theme

### DIFF
--- a/src/app/(frontend)/globals.css
+++ b/src/app/(frontend)/globals.css
@@ -127,6 +127,16 @@
     --brand-900: 206 57% 24%;
     --brand-950: 208 58% 16%;
   }
+
+  .snfac {
+    --secondary: 178 83% 35%;
+    --secondary-foreground: 0 0% 100%;
+
+    --callout: 178 83% 35%;
+    --callout-foreground: 0 0% 100%;
+
+    --header-foreground-highlight: 240 3.8% 35.3%;
+  }
 }
 
 @layer base {


### PR DESCRIPTION
Resolves #268 

Changed a minimal amount from the default slate theme. 

I wonder if we should use a different color for callout and secondary but I think it looks OK:
![CleanShot 2025-06-23 at 19 47 55@2x](https://github.com/user-attachments/assets/9c996ebe-75f7-47a7-bf27-df76c83c30a2)

We can ask Sawtooth if they want changes but this should do for now. 