### PR TITLE
Nested error boundaries

### DIFF
--- a/src/app/(frontend)/[center]/blog/error.tsx
+++ b/src/app/(frontend)/[center]/blog/error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return <ErrorBoundary error={error} reset={reset} />
+}

--- a/src/app/(frontend)/[center]/blog/error.tsx
+++ b/src/app/(frontend)/[center]/blog/error.tsx
@@ -2,12 +2,4 @@
 
 import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
 
-export default function Error({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string }
-  reset: () => void
-}) {
-  return <ErrorBoundary error={error} reset={reset} />
-}
+export default ErrorBoundary

--- a/src/app/(frontend)/[center]/error.tsx
+++ b/src/app/(frontend)/[center]/error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return <ErrorBoundary error={error} reset={reset} />
+}

--- a/src/app/(frontend)/[center]/error.tsx
+++ b/src/app/(frontend)/[center]/error.tsx
@@ -2,12 +2,4 @@
 
 import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
 
-export default function Error({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string }
-  reset: () => void
-}) {
-  return <ErrorBoundary error={error} reset={reset} />
-}
+export default ErrorBoundary

--- a/src/app/(frontend)/[center]/forecasts/error.tsx
+++ b/src/app/(frontend)/[center]/forecasts/error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return <ErrorBoundary error={error} reset={reset} />
+}

--- a/src/app/(frontend)/[center]/forecasts/error.tsx
+++ b/src/app/(frontend)/[center]/forecasts/error.tsx
@@ -2,12 +2,4 @@
 
 import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
 
-export default function Error({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string }
-  reset: () => void
-}) {
-  return <ErrorBoundary error={error} reset={reset} />
-}
+export default ErrorBoundary

--- a/src/app/(frontend)/[center]/observations/error.tsx
+++ b/src/app/(frontend)/[center]/observations/error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return <ErrorBoundary error={error} reset={reset} />
+}

--- a/src/app/(frontend)/[center]/observations/error.tsx
+++ b/src/app/(frontend)/[center]/observations/error.tsx
@@ -2,12 +2,4 @@
 
 import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
 
-export default function Error({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string }
-  reset: () => void
-}) {
-  return <ErrorBoundary error={error} reset={reset} />
-}
+export default ErrorBoundary

--- a/src/app/(frontend)/[center]/weather/error.tsx
+++ b/src/app/(frontend)/[center]/weather/error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return <ErrorBoundary error={error} reset={reset} />
+}

--- a/src/app/(frontend)/[center]/weather/error.tsx
+++ b/src/app/(frontend)/[center]/weather/error.tsx
@@ -2,12 +2,4 @@
 
 import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
 
-export default function Error({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string }
-  reset: () => void
-}) {
-  return <ErrorBoundary error={error} reset={reset} />
-}
+export default ErrorBoundary

--- a/src/app/(frontend)/error.tsx
+++ b/src/app/(frontend)/error.tsx
@@ -2,12 +2,4 @@
 
 import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
 
-export default function Error({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string }
-  reset: () => void
-}) {
-  return <ErrorBoundary error={error} reset={reset} showGoBack={false} homeHref="/" />
-}
+export default ErrorBoundary

--- a/src/app/(frontend)/error.tsx
+++ b/src/app/(frontend)/error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return <ErrorBoundary error={error} reset={reset} showGoBack={false} homeHref="/" />
+}

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+type ErrorBoundaryProps = {
+  error: Error & { digest?: string }
+  reset: () => void
+  showGoBack?: boolean
+  homeHref?: string
+}
+
+export function ErrorBoundary({
+  error,
+  reset,
+  showGoBack = true,
+  homeHref = '/',
+}: ErrorBoundaryProps) {
+  const router = useRouter()
+
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  const handleGoBack = () => {
+    router.back()
+  }
+
+  const handleGoHome = () => {
+    router.push(homeHref)
+  }
+
+  return (
+    <div className="container py-14">
+      <div className="max-w-4xl mx-auto text-center border-4 border-red-500 p-8 shadow rounded">
+        <div className="mb-12">
+          <h1 className="text-4xl font-bold mb-4">Something went wrong</h1>
+          <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
+            We encountered an unexpected error. Don&apos;t worry, we&apos;re on it.
+          </p>
+
+          {process.env.NODE_ENV !== 'production' && (
+            <details className="text-left bg-muted p-4 rounded-lg mb-8 max-w-2xl mx-auto">
+              <summary className="cursor-pointer font-medium text-sm mb-2">
+                Error Details (Development only)
+              </summary>
+              <pre className="text-xs text-muted-foreground whitespace-pre-wrap overflow-x-auto">
+                {error.message}
+                {error.stack && '\n\n' + error.stack}
+              </pre>
+            </details>
+          )}
+        </div>
+
+        <div className="space-y-4 sm:space-y-0 sm:space-x-4 sm:flex sm:justify-center">
+          <Button onClick={reset} size="lg">
+            Reset
+          </Button>
+          {showGoBack && (
+            <Button onClick={handleGoBack} variant="outline" size="lg">
+              Go Back
+            </Button>
+          )}
+          <Button onClick={handleGoHome} variant="outline" size="lg">
+            Go Home
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Resolves #296 

Adding a simple ErrorBoundary component and error pages nested in various routes. 

Example: 
<img width="1406" height="1085" alt="CleanShot 2025-08-07 at 14 16 18" src="https://github.com/user-attachments/assets/fead5c32-f828-4d94-ab7d-c90969fa1a67" />
