### PR TITLE
Bugfix: better initial hash handling for widgets

### DIFF
--- a/src/components/NACWidget/WidgetHashHandler.client.tsx
+++ b/src/components/NACWidget/WidgetHashHandler.client.tsx
@@ -1,15 +1,21 @@
 'use client'
 import { useHash } from '@/utilities/useHash'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 export function WidgetHashHandler({ initialHash }: { initialHash: string }) {
   const hash = useHash()
+  const hasSetInitialHash = useRef(false)
 
   useEffect(() => {
-    if (!hash) {
+    if (!hasSetInitialHash.current || !hash) {
       window.location.hash = initialHash
+      hasSetInitialHash.current = true
     }
   }, [hash, initialHash])
+
+  useEffect(() => {
+    hasSetInitialHash.current = false
+  }, [initialHash])
 
   return null
 }


### PR DESCRIPTION
Resolves #539 

The WidgetHashHandler was only setting the hash if there wasn't already a hash set. This uses a ref to detect if an initial hash has been set _or_ if the hash is empty. 