### PR TITLE
Adding permissive read back for the media collection

### DIFF
--- a/src/access/byTenantRole.ts
+++ b/src/access/byTenantRole.ts
@@ -62,3 +62,14 @@ export const accessByTenantRole: (collection: ruleCollection) => CollectionConfi
     delete: byTenantRole('delete', collection),
   }
 }
+
+export const accessByTenantRoleWithPermissiveRead: (
+  collection: ruleCollection,
+) => CollectionConfig['access'] = (collection: ruleCollection) => {
+  return {
+    create: byTenantRole('create', collection),
+    read: () => true, // world readable
+    update: byTenantRole('update', collection),
+    delete: byTenantRole('delete', collection),
+  }
+}

--- a/src/collections/Media/index.ts
+++ b/src/collections/Media/index.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from 'payload'
 
-import { accessByTenantRole } from '@/access/byTenantRole'
+import { accessByTenantRoleWithPermissiveRead } from '@/access/byTenantRole'
 import { filterByTenant } from '@/access/filterByTenant'
 import { contentHashField } from '@/fields/contentHashField'
 import { tenantField } from '@/fields/tenantField'
@@ -19,7 +19,7 @@ const dirname = path.dirname(filename)
 
 export const Media: CollectionConfig = {
   slug: 'media',
-  access: accessByTenantRole('media'),
+  access: accessByTenantRoleWithPermissiveRead('media'),
   admin: {
     baseListFilter: filterByTenant,
     group: 'Content',


### PR DESCRIPTION
Well, that was a silly mistake on my part. Removing permissive read for the media collection results in the frontend not being able to load images because they are client-side requests. 

#321 introduced this.