### PR TITLE
Always use Edge Config in Payload config

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ The system operates with these priorities:
 
 We have two edge config stores in Vercel:
 
-1. For preview environment. This can also be used for local dev if needed for testing. But an edge config is not required for local development because of the cached API route fallback.
-1. For preview environment
-1. For prod environment
-   NOTE: This can also be used for local dev if needed for testing, but an edge config is not required for local development because of the cached API route fallback.
+1. For prod environment `avy-edge-config-prod`
+1. For preview environments `avy-edge-config-preview`
+
+   NOTE: This should also be used for local dev. Our preview environments still use our seed script so these values _should_ be in sync with our local environments. The preview edge config can updated manually in Vercel if you need additional tenants in your local env.
 
 ## Developing Emails
 

--- a/src/utilities/tenancy/getTenants.ts
+++ b/src/utilities/tenancy/getTenants.ts
@@ -1,24 +1,14 @@
-import { getCachedTenants } from '@/collections/Tenants/endpoints/cachedPublicTenants'
 import { TenantData } from '@/middleware'
 import { getAllTenantsFromEdgeConfig } from '@/services/vercel'
 
 export async function getTenants(): Promise<TenantData> {
-  let tenants: TenantData = []
-
   try {
-    tenants = await getAllTenantsFromEdgeConfig()
+    return getAllTenantsFromEdgeConfig()
   } catch (error) {
-    console.warn(
-      'Failed to get all tenants from Edge Config, falling back to cached API route:',
+    console.error(
+      'Failed to get all tenants from Edge Config, make sure you have set the VERCEL_EDGE_CONFIG env var. Error: ',
       error instanceof Error ? error.message : error,
     )
+    return []
   }
-
-  try {
-    tenants = await getCachedTenants()
-  } catch (error) {
-    console.warn('Failed to get cached tenants:', error instanceof Error ? error.message : error)
-  }
-
-  return tenants
 }


### PR DESCRIPTION
I was falling back to the `getCachedTenants` function in the `getTenants` function. This is roughly the behavior in the middleware and I wanted to allow for not configuring the edge config in your local env. But this was causing circular dependency / import errors on Payload init. The `getCachedTenants` function uses payload but the `getTenants` function is called during Payload's init (to generate the csrf url whitelist) so Payload hasn't been initialized yet. 

This just means that you must have the `VERCEL_EDGE_CONFIG` env var set in your local now. 