### PR TITLE
.github: use normal Bash preamble for sanity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,10 @@ jobs:
         shell: bash
       - name: 🧹 Run pnpm generate:type
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           pnpm generate:types
           if [[ ! -z "$(git status --short)" ]]
           then
@@ -96,6 +100,10 @@ jobs:
           fi
       - name: 🧹 Run pnpm generate:importmap
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           pnpm generate:importmap
           if [[ ! -z "$(git status --short)" ]]
           then
@@ -143,6 +151,10 @@ jobs:
         shell: bash
       - name: Check if a migration is needed
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           output=$(pnpm payload migrate:create --skip-empty 2>&1)
           echo "$output"
           if echo "$output" | grep -q "Migration created at"; then

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -14,6 +14,10 @@ jobs:
           TURSO_INSTALL_SKIP_SIGNUP: 'true'
       - name: Delete preview database
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           ref="${{ github.event.ref }}"
           branch="${ref##refs/heads/}"
           clean_branch="${branch//[^a-z0-9\-]/x}"

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -19,6 +19,10 @@ jobs:
           TURSO_INSTALL_SKIP_SIGNUP: 'true'
       - name: Clone production database to dev
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           /home/runner/.turso/turso org switch nwac
           if /home/runner/.turso/turso db show payloadcms-dev; then
             /home/runner/.turso/turso db destroy payloadcms-dev --yes
@@ -29,6 +33,10 @@ jobs:
       - name: Record database connection URI and token
         id: connection
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           echo "uri=$(/home/runner/.turso/turso db show payloadcms-dev --url )" >> "${GITHUB_OUTPUT}"
           echo "token=$(/home/runner/.turso/turso db tokens create payloadcms-dev )" >> "${GITHUB_OUTPUT}"
         env:
@@ -56,6 +64,10 @@ jobs:
       - name: Generate random non-prod sync password
         id: generate-sync-password
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           generated_password=$(openssl rand -base64 32)
           echo "::add-mask::$generated_password"
           echo "password=$generated_password" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -22,6 +22,10 @@ jobs:
       - name: Create a new database for the preview
         id: database
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           head_ref="${{ github.head_ref }}"
           ref="${head_ref//[^a-z0-9\-]/x}"
           # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
@@ -47,6 +51,10 @@ jobs:
       - name: Record database connection URI and token
         id: connection
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           echo "uri=$(/home/runner/.turso/turso db show "${{ steps.database.outputs.name }}" --url)" >> "${GITHUB_OUTPUT}"
           echo "token=$(/home/runner/.turso/turso db tokens create "${{ steps.database.outputs.name }}")" >> "${GITHUB_OUTPUT}"
         env:
@@ -68,6 +76,10 @@ jobs:
       - name: Generate preview domain names
         id: domains
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           PREVIEW_ALIAS="${{ steps.database.outputs.ref }}.preview.avy-fx.org"
           WILDCARD_PREVIEW_ALIAS="*.${{ steps.database.outputs.ref }}.preview.avy-fx.org"
 
@@ -104,6 +116,10 @@ jobs:
       - name: Deploy Project Artifacts to Vercel
         id: deployment
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           fullName="${{ github.repository }}"
           DEPLOYMENT_URL=$(vercel deploy --yes --prebuilt --target=preview \
             --meta='githubCommitAuthorName=${{ github.event.pull_request.user.login }}' \
@@ -122,6 +138,10 @@ jobs:
       - name: Create aliases for the deployment
         id: aliases
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           echo "Setting preview alias: ${{ steps.domains.outputs.preview_alias }}"
           vercel alias --scope=nwac --token=${{ secrets.VERCEL_TOKEN }} set "${{ steps.deployment.outputs.url }}" "${{ steps.domains.outputs.preview_alias }}"
 

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -20,6 +20,10 @@ jobs:
       - name: Record database connection URI and token
         id: connection
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           /home/runner/.turso/turso org switch nwac
           echo "uri=$(/home/runner/.turso/turso db show payloadcms-prod --url )" >> "${GITHUB_OUTPUT}"
           echo "token=$(/home/runner/.turso/turso db tokens create payloadcms-prod )" >> "${GITHUB_OUTPUT}"
@@ -62,6 +66,10 @@ jobs:
       - name: Deploy Project Artifacts to Vercel
         id: deployment
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           fullName="${{ github.repository }}"
           vercel deploy --yes --prebuilt --target=production \
             --meta='githubCommitAuthorName=${{ github.event.pusher.name }}' \

--- a/.github/workflows/sync-prod-to-dev.yml
+++ b/.github/workflows/sync-prod-to-dev.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Delete dev db and create a new db from prod
         id: database
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           /home/runner/.turso/turso org switch nwac
           if /home/runner/.turso/turso db show payloadcms-dev; then
             /home/runner/.turso/turso db destroy payloadcms-dev --yes
@@ -33,6 +37,10 @@ jobs:
       - name: Record database connection URI and token
         id: connection
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           echo "uri=$(/home/runner/.turso/turso db show payloadcms-dev --url)" >> "${GITHUB_OUTPUT}"
           echo "token=$(/home/runner/.turso/turso db tokens create payloadcms-dev)" >> "${GITHUB_OUTPUT}"
         env:
@@ -58,6 +66,10 @@ jobs:
       - name: Generate random non-prod sync password
         id: generate-sync-password
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           generated_password=$(openssl rand -base64 32)
           echo "::add-mask::$generated_password"
           echo "password=$generated_password" >> "$GITHUB_OUTPUT"
@@ -100,6 +112,10 @@ jobs:
       - name: Deploy Project Artifacts to Vercel
         id: deployment
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           fullName="${{ github.repository }}"
           vercel deploy --yes --prebuilt --target=preview \
             --meta='githubCommitAuthorName=${{ github.workflow }}' \


### PR DESCRIPTION
You never want to use this everywhere until you do. We probably want it on *all* shell steps, even one-liners, since `pipefail` is the semantic everyone would expect, but I won't let perfect be the enemy of good. Complex shell-isms must have the preamble.