### PR TITLE
Bugfix: Live previews

### DIFF
--- a/src/app/(frontend)/[center]/next/preview/route.ts
+++ b/src/app/(frontend)/[center]/next/preview/route.ts
@@ -72,7 +72,9 @@ export async function GET(
           select: {},
           where: {
             slug: {
-              equals: slug,
+              // Exception for pages collection which has a concept of canonical urls based on their nesting in the navigation
+              // Uses the last path part as the slug
+              equals: collection === 'pages' ? slug.split('/').filter(Boolean).pop() : slug,
             },
           },
         })


### PR DESCRIPTION
Live previews broke due to the canonical url logic for pages that are nested in the navigation. This fixes this by adding handling for canonical urls. 