### PR TITLE
Debugging  'cannot read properties of null' and attempt to fix the vercel build error

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'check-next-version'
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'check-next-version'
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - 'release'
+      - 'check-next-version'
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/src/app/(frontend)/[center]/[...segments]/page.tsx
+++ b/src/app/(frontend)/[center]/[...segments]/page.tsx
@@ -23,14 +23,24 @@ export async function generateStaticParams() {
     },
   })
 
-  // TODO: use same logic as header to walk the tree and find all pages
-
+  // TODO: use same logic as header to walk the tree and find all pages)
   const params: PathArgs[] = []
   for (const post of pages.docs) {
+    if (!post.slug || typeof post.slug !== 'string') {
+      payload.logger.error(`Invalid page slug: ${JSON.stringify(post)}`)
+      continue
+    }
+
     if (typeof post.tenant === 'number') {
       payload.logger.error(`got number for page tenant: ${JSON.stringify(post.tenant)}`)
       continue
     }
+
+    if (!post.tenant || typeof post.tenant.slug !== 'string') {
+      payload.logger.error(`Invalid tenant slug: ${JSON.stringify(post)}`)
+      continue
+    }
+
     if (post.tenant) {
       params.push({ center: post.tenant.slug, segments: [post.slug] })
     }

--- a/src/app/(frontend)/[center]/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/[slug]/page.tsx
@@ -35,8 +35,18 @@ export async function generateStaticParams() {
 
   const params: PathArgs[] = []
   for (const page of pages.docs) {
+    if (!page.slug || typeof page.slug !== 'string') {
+      payload.logger.error(`Invalid page slug: ${JSON.stringify(page)}`)
+      continue
+    }
+
     if (typeof page.tenant === 'number') {
-      payload.logger.error(`got number for page tenant: ${JSON.stringify(page.tenant)}`)
+      payload.logger.error(`got number for post tenant`)
+      continue
+    }
+
+    if (!page.tenant || typeof page.tenant.slug !== 'string') {
+      payload.logger.error(`Invalid tenant slug: ${JSON.stringify(page)}`)
       continue
     }
     if (page.tenant) {

--- a/src/app/(frontend)/[center]/blog/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/blog/[slug]/page.tsx
@@ -34,10 +34,21 @@ export async function generateStaticParams() {
 
   const params: PathArgs[] = []
   for (const post of posts.docs) {
+    if (!post.slug || typeof post.slug !== 'string') {
+      payload.logger.error(`Invalid page slug: ${JSON.stringify(post)}`)
+      continue
+    }
+
     if (typeof post.tenant === 'number') {
       payload.logger.error(`got number for post tenant`)
       continue
     }
+
+    if (!post.tenant || typeof post.tenant.slug !== 'string') {
+      payload.logger.error(`Invalid tenant slug: ${JSON.stringify(post)}`)
+      continue
+    }
+
     if (post.tenant) {
       params.push({ center: post.tenant.slug, slug: post.slug })
     }

--- a/src/app/(frontend)/[center]/forecasts/avalanche/[zone]/page.tsx
+++ b/src/app/(frontend)/[center]/forecasts/avalanche/[zone]/page.tsx
@@ -24,7 +24,9 @@ export async function generateStaticParams() {
 
   // TODO: hit the NAC API for forecast zones, translate active names to slugs
 
-  return tenants.docs.map((tenant): PathArgs => ({ center: tenant.slug, zone: '' }))
+  return tenants.docs
+    .filter((tenant) => typeof tenant.slug === 'string' && tenant.slug.trim() !== '')
+    .map((tenant): PathArgs => ({ center: tenant.slug, zone: '' }))
 }
 
 type Args = {

--- a/src/app/(frontend)/[center]/forecasts/avalanche/page.tsx
+++ b/src/app/(frontend)/[center]/forecasts/avalanche/page.tsx
@@ -23,7 +23,9 @@ export async function generateStaticParams() {
     },
   })
 
-  return tenants.docs.map((tenant): PathArgs => ({ center: tenant.slug }))
+  return tenants.docs
+    .filter((tenant) => typeof tenant.slug === 'string' && tenant.slug.trim() !== '')
+    .map((tenant): PathArgs => ({ center: tenant.slug }))
 }
 
 type Args = {

--- a/src/app/(frontend)/[center]/layout.tsx
+++ b/src/app/(frontend)/[center]/layout.tsx
@@ -33,7 +33,9 @@ export async function generateStaticParams() {
     },
   })
 
-  return tenants.docs.map((tenant) => ({ center: tenant.slug }))
+  return tenants.docs
+    .filter((tenant) => typeof tenant.slug === 'string' && tenant.slug.trim() !== '')
+    .map((tenant): PathArgs => ({ center: tenant.slug }))
 }
 
 type Args = {

--- a/src/app/(frontend)/[center]/observations/page.tsx
+++ b/src/app/(frontend)/[center]/observations/page.tsx
@@ -24,7 +24,9 @@ export async function generateStaticParams() {
     },
   })
 
-  return tenants.docs.map((tenant): PathArgs => ({ center: tenant.slug }))
+  return tenants.docs
+    .filter((tenant) => typeof tenant.slug === 'string' && tenant.slug.trim() !== '')
+    .map((tenant): PathArgs => ({ center: tenant.slug }))
 }
 
 type Args = {

--- a/src/app/(frontend)/[center]/observations/submit/page.tsx
+++ b/src/app/(frontend)/[center]/observations/submit/page.tsx
@@ -23,7 +23,9 @@ export async function generateStaticParams() {
     },
   })
 
