### PR TITLE
Hide blog nav item if no published posts & unpublished pages/posts

### DIFF
--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -39,6 +39,7 @@ export const Pages: CollectionConfig<'pages'> = {
     title: true,
     slug: true,
     meta: true,
+    _status: true,
   },
   admin: {
     group: 'Content',

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -36,6 +36,7 @@ export const Posts: CollectionConfig<'posts'> = {
     featuredImage: true,
     slug: true,
     title: true,
+    _status: true,
   },
   admin: {
     group: 'Content',


### PR DESCRIPTION
Resolves #18 

## Key changes
- Hides the blog top level nav item if there are no published posts for the tenant
- Hides unpublished pages and posts (internal links) from the navigation

I chose not to add a 404 to any of the blog routes if there are no published posts because I didn't want to mess with the empty states too much. For example, if a user filters by a tag and there are no posts for that tag and empty state should be displayed. To differentiate between no results being returned because of the tag or because there are no published posts at all would require an extra query. Not a big deal but I didn't feel like it was worth the effort. 

I think that if someone types in /blog and sees the empty state of the blog that's fine. The goal here is to just not advertise an empty blog. 