### PR TITLE
Bugfix: favicons weren't loading for center-scoped routes

### DIFF
--- a/src/app/(frontend)/[center]/layout.tsx
+++ b/src/app/(frontend)/[center]/layout.tsx
@@ -123,7 +123,7 @@ export async function generateMetadata({ params }: Args): Promise<Metadata> {
     const cacheTag = settings.icon.updatedAt
 
     iconImgSrc = getMediaURL(
-      settings.icon.sizes?.thumbnail?.url,
+      settings.icon.sizes?.thumbnail?.url || settings.icon.url,
       cacheTag,
       getHostnameFromTenant(tenant),
     )

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -116,10 +116,6 @@ export default async function RootLayout({ children }: Args) {
 
   return (
     <html className={cn(lato.variable)} lang="en" suppressHydrationWarning>
-      <head>
-        <link href="/favicon.ico" rel="icon" sizes="96x96" />
-        <link href="/favicon.svg" rel="icon" type="image/svg+xml" />
-      </head>
       <body>
         <PostHogProvider>
           <AdminBar

--- a/src/app/[...segmentsNotFound]/layout.tsx
+++ b/src/app/[...segmentsNotFound]/layout.tsx
@@ -106,10 +106,6 @@ const lato = localFont({
 export default function FallbackRootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html className={cn(lato.variable)} lang="en" suppressHydrationWarning>
-      <head>
-        <link href="/favicon.ico" rel="icon" sizes="96x96" />
-        <link href="/favicon.svg" rel="icon" type="image/svg+xml" />
-      </head>
       <body className="w-screen h-screen overflow-x-hidden flex justify-center items-center">
         {children}
       </body>

--- a/src/app/[...segmentsNotFound]/layout.tsx
+++ b/src/app/[...segmentsNotFound]/layout.tsx
@@ -1,4 +1,7 @@
+import { getURL } from '@/utilities/getURL'
+import { mergeOpenGraph } from '@/utilities/mergeOpenGraph'
 import { cn } from '@/utilities/ui'
+import { Metadata } from 'next'
 import localFont from 'next/font/local'
 import '../(frontend)/globals.css'
 
@@ -112,4 +115,24 @@ export default function FallbackRootLayout({ children }: { children: React.React
       </body>
     </html>
   )
+}
+
+export const metadata: Metadata = {
+  title: 'Not found | Avy',
+  description: "Not found. You've ventured into unknown terrain. Best to keep it under 30°.",
+  metadataBase: new URL(getURL()),
+  openGraph: mergeOpenGraph({
+    description: 'Avy avalanche center websites.',
+    images: [
+      {
+        url: `${getURL()}/assets/avy-web-og-image.webp`,
+      },
+    ],
+  }),
+  twitter: {
+    card: 'summary_large_image',
+  },
+  icons: {
+    icon: '/assets/favicon.ico',
+  },
 }


### PR DESCRIPTION
Hardcoded <link> tags were unnecessary and the metadata for center-scoped routes was using the website settings' thumbnail size but that's only generated for images over a certain size which icons often are not. So falling back to just the url attribute. 