### PR TITLE
Bugfix: adding MediaBlock to richText fields in all blocks

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -121,9 +121,9 @@ export const importMap = {
   '@/components/LogoutButton#LogoutButton': LogoutButton_db9ac62598c46d0f1db201f6af05442e,
   '@/components/Icon/AvyFxIcon#AvyFxIcon': AvyFxIcon_5698f736c9797d81d0dacf1b1321e327,
   '@/components/Logo/AvyFxLogo#AvyFxLogo': AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4,
-  '@/components/ViewTypeAction#default': default_cb0ad5752e1389a2a940bb73c2c0e7d2,
   '@payloadcms/plugin-multi-tenant/rsc#GlobalViewRedirect':
     GlobalViewRedirect_d6d5f193a167989e2ee7d14202901e62,
+  '@/components/ViewTypeAction#default': default_cb0ad5752e1389a2a940bb73c2c0e7d2,
   '@/components/BeforeDashboard#default': default_1a7510af427896d367a49dbf838d2de6,
   '@/components/TenantSelector/TenantSelector#default': default_2aead22399b7847b21b134dc4a7931e0,
   '@payloadcms/plugin-multi-tenant/rsc#TenantSelectionProvider':

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -121,9 +121,9 @@ export const importMap = {
   '@/components/LogoutButton#LogoutButton': LogoutButton_db9ac62598c46d0f1db201f6af05442e,
   '@/components/Icon/AvyFxIcon#AvyFxIcon': AvyFxIcon_5698f736c9797d81d0dacf1b1321e327,
   '@/components/Logo/AvyFxLogo#AvyFxLogo': AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4,
+  '@/components/ViewTypeAction#default': default_cb0ad5752e1389a2a940bb73c2c0e7d2,
   '@payloadcms/plugin-multi-tenant/rsc#GlobalViewRedirect':
     GlobalViewRedirect_d6d5f193a167989e2ee7d14202901e62,
-  '@/components/ViewTypeAction#default': default_cb0ad5752e1389a2a940bb73c2c0e7d2,
   '@/components/BeforeDashboard#default': default_1a7510af427896d367a49dbf838d2de6,
   '@/components/TenantSelector/TenantSelector#default': default_2aead22399b7847b21b134dc4a7931e0,
   '@payloadcms/plugin-multi-tenant/rsc#TenantSelectionProvider':

--- a/src/blocks/Content/config.ts
+++ b/src/blocks/Content/config.ts
@@ -9,6 +9,7 @@ import {
 } from '@payloadcms/richtext-lexical'
 import { ButtonsBlock } from '../Buttons/config'
 import { GenericEmbedLexical } from '../GenericEmbed/config'
+import { MediaBlock } from '../MediaBlock/config'
 
 export const Content: Block = {
   slug: 'content',
@@ -43,7 +44,7 @@ export const Content: Block = {
               return [
                 ...rootFeatures,
                 BlocksFeature({
-                  blocks: [ButtonsBlock, GenericEmbedLexical],
+                  blocks: [ButtonsBlock, MediaBlock, GenericEmbedLexical],
                 }),
                 HorizontalRuleFeature(),
                 InlineToolbarFeature(),

--- a/src/blocks/ContentWithCallout/config.ts
+++ b/src/blocks/ContentWithCallout/config.ts
@@ -3,6 +3,7 @@ import type { Block } from 'payload'
 import { BlocksFeature, FixedToolbarFeature, lexicalEditor } from '@payloadcms/richtext-lexical'
 import { ButtonsBlock } from '../Buttons/config'
 import { GenericEmbedLexical } from '../GenericEmbed/config'
+import { MediaBlock } from '../MediaBlock/config'
 
 export const ContentWithCallout: Block = {
   slug: 'contentWithCallout',
@@ -18,7 +19,7 @@ export const ContentWithCallout: Block = {
             ...rootFeatures,
             FixedToolbarFeature(),
             BlocksFeature({
-              blocks: [ButtonsBlock, GenericEmbedLexical],
+              blocks: [ButtonsBlock, MediaBlock, GenericEmbedLexical],
             }),
           ]
         },
@@ -34,7 +35,7 @@ export const ContentWithCallout: Block = {
           return [
             ...rootFeatures,
             BlocksFeature({
-              blocks: [ButtonsBlock, GenericEmbedLexical],
+              blocks: [ButtonsBlock, MediaBlock, GenericEmbedLexical],
             }),
           ]
         },

--- a/src/collections/HomePages/index.tsx
+++ b/src/collections/HomePages/index.tsx
@@ -136,7 +136,7 @@ export const HomePages: CollectionConfig = {
                   return [
                     ...rootFeatures,
                     BlocksFeature({
-                      blocks: [ButtonsBlock, GenericEmbedLexical],
+                      blocks: [ButtonsBlock, GenericEmbedLexical, MediaBlock],
                     }),
                     HorizontalRuleFeature(),
                     InlineToolbarFeature(),


### PR DESCRIPTION
Resolves #435 

I don't think we want to add the MediaBlock to the defaultLexical BlocksFeatures but I think it makes sense to add it to all of our existing blocks' richText fields. 