### PR TITLE
Restrict access to bootstrap and seed endpoints

### DIFF
--- a/src/app/next/bootstrap/route.ts
+++ b/src/app/next/bootstrap/route.ts
@@ -6,6 +6,11 @@ import { getPayload } from 'payload'
 export const maxDuration = 240 // seconds
 
 export async function POST(): Promise<Response> {
+  // Don't allow bootstrapping in production
+  if (process.env.NODE_ENV === 'production') {
+    return new Response('Not allowed.', { status: 403 })
+  }
+
   const payload = await getPayload({ config })
   const requestHeaders = await headers()
 

--- a/src/app/next/incremental/route.ts
+++ b/src/app/next/incremental/route.ts
@@ -1,7 +1,8 @@
+import { byGlobalRole } from '@/access/byGlobalRole'
 import { seed } from '@/endpoints/seed'
 import config from '@payload-config'
 import { headers } from 'next/headers'
-import { createLocalReq, getPayload } from 'payload'
+import { createLocalReq, getPayload, PayloadRequest } from 'payload'
 
 export const maxDuration = 240 // seconds
 
@@ -14,6 +15,23 @@ export async function POST(): Promise<Response> {
 
   if (!user) {
     return new Response('Action forbidden.', { status: 403 })
+  }
+
+  // Only allow access in production if the user is a super admin or the only existing user
+  if (process.env.NODE_ENV === 'production') {
+    const usersRes = await payload.count({
+      collection: 'users',
+    })
+
+    const mockedPayloadReq = {
+      user,
+      payload,
+    } as PayloadRequest
+    const isSuperAdmin = byGlobalRole('*', '*')({ req: mockedPayloadReq })
+
+    if (!isSuperAdmin && usersRes.totalDocs > 1) {
+      return new Response('Not allowed.', { status: 403 })
+    }
   }
 
   try {

--- a/src/app/next/incremental/route.ts
+++ b/src/app/next/incremental/route.ts
@@ -1,12 +1,16 @@
-import { byGlobalRole } from '@/access/byGlobalRole'
 import { seed } from '@/endpoints/seed'
 import config from '@payload-config'
 import { headers } from 'next/headers'
-import { createLocalReq, getPayload, PayloadRequest } from 'payload'
+import { createLocalReq, getPayload } from 'payload'
 
 export const maxDuration = 240 // seconds
 
 export async function POST(): Promise<Response> {
+  // Don't allow incremental seeding in production
+  if (process.env.NODE_ENV === 'production') {
+    return new Response('Not allowed.', { status: 403 })
+  }
+
   const payload = await getPayload({ config })
   const requestHeaders = await headers()
 
@@ -15,23 +19,6 @@ export async function POST(): Promise<Response> {
 
   if (!user) {
     return new Response('Action forbidden.', { status: 403 })
-  }
-
-  // Only allow access in production if the user is a super admin or the only existing user
-  if (process.env.NODE_ENV === 'production') {
-    const usersRes = await payload.count({
-      collection: 'users',
-    })
-
-    const mockedPayloadReq = {
-      user,
-      payload,
-    } as PayloadRequest
-    const isSuperAdmin = byGlobalRole('*', '*')({ req: mockedPayloadReq })
-
-    if (!isSuperAdmin && usersRes.totalDocs > 1) {
-      return new Response('Not allowed.', { status: 403 })
-    }
   }
 
   try {

--- a/src/app/next/seed/route.ts
+++ b/src/app/next/seed/route.ts
@@ -1,7 +1,8 @@
+import { byGlobalRole } from '@/access/byGlobalRole'
 import { seed } from '@/endpoints/seed'
 import config from '@payload-config'
 import { headers } from 'next/headers'
-import { createLocalReq, getPayload } from 'payload'
+import { createLocalReq, getPayload, PayloadRequest } from 'payload'
 
 export const maxDuration = 240 // seconds
 
@@ -14,6 +15,23 @@ export async function POST(): Promise<Response> {
 
   if (!user) {
     return new Response('Action forbidden.', { status: 403 })
+  }
+
+  // Only allow access in production if the user is a super admin or the only existing user
+  if (process.env.NODE_ENV === 'production') {
+    const usersRes = await payload.count({
+      collection: 'users',
+    })
+
+    const mockedPayloadReq = {
+      user,
+      payload,
+    } as PayloadRequest
+    const isSuperAdmin = byGlobalRole('*', '*')({ req: mockedPayloadReq })
+
+    if (!isSuperAdmin && usersRes.totalDocs > 1) {
+      return new Response('Not allowed.', { status: 403 })
+    }
   }
 
   try {


### PR DESCRIPTION
Right now any logged in user could technically hit the bootstrap, seed, or incremental seed endpoints in production. They just need to grab their `payload-token` from their cookie in their browser's dev tools and send a request with that as the Bearer token. 

Obviously, this isn't super likely but we might as well lock it down. 

