### PR TITLE
Bugfix: CSRF whitelist - include subdomains

### DIFF
--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -25,6 +25,7 @@ import { NACWidgetsConfig } from './globals/NACWidgetsConfig/config'
 import { plugins } from './plugins'
 import { getURL } from './utilities/getURL'
 import { getProductionTenantUrls } from './utilities/tenancy/getProductionTenantUrls'
+import { getTenantSubdomainUrls } from './utilities/tenancy/getTenantSubdomainUrls'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -155,7 +156,11 @@ export default buildConfig({
     getURL(),
     ...(await getProductionTenantUrls()),
   ].filter(Boolean),
-  csrf: [getURL(), ...(await getProductionTenantUrls())].filter(Boolean),
+  csrf: [
+    getURL(),
+    ...(await getTenantSubdomainUrls()),
+    ...(await getProductionTenantUrls()),
+  ].filter(Boolean),
   globals: [NACWidgetsConfig],
   graphQL: {
     disable: true,

--- a/src/utilities/tenancy/getProductionTenantUrls.ts
+++ b/src/utilities/tenancy/getProductionTenantUrls.ts
@@ -1,9 +1,9 @@
-import { getAllTenantsFromEdgeConfig } from '@/services/vercel'
 import { getURL } from '../getURL'
+import { getTenants } from './getTenants'
 import { PRODUCTION_TENANTS } from './tenants'
 
 export async function getProductionTenantUrls() {
-  const tenants = await getAllTenantsFromEdgeConfig()
+  const tenants = await getTenants()
   const productionTenantDefs = tenants.filter((tenant) => PRODUCTION_TENANTS.includes(tenant.slug))
   return productionTenantDefs.map(({ customDomain }) => getURL(customDomain))
 }

--- a/src/utilities/tenancy/getTenantSubdomainUrls.ts
+++ b/src/utilities/tenancy/getTenantSubdomainUrls.ts
@@ -1,0 +1,7 @@
+import { PROTOCOL, ROOT_DOMAIN } from '../domain'
+import { getTenants } from './getTenants'
+
+export async function getTenantSubdomainUrls() {
+  const tenants = await getTenants()
+  return tenants.map(({ slug }) => `${PROTOCOL}://${slug}.${ROOT_DOMAIN}`)
+}

--- a/src/utilities/tenancy/getTenants.ts
+++ b/src/utilities/tenancy/getTenants.ts
@@ -1,0 +1,17 @@
+import { getCachedTenants } from '@/collections/Tenants/endpoints/cachedPublicTenants'
+import { TenantData } from '@/middleware'
+import { getAllTenantsFromEdgeConfig } from '@/services/vercel'
+
+export async function getTenants(): Promise<TenantData> {
+  let tenants: TenantData = []
+
+  try {
+    tenants = await getAllTenantsFromEdgeConfig()
+  } catch {}
+
+  try {
+    tenants = await getCachedTenants()
+  } catch {}
+
+  return tenants
+}

--- a/src/utilities/tenancy/getTenants.ts
+++ b/src/utilities/tenancy/getTenants.ts
@@ -7,11 +7,18 @@ export async function getTenants(): Promise<TenantData> {
 
   try {
     tenants = await getAllTenantsFromEdgeConfig()
-  } catch {}
+  } catch (error) {
+    console.warn(
+      'Failed to get all tenants from Edge Config, falling back to cached API route:',
+      error instanceof Error ? error.message : error,
+    )
+  }
 
   try {
     tenants = await getCachedTenants()
-  } catch {}
+  } catch (error) {
+    console.warn('Failed to get cached tenants:', error instanceof Error ? error.message : error)
+  }
 
   return tenants
 }


### PR DESCRIPTION
Experiencing the following error on a user's account page while on a tenant's subdomain (i.e. `http://nwac.localhost:3000/admin/account`: 
```
index.js:15023 Uncaught (in promise) TypeError: Cannot destructure property 'data' of '(intermediate value)' as it is null.
```

Introduced in this PR: https://github.com/NWACus/web/pull/334/files#diff-f6b6f316a2640772c82fc212b5863ca4bf1139a256e8f4e1ef0145e1ac66daef 
Specifically, I added CSRF protection: https://payloadcms.com/docs/authentication/cookies#csrf-attacks

The docs make it seem like this should work across subdomains without additional configuration but that doesn't seem to be the case. I didn't notice the roles not loading (and some other bugs in my testing apparently). 

This PR adds all of our tenant subdomains to the csrf whitelist. 