### PR TITLE
Add concurrency to cancel build on multiple pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: lint


### PR DESCRIPTION
In #481 I added `concurrency` to  the `preview` workflow which will cancel any previous build if I new one is pushed. I want to add this to our `ci` workflow as well.


Partially fixes/ maybe fixes #478 