### PR TITLE
hiding readOnly lastLogin field during create operations

### DIFF
--- a/src/collections/Users/index.ts
+++ b/src/collections/Users/index.ts
@@ -52,6 +52,15 @@ export const Users: CollectionConfig = {
       type: 'date',
       admin: {
         readOnly: true,
+        date: {
+          displayFormat: 'LLLL do yyyy, hh:mm a',
+        },
+        condition: (_data, _siblingData, ctx) => {
+          if (ctx.operation === 'create') {
+            return false
+          }
+          return true
+        },
       },
     },
     contentHashField(),


### PR DESCRIPTION
Resolves #327 

Their create first user view explicitly sets readOnly to false in their RenderFields function which receives all fields for the users collection so it was showing up during create operations. I added a condition that hides the field if the operation is create. 