### PR TITLE
ignoring /assets urls from middleware to avoid rewriting those urls

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,7 +13,7 @@ export const config = {
      * 4. all root files inside /public (e.g. /favicon.ico)
      * 5. /media and /thumbnail (inside /public)
      */
-    '/((?!api|_next|_static|_vercel|[\\w-]+\\.\\w+|media|thumbnail).*)',
+    '/((?!api|_next|_static|_vercel|[\\w-]+\\.\\w+|media|thumbnail|assets).*)',
   ],
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,6 +12,7 @@ export const config = {
      * 3. /_static (inside /public)
      * 4. all root files inside /public (e.g. /favicon.ico)
      * 5. /media and /thumbnail (inside /public)
+     * 6. files in /src/assets (used in Payload config and logo and icon components)
      */
     '/((?!api|_next|_static|_vercel|[\\w-]+\\.\\w+|media|thumbnail|assets).*)',
   ],


### PR DESCRIPTION
Resolves #290 

The /assets/icon.png url was being rewritten to /{tenant slug}/assets/icon.png which doesn't exist in our routing so we can ignore these from the middleware and have them served from the root domain. 