-  return tenants.docs.map((tenant): PathArgs => ({ center: tenant.slug }))
+  return tenants.docs
+    .filter((tenant) => typeof tenant.slug === 'string' && tenant.slug.trim() !== '')
+    .map((tenant): PathArgs => ({ center: tenant.slug }))
 }
 
 type Args = {

--- a/src/app/(frontend)/[center]/page.tsx
+++ b/src/app/(frontend)/[center]/page.tsx
@@ -24,7 +24,9 @@ export async function generateStaticParams() {
     },
   })
 
-  return tenants.docs.map((tenant): PathArgs => ({ center: tenant.slug }))
+  return tenants.docs
+    .filter((tenant) => typeof tenant.slug === 'string' && tenant.slug.trim() !== '')
+    .map((tenant): PathArgs => ({ center: tenant.slug }))
 }
 
 type Args = {

--- a/src/app/(frontend)/[center]/theme-preview/page.tsx
+++ b/src/app/(frontend)/[center]/theme-preview/page.tsx
@@ -53,7 +53,9 @@ export async function generateStaticParams() {
     },
   })
 
-  return tenants.docs.map((tenant): PathArgs => ({ center: tenant.slug }))
+  return tenants.docs
+    .filter((tenant) => typeof tenant.slug === 'string' && tenant.slug.trim() !== '')
+    .map((tenant): PathArgs => ({ center: tenant.slug }))
 }
 
 type Args = {

--- a/src/app/(frontend)/[center]/weather/stations/map/page.tsx
+++ b/src/app/(frontend)/[center]/weather/stations/map/page.tsx
@@ -22,7 +22,9 @@ export async function generateStaticParams() {
     },
   })
 
-  return tenants.docs.map((tenant): PathArgs => ({ center: tenant.slug }))
+  return tenants.docs
+    .filter((tenant) => typeof tenant.slug === 'string' && tenant.slug.trim() !== '')
+    .map((tenant): PathArgs => ({ center: tenant.slug }))
 }
 
 type Args = {


### PR DESCRIPTION
I was able to point local build at the deployed dev db to debug. I used the dev db url and generated a token inside of turso and populated that into DATABASE_AUTH_TOKEN env variable. That repro-ed the error right away. 

error
```bash
 ✓ Compiled successfully
   Linting and checking validity of types ...
   Collecting page data ...
TypeError: Cannot read properties of null (reading 'replace')
    at Array.map (<anonymous>)
    at Array.forEach (<anonymous>)

> Build error occurred
[Error: Failed to collect page data for /[center]/[...segments]] {
  type: 'Error'
}
```
link to GAH with this error: https://github.com/NWACus/web/actions/runs/17338501404/job/49228723110

I inspected the db, and basically we have a null record for 1 page that is getting processed for each tenant and causing issues since our code assumed slug is never null. The problematic is in the pages table, id 112. 

<img width="1346" height="82" alt="image" src="https://github.com/user-attachments/assets/3a607b25-6306-4184-8427-dbe7da73e53d" />

I did not spend much time thinking how to do this the right way, just through this together quickly to test the theory that this will fix things. There is likely a better way to do this but with these fixes I was able to get the build working locally off the dev db. Going to run the development github action next just to make sure it workes in GAH world as well (it should). 

I was seeing a lot of timeout errors when trying to get the build working locally, just a note, not sure if that is normal
```bash
  params: [Array],
  [cause]: [TypeError: fetch failed] {
    [cause]: [AggregateError: ] { code: 'ETIMEDOUT' }
  }
}
```

Havent dug into how or why that empty row got into the db, would be good to do next! 