### PR TITLE
Warnings widget typo fix

### DIFF
--- a/src/app/(frontend)/[center]/page.tsx
+++ b/src/app/(frontend)/[center]/page.tsx
@@ -48,7 +48,7 @@ export default async function Page({ params }: Args) {
     <>
       <NACWidget
         center={center}
-        widget="warning"
+        widget="warnings"
         widgetsVersion={version}
         widgetsBaseUrl={baseUrl}
       />

--- a/src/components/NACWidget/index.tsx
+++ b/src/components/NACWidget/index.tsx
@@ -111,7 +111,7 @@ export function NACWidget({
     const widgetData = {
       googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || '',
       centerId: fallbackCenter.toUpperCase(),
-      devMode: true,
+      devMode: false,
       mountId: `#${widgetId}`,
       baseUrl: baseUrl,
       controlledMount: true,

--- a/src/components/NACWidget/index.tsx
+++ b/src/components/NACWidget/index.tsx
@@ -3,7 +3,7 @@
 import Script from 'next/script'
 import { useEffect, useState } from 'react'
 
-export type Widget = 'map' | 'forecast' | 'warning' | 'stations' | 'observations'
+export type Widget = 'map' | 'forecast' | 'warnings' | 'stations' | 'observations'
 
 export const loadersByWidget: Record<
   Widget,
@@ -18,7 +18,7 @@ export const loadersByWidget: Record<
     widgetControllerKey:
       | 'mapWidget'
       | 'forecastWidget'
-      | 'warningWidget'
+      | 'warningsWidget'
       | 'stationWidget'
       | 'obsWidget'
   }
@@ -33,10 +33,10 @@ export const loadersByWidget: Record<
     widgetDataKey: 'forecastWidgetData',
     widgetControllerKey: 'forecastWidget',
   },
-  warning: {
+  warnings: {
     scriptName: 'warnings',
     widgetDataKey: 'warningWidgetData',
-    widgetControllerKey: 'warningWidget',
+    widgetControllerKey: 'warningsWidget',
   },
   stations: {
     scriptName: 'stations',
@@ -111,7 +111,7 @@ export function NACWidget({
     const widgetData = {
       googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || '',
       centerId: fallbackCenter.toUpperCase(),
-      devMode: false,
+      devMode: true,
       mountId: `#${widgetId}`,
       baseUrl: baseUrl,
       controlledMount: true,

--- a/src/nac-widget-globals.d.ts
+++ b/src/nac-widget-globals.d.ts
@@ -17,7 +17,7 @@ interface Window {
     _mounted: boolean
   }
   forecastWidget?: (typeof Window)['mapWidget']
-  warningWidget?: (typeof Window)['mapWidget']
+  warningsWidget?: (typeof Window)['mapWidget']
   stationWidget?: (typeof Window)['mapWidget']
   obsWidget?: (typeof Window)['mapWidget']
 }


### PR DESCRIPTION
Resolves #254 

There was a typo in the key used for the warnings widget on the window object. The warnings widget uses singular and plural naming in the `afp-public-widget` repo. 

<img width="3024" height="1806" alt="CleanShot 2025-09-22 at 18 56 02@2x" src="https://github.com/user-attachments/assets/be45c398-4389-4572-8394-bcdcd0311231" />

## To test locally
Set https://github.com/NWACus/web/blob/warnings-widget/src/components/NACWidget/index.tsx#L114 to `devMode: true`. I've created a warning and a watch for NWAC in the dev AFP. 