### PR TITLE
Quick wins: block styling and admin view

### DIFF
--- a/src/blocks/Content/Component.tsx
+++ b/src/blocks/Content/Component.tsx
@@ -21,11 +21,11 @@ export const ContentBlock = (props: ContentBlockProps) => {
   return (
     <div className={`${bgColorClass}`}>
       <div className="container py-16">
-        <div className="grid grid-cols-4 lg:grid-cols-12 gap-y-8 gap-x-16">
+        <div className="grid grid-cols-2 lg:grid-cols-12 gap-y-8 gap-x-16">
           {columns?.map((col, index) => {
             const { richText } = col
             return (
-              <div className={cn('col-span-4 md:col-span-2', colsSpanClass, textColor)} key={index}>
+              <div className={cn('col-span-2', colsSpanClass, textColor)} key={index}>
                 {richText && <RichText data={richText} enableGutter={false} />}
               </div>
             )

--- a/src/blocks/MediaBlock/Component.tsx
+++ b/src/blocks/MediaBlock/Component.tsx
@@ -36,13 +36,13 @@ export const MediaBlock = (props: Props) => {
       {(media || staticImage) && (
         <Media
           className="my-0"
-          imgClassName={cn(imgClassName)}
+          imgClassName={cn('mx-auto', imgClassName)}
           resource={media}
           src={staticImage}
         />
       )}
       {caption && (
-        <div className={cn({ container: !disableInnerContainer }, captionClassName)}>
+        <div className={cn('mt-4', { container: !disableInnerContainer }, captionClassName)}>
           <RichText data={caption} enableGutter={false} className="text-xs" />
         </div>
       )}

--- a/src/collections/HomePages/index.tsx
+++ b/src/collections/HomePages/index.tsx
@@ -160,6 +160,7 @@ export const HomePages: CollectionConfig = {
       admin: {
         description:
           'This is the body of your home page. This content will appear below the forecast zones map and the Highlighted Content section.',
+        initCollapsed: false,
       },
       type: 'blocks',
       blocks: [

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -125,7 +125,7 @@ export const Pages: CollectionConfig<'pages'> = {
               ],
               required: true,
               admin: {
-                initCollapsed: true,
+                initCollapsed: false,
               },
             },
           ],


### PR DESCRIPTION
### Description
* Centers media block images
* Fixes admin view for initially adding a block to be open instead of collapased
* Fixes content width on tablet

### Issue
Fixes #434 
Fixes #384
Fixes #380 