### PR TITLE
Clone parentMeta in generatMeta_ functions

### DIFF
--- a/src/utilities/generateMeta.ts
+++ b/src/utilities/generateMeta.ts
@@ -8,7 +8,7 @@ import { getHostnameFromTenant } from './tenancy/getHostnameFromTenant'
 import { resolveTenant } from './tenancy/resolveTenant'
 
 function cloneParentMeta(parentMeta?: Metadata) {
-  return parentMeta ? structuredClone(parentMeta) : {}
+  return parentMeta ? JSON.parse(JSON.stringify(parentMeta)) : {}
 }
 
 export const generateMetaForPage = async (args: {

--- a/src/utilities/generateMeta.ts
+++ b/src/utilities/generateMeta.ts
@@ -7,6 +7,10 @@ import { mergeOpenGraph } from './mergeOpenGraph'
 import { getHostnameFromTenant } from './tenancy/getHostnameFromTenant'
 import { resolveTenant } from './tenancy/resolveTenant'
 
+function cloneParentMeta(parentMeta?: Metadata) {
+  return parentMeta ? structuredClone(parentMeta) : {}
+}
+
 export const generateMetaForPage = async (args: {
   customTitle?: string
   center: string
@@ -37,8 +41,7 @@ export const generateMetaForPage = async (args: {
     ? `${doc.meta?.title} | ${parentTitle ?? tenant?.name}`
     : doc.meta?.title
 
-  // Deep clone parent metadata to avoid mutation issues
-  const clonedParentMeta = parentMeta ? JSON.parse(JSON.stringify(parentMeta)) : {}
+  const clonedParentMeta = cloneParentMeta(parentMeta)
 
   return {
     ...clonedParentMeta,
@@ -83,7 +86,7 @@ export const generateMetaForPost = async (args: {
   const title = customTitle ? customTitle : `${doc?.title} | ${parentTitle ?? tenant?.name}`
 
   // Deep clone parent metadata to avoid mutation issues
-  const clonedParentMeta = parentMeta ? JSON.parse(JSON.stringify(parentMeta)) : {}
+  const clonedParentMeta = cloneParentMeta(parentMeta)
 
   return {
     ...clonedParentMeta,

--- a/src/utilities/generateMeta.ts
+++ b/src/utilities/generateMeta.ts
@@ -37,15 +37,18 @@ export const generateMetaForPage = async (args: {
     ? `${doc.meta?.title} | ${parentTitle ?? tenant?.name}`
     : doc.meta?.title
 
+  // Deep clone parent metadata to avoid mutation issues
+  const clonedParentMeta = parentMeta ? JSON.parse(JSON.stringify(parentMeta)) : {}
+
   return {
-    ...(parentMeta ? { ...parentMeta } : {}),
+    ...clonedParentMeta,
     title,
     description: doc?.meta?.description,
     alternates: {
       canonical: url,
     },
     openGraph: mergeOpenGraph({
-      ...(parentMeta ? { ...parentMeta.openGraph } : {}),
+      ...(clonedParentMeta.openGraph || {}),
       description: doc?.meta?.description || '',
       title: title || '',
       url,
@@ -79,15 +82,18 @@ export const generateMetaForPost = async (args: {
 
   const title = customTitle ? customTitle : `${doc?.title} | ${parentTitle ?? tenant?.name}`
 
+  // Deep clone parent metadata to avoid mutation issues
+  const clonedParentMeta = parentMeta ? JSON.parse(JSON.stringify(parentMeta)) : {}
+
   return {
-    ...(parentMeta ? { ...parentMeta } : {}),
+    ...clonedParentMeta,
     title,
     description: doc.description,
     alternates: {
       canonical: url,
     },
     openGraph: mergeOpenGraph({
-      ...(parentMeta ? { ...parentMeta.openGraph } : {}),
+      ...(clonedParentMeta.openGraph || {}),
       description: doc.description || '',
       title: title || '',
       url,


### PR DESCRIPTION
I started getting an error thrown on page and post routes: `Cannot add property rel, object is not extensible`. 

I believe this is due to Next.js attempting to add a rel property to an immutable object. I wonder if this is due to #509 and I just didn't notice this locally when I was testing for some reason. Potentially due to cached pages. 

@rchlfryn this is the issue we saw in my local when we paired the other day. I know you weren't getting this error locally but I wonder if you hadn't pulled the latest from `main`? Can you try to recreate this error on latest `main` locally?

Visit http://sac.localhost:3000/education/learn and you should get an error boundary with that error. 