### PR TITLE
Fixes NAC widget/ navigation bug

### DIFF
--- a/src/app/(frontend)/[center]/nac-widgets.css
+++ b/src/app/(frontend)/[center]/nac-widgets.css
@@ -49,11 +49,6 @@
   display: none;
 }
 
-/* Hide All Archived Forecasts in date picker */
-#nac-date-selector .nac-container-fluid {
-  display: none;
-}
-
 #nac-app {
   min-height: initial !important;
 }

--- a/src/app/(frontend)/[center]/nac-widgets.css
+++ b/src/app/(frontend)/[center]/nac-widgets.css
@@ -39,11 +39,18 @@
   @apply bg-background text-foreground !important;
 }
 
+/* Hide Zone selector on top right */
 #nac-zone-selector {
   display: none;
 }
 
+/* Hide back to top button */
 #nac-app .nac-btn.nac-to-top {
+  display: none;
+}
+
+/* Hide All Archived Forecasts in date picker */
+#nac-date-selector .nac-container-fluid {
   display: none;
 }
 

--- a/src/components/NACWidget/WidgetHashHandler.client.tsx
+++ b/src/components/NACWidget/WidgetHashHandler.client.tsx
@@ -1,14 +1,15 @@
 'use client'
+import { useHash } from '@/utilities/useHash'
 import { useEffect } from 'react'
 
 export function WidgetHashHandler({ initialHash }: { initialHash: string }) {
-  useEffect(() => {
-    const url = new URL(window.location.href)
+  const hash = useHash()
 
-    if (!url.hash.includes(initialHash)) {
-      window.location.replace(`${url.pathname}${url.search}#${initialHash}`)
+  useEffect(() => {
+    if (!hash) {
+      window.location.hash = initialHash
     }
-  }, [initialHash])
+  }, [hash, initialHash])
 
   return null
 }

--- a/src/utilities/useHash.ts
+++ b/src/utilities/useHash.ts
@@ -3,7 +3,9 @@
 import { useEffect, useState } from 'react'
 
 export function useHash() {
-  const [hash, setHash] = useState('')
+  const [hash, setHash] = useState(() =>
+    typeof window !== 'undefined' ? window.location.hash : '',
+  )
 
   useEffect(() => {
     // Set initial hash asynchronously

--- a/src/utilities/useHash.ts
+++ b/src/utilities/useHash.ts
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function useHash() {
+  const [hash, setHash] = useState('')
+
+  useEffect(() => {
+    // Set initial hash asynchronously
+    setTimeout(() => {
+      setHash(window.location.hash)
+    }, 0)
+
+    const updateHash = () => {
+      // Defer state update to avoid useInsertionEffect error
+      setTimeout(() => {
+        setHash(window.location.hash)
+      }, 0)
+    }
+
+    window.addEventListener('hashchange', updateHash)
+    window.addEventListener('popstate', updateHash)
+
+    const originalPushState = window.history.pushState
+    const originalReplaceState = window.history.replaceState
+
+    window.history.pushState = function (...args) {
+      originalPushState.apply(window.history, args)
+      setTimeout(updateHash, 0)
+    }
+
+    window.history.replaceState = function (...args) {
+      originalReplaceState.apply(window.history, args)
+      setTimeout(updateHash, 0)
+    }
+
+    return () => {
+      window.removeEventListener('hashchange', updateHash)
+      window.removeEventListener('popstate', updateHash)
+      window.history.pushState = originalPushState
+      window.history.replaceState = originalReplaceState
+    }
+  }, [])
+
+  return hash
+}


### PR DESCRIPTION
### Description
When visiting the forecast archive from the date picker, clicking the zone link does not navigate you to the zone forecast anymore. The URL is updated but the widget does not update it's internal routing because the zone hash is not added to the URL. This PR hides the `All Forecast Archive` button in the date picker.


### Issues
Possibly fixes #292 