### PR TITLE
adding homePages to seed tenant scoped admin role in seed data

### DIFF
--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -205,6 +205,7 @@ export const seed = async ({
             'users',
             'redirects',
             'sponsors',
+            'homePages',
           ],
           actions: ['*'],
         },


### PR DESCRIPTION
Noticed that this was never added to our seed data. We added this manually in production. 