### PR TITLE
Adjust roles for avalanche center roles

### DIFF
--- a/src/collections/Navigations/index.tsx
+++ b/src/collections/Navigations/index.tsx
@@ -87,9 +87,7 @@ export const Navigations: CollectionConfig = {
   ],
   versions: {
     drafts: {
-      autosave: {
-        interval: 100,
-      },
+      autosave: true,
     },
     maxPerDoc: 10,
   },

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -150,42 +150,73 @@ export const seed = async ({
 
   const roles = await upsertGlobals('roles', payload, incremental, (obj) => obj.name, [
     {
+      name: 'Super Admin',
+      rules: [
+        {
+          collections: ['*'],
+          actions: ['*'],
+        },
+      ],
+    },
+    {
       name: 'Admin',
       rules: [
         {
-          collections: ['*'],
-          actions: ['*'],
-        },
-      ],
-    },
-    {
-      name: 'User Administrator',
-      rules: [
-        {
-          collections: ['roleAssignments'],
-          actions: ['create', 'read', 'update'],
-        },
-      ],
-    },
-    {
-      name: 'Contributor',
-      rules: [
-        {
-          collections: ['posts', 'pages', 'media'],
+          collections: [
+            'pages',
+            'posts',
+            'tags',
+            'roleAssignments',
+            'settings',
+            'media',
+            'biographies',
+            'teams',
+            'forms',
+            'formSubmissions',
+            'users',
+            'redirects',
+          ],
           actions: ['*'],
         },
         {
-          collections: ['tenants'],
+          collections: ['navigations', 'tenants'],
           actions: ['read'],
         },
       ],
     },
     {
-      name: 'Viewer',
+      name: 'Forecaster',
       rules: [
         {
-          collections: ['*'],
-          actions: ['read'],
+          collections: [
+            'pages',
+            'posts',
+            'tags',
+            'media',
+            'biographies',
+            'teams',
+            'forms',
+            'formSubmissions',
+          ],
+          actions: ['*'],
+        },
+      ],
+    },
+    {
+      name: 'Non-Profit Staff',
+      rules: [
+        {
+          collections: [
+            'pages',
+            'posts',
+            'tags',
+            'media',
+            'biographies',
+            'teams',
+            'forms',
+            'formSubmissions',
+          ],
+          actions: ['*'],
         },
       ],
     },
@@ -414,13 +445,13 @@ export const seed = async ({
           password: password,
         },
         {
-          name: tenant.slug.toUpperCase() + ' Contributor',
-          email: 'contributor@' + (tenant.customDomain as NonNullable<Tenant['customDomain']>),
+          name: tenant.slug.toUpperCase() + ' Forecaster',
+          email: 'forecaster@' + (tenant.customDomain as NonNullable<Tenant['customDomain']>),
           password: password,
         },
         {
-          name: tenant.slug.toUpperCase() + ' Viewer',
-          email: 'viewer@' + (tenant.customDomain as NonNullable<Tenant['customDomain']>),
+          name: tenant.slug.toUpperCase() + ' Non-Profit Staff',
+          email: 'staff@' + (tenant.customDomain as NonNullable<Tenant['customDomain']>),
           password: password,
         },
       ])
@@ -438,13 +469,13 @@ export const seed = async ({
   const { user } = await payload.auth({ headers: requestHeaders })
   const globalRoleAssignments: RequiredDataFromCollectionSlug<'globalRoleAssignments'>[] = [
     {
-      roles: [roles['Admin'].id],
+      roles: [roles['Super Admin'].id],
       user: users['Super Admin'].id,
     },
   ]
   if (user && user.email !== users['Super Admin'].email) {
     globalRoleAssignments.push({
-      roles: [roles['Admin'].id],
+      roles: [roles['Super Admin'].id],
       user: user.id,
     })
   }
@@ -474,14 +505,14 @@ export const seed = async ({
           },
           {
             tenant: tenant.id,
-            roles: [roles['Contributor'].id],
-            user: users[tenant.slug.toUpperCase() + ' Contributor'].id,
+            roles: [roles['Forecaster'].id],
+            user: users[tenant.slug.toUpperCase() + ' Forecaster'].id,
           },
 
           {
             tenant: tenant.id,
-            roles: [roles['Viewer'].id],
-            user: users[tenant.slug.toUpperCase() + ' Viewer'].id,
+            roles: [roles['Non-Profit Staff'].id],
+            user: users[tenant.slug.toUpperCase() + ' Non-Profit Staff'].id,
           },
         ])
         .flat(),
@@ -548,7 +579,7 @@ export const seed = async ({
     Object.values(tenants)
       .map((tenant): RequiredDataFromCollectionSlug<'posts'>[] => [
         post1(tenant, images[tenant.slug]['image1'], images[tenant.slug]['image2'], [
-          users[tenant.slug.toUpperCase() + ' Contributor'],
+          users[tenant.slug.toUpperCase() + ' Forecaster'],
           users[tenant.slug.toUpperCase() + ' Admin'],
         ]),
         post2(
@@ -561,7 +592,7 @@ export const seed = async ({
           tenant,
           images[tenant.slug]['image3'],
           images[tenant.slug]['image1'],
-          users[tenant.slug.toUpperCase() + ' Contributor'],
+          users[tenant.slug.toUpperCase() + ' Forecaster'],
         ),
       ])
       .flat(),

--- a/src/fields/contentHashField.ts
+++ b/src/fields/contentHashField.ts
@@ -7,6 +7,8 @@ export const contentHashField = (): Field => {
     required: false,
     admin: {
       hidden: true,
+      disableListColumn: true,
+      disableListFilter: true,
     },
   }
 }


### PR DESCRIPTION
Adjusts seeded roles to match what we're thinking for avalanche center roles. 

I realize that the "Super Admin" role isn't necessarily a super admin since they might be tenant-scoped and we might not want to allow a tenant admin to have this role since we want to only allow read on some collections like navigations. But this is just a quick update for our demo and to get more in alignment with center roles. 

I also made two seemingly unrelated changes:
- The navigation autosave change is to resolve an error I started experiencing when limiting an admin user to only read navigations. I think the autosave was saving too quickly for access control to be handled correctly? Either way, using the default autosave time of 800ms resolved the issue I was running into. 
- I hid the contentHash field from list views and from list view filters. I figure this just makes sense for long term but also for demoing the admin panel as no one needs to see that field.