### PR TITLE
Adds a build and deploy to sync-prod-to-dev workflow

### DIFF
--- a/.github/workflows/sync-prod-to-dev.yml
+++ b/.github/workflows/sync-prod-to-dev.yml
@@ -82,3 +82,26 @@ jobs:
           DATABASE_URI: '${{ steps.connection.outputs.uri }}'
           DATABASE_AUTH_TOKEN: '${{ steps.connection.outputs.token }}'
           PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --git-branch=main --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --yes --target=preview --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          DATABASE_URI: '${{ steps.connection.outputs.uri }}'
+          DATABASE_AUTH_TOKEN: '${{ steps.connection.outputs.token }}'
+          PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
+      - name: Deploy Project Artifacts to Vercel
+        id: deployment
+        run: |
+          fullName="${{ github.repository }}"
+          vercel deploy --yes --prebuilt --target=preview \
+            --meta='githubCommitAuthorName=${{ github.workflow }}' \
+            --meta='githubCommitOrg=${{ github.repository_owner }}' \
+            --meta='githubCommitRef=main' \
+            --meta="githubCommitRepo=${fullName##*/}" \
+            --meta='githubCommitSha=${{ github.sha }}' \
+            --meta='githubDeployment=1' \
+            --meta='githubOrg=${{ github.repository_owner }}' \
+            --meta="githubRepo=${fullName##*/}" \
+            --meta='githubCommitAuthorLogin=${{ github.workflow }}' \
+            --token=${{ secrets.VERCEL_TOKEN }}

--- a/src/scripts/update-media-prefix.ts
+++ b/src/scripts/update-media-prefix.ts
@@ -21,6 +21,9 @@ async function updateMediaPrefix(prefix: string) {
     data: {
       prefix,
     },
+    context: {
+      disableRevalidate: true,
+    },
   })
 }
 


### PR DESCRIPTION
Resolves #408 

- Adds a build and deploy to the sync
- Disables revalidation in update-media-prefix script because it runs without a next.js server and throws revalidation errors