### PR TITLE
Fix link bug

### DIFF
--- a/src/fields/defaultLexical.ts
+++ b/src/fields/defaultLexical.ts
@@ -1,6 +1,7 @@
 import { BlogListBlockLexical } from '@/blocks/BlogList/config'
 import { GenericEmbedLexical } from '@/blocks/GenericEmbed/config'
 import { SingleBlogPostBlockLexical } from '@/blocks/SingleBlogPost/config'
+import isAbsoluteUrl from '@/utilities/isAbsoluteUrl'
 import {
   AlignFeature,
   BlocksFeature,
@@ -10,12 +11,13 @@ import {
   ItalicFeature,
   lexicalEditor,
   LinkFeature,
+  LinkFields,
   OrderedListFeature,
   ParagraphFeature,
   UnderlineFeature,
   UnorderedListFeature,
 } from '@payloadcms/richtext-lexical'
-import { Config } from 'payload'
+import { Config, TextFieldSingleValidation } from 'payload'
 
 export const defaultLexical: Config['editor'] = lexicalEditor({
   features: () => {
@@ -41,10 +43,19 @@ export const defaultLexical: Config['editor'] = lexicalEditor({
               name: 'url',
               type: 'text',
               admin: {
-                condition: ({ linkType }) => linkType !== 'internal',
+                condition: (_data, siblingData) => siblingData?.linkType !== 'internal',
               },
               label: ({ t }) => t('fields:enterURL'),
               required: true,
+              validate: ((value, options) => {
+                if ((options?.siblingData as LinkFields)?.linkType === 'internal') {
+                  return true // no validation needed, as no url should exist for internal links
+                }
+                return (
+                  isAbsoluteUrl(value) ||
+                  'External URL must be an absolute url with a protocol. I.e. https://www.example.com.'
+                )
+              }) as TextFieldSingleValidation,
             },
           ]
         },

--- a/src/fields/defaultLexical.ts
+++ b/src/fields/defaultLexical.ts
@@ -1,7 +1,6 @@
 import { BlogListBlockLexical } from '@/blocks/BlogList/config'
 import { GenericEmbedLexical } from '@/blocks/GenericEmbed/config'
 import { SingleBlogPostBlockLexical } from '@/blocks/SingleBlogPost/config'
-import isAbsoluteUrl from '@/utilities/isAbsoluteUrl'
 import {
   AlignFeature,
   BlocksFeature,
@@ -17,6 +16,7 @@ import {
   UnderlineFeature,
   UnorderedListFeature,
 } from '@payloadcms/richtext-lexical'
+import { validateUrlMinimal } from 'node_modules/@payloadcms/richtext-lexical/dist/lexical/utils/url'
 import { Config, TextFieldSingleValidation } from 'payload'
 
 export const defaultLexical: Config['editor'] = lexicalEditor({
@@ -47,14 +47,13 @@ export const defaultLexical: Config['editor'] = lexicalEditor({
               },
               label: ({ t }) => t('fields:enterURL'),
               required: true,
-              validate: ((value, options) => {
+              validate: ((value: string, options) => {
                 if ((options?.siblingData as LinkFields)?.linkType === 'internal') {
-                  return true // no validation needed, as no url should exist for internal links
+                  return // no validation needed, as no url should exist for internal links
                 }
-                return (
-                  isAbsoluteUrl(value) ||
-                  'External URL must be an absolute url with a protocol. I.e. https://www.example.com.'
-                )
+                if (!validateUrlMinimal(value)) {
+                  return 'Invalid URL'
+                }
               }) as TextFieldSingleValidation,
             },
           ]


### PR DESCRIPTION
### Description
~Making it `link.type` -- not `linkType` worked..  which is weird because it looks like it should be [linkType](https://github.com/payloadcms/payload/blob/main/packages/richtext-lexical/src/features/link/nodes/types.ts#L16)~

Updated from the payload template [defaultLexical.ts](https://github.com/payloadcms/payload/blob/a92c25162063f0b2da4e982728af78057fea9598/templates/website/src/fields/defaultLexical.ts#L21) which they updated in [v3.23.0](https://github.com/payloadcms/payload/pull/11074)



### Issue
Resolves #392 