### PR TITLE
Style updates - blogs and buttons block

### DIFF
--- a/src/app/(frontend)/[center]/blog/page.tsx
+++ b/src/app/(frontend)/[center]/blog/page.tsx
@@ -75,7 +75,7 @@ export default async function Page({ params, searchParams }: Args) {
 
   return (
     <div className="pt-4">
-      <div className="container md:max-lg:max-w-5xl mb-16 flex flex-col-reverse md:flex-row flex-1">
+      <div className="container md:max-lg:max-w-5xl mb-16 flex flex-col-reverse md:flex-row flex-1 gap-10 md:gap-16">
         <div className="grow">
           <Suspense fallback={<div>Loading posts...</div>}>
             <PostCollection posts={posts.docs} />
@@ -83,7 +83,7 @@ export default async function Page({ params, searchParams }: Args) {
         </div>
 
         {/* Sorting and filters */}
-        <div className="flex flex-col gap-16 shrink-0 justify-between md:justify-start md:w-[240px] lg:w-[300px]">
+        <div className="flex flex-col shrink-0 justify-between md:justify-start md:w-[240px] lg:w-[300px]">
           <Suspense fallback={<div>Loading filters...</div>}>
             <PostsSort initialSort={sort} />
             {tags.docs.length > 1 && <PostsTags tags={tags.docs} />}

--- a/src/app/(frontend)/[center]/blog/page.tsx
+++ b/src/app/(frontend)/[center]/blog/page.tsx
@@ -83,7 +83,7 @@ export default async function Page({ params, searchParams }: Args) {
         </div>
 
         {/* Sorting and filters */}
-        <div className="ms-16 flex flex-col gap-4 shrink-0 justify-between md:justify-start md:w-[240px] lg:w-[300px]">
+        <div className="flex flex-col gap-16 shrink-0 justify-between md:justify-start md:w-[240px] lg:w-[300px]">
           <Suspense fallback={<div>Loading filters...</div>}>
             <PostsSort initialSort={sort} />
             {tags.docs.length > 1 && <PostsTags tags={tags.docs} />}

--- a/src/app/(frontend)/[center]/blog/page.tsx
+++ b/src/app/(frontend)/[center]/blog/page.tsx
@@ -75,7 +75,7 @@ export default async function Page({ params, searchParams }: Args) {
 
   return (
     <div className="pt-4">
-      <div className="container md:max-lg:max-w-5xl mb-16 flex flex-col-reverse md:flex-row flex-1 gap-6">
+      <div className="container md:max-lg:max-w-5xl mb-16 flex flex-col-reverse md:flex-row flex-1">
         <div className="grow">
           <Suspense fallback={<div>Loading posts...</div>}>
             <PostCollection posts={posts.docs} />
@@ -83,7 +83,7 @@ export default async function Page({ params, searchParams }: Args) {
         </div>
 
         {/* Sorting and filters */}
-        <div className="flex flex-col gap-4 shrink-0 justify-between md:justify-start md:w-[240px] lg:w-[300px]">
+        <div className="ms-16 flex flex-col gap-4 shrink-0 justify-between md:justify-start md:w-[240px] lg:w-[300px]">
           <Suspense fallback={<div>Loading filters...</div>}>
             <PostsSort initialSort={sort} />
             {tags.docs.length > 1 && <PostsTags tags={tags.docs} />}

--- a/src/blocks/Button/Component.tsx
+++ b/src/blocks/Button/Component.tsx
@@ -3,7 +3,7 @@ import type { ButtonBlock as ButtonBlockProps } from 'src/payload-types'
 
 export const ButtonBlockComponent = ({ button }: ButtonBlockProps) => {
   return (
-    <div>
+    <div className="my-4">
       <CMSLink className="no-underline me-4" {...button} />
     </div>
   )

--- a/src/components/AuthorAvatar/index.tsx
+++ b/src/components/AuthorAvatar/index.tsx
@@ -28,12 +28,12 @@ export const AuthorAvatar = (props: { authors: Post['authors']; date: Post['upda
 
   return (
     <>
-      <div className="flex items-center mb-6">
-        <div className={cn(`${combinedAuthorsPhotos.length > 1 && 'flex -space-x-2'}`, 'me-4')}>
+      <div className="flex items-center mb-6 gap-3">
+        <div className={cn(`${combinedAuthorsPhotos.length > 1 && 'flex -space-x-2'}`)}>
           {combinedAuthorsPhotos.map((authorPhoto, index) => (
             <MediaAvatar
               resource={authorPhoto}
-              className="xl:size-[60px] shadow-md"
+              className="shadow-md"
               key={index}
               fallback={combinedAuthorsInitials[index]}
               isCircle

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -35,7 +35,7 @@ export const CMSLink = (props: CMSLinkType) => {
   } = props
 
   const href = handleReferenceURL({ url: url, type: type, reference: reference })
-  const referenceTitle = (reference?.value as BuiltInPage | Page | Post).title
+  const referenceTitle = (reference && (reference?.value as BuiltInPage | Page | Post).title) || ''
   const buttonLabel = label ? label : referenceTitle
 
   if (!href) return null

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -35,6 +35,8 @@ export const CMSLink = (props: CMSLinkType) => {
   } = props
 
   const href = handleReferenceURL({ url: url, type: type, reference: reference })
+  const referenceTitle = (reference?.value as BuiltInPage | Page | Post).title
+  const buttonLabel = label ? label : referenceTitle
 
   if (!href) return null
 
@@ -45,7 +47,7 @@ export const CMSLink = (props: CMSLinkType) => {
   if (appearance === 'inline') {
     return (
       <Link className={cn(className)} href={href || url || ''} {...newTabProps}>
-        {label && label}
+        {buttonLabel}
         {children && children}
       </Link>
     )
@@ -54,7 +56,7 @@ export const CMSLink = (props: CMSLinkType) => {
   return (
     <Button asChild className={className} size={size} variant={appearance}>
       <Link className={cn(className)} href={href || url || ''} {...newTabProps}>
-        {label && label}
+        {buttonLabel}
         {children && children}
       </Link>
     </Button>

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -14,7 +14,7 @@ type CMSLinkType = {
   newTab?: boolean | null
   reference?: {
     relationTo: 'builtInPages' | 'pages' | 'posts'
-    value: BuiltInPage | Page | Post | string | number
+    value: BuiltInPage | Page | Post | number
   } | null
   size?: ButtonProps['size'] | null
   type?: 'internal' | 'external' | null
@@ -35,7 +35,12 @@ export const CMSLink = (props: CMSLinkType) => {
   } = props
 
   const href = handleReferenceURL({ url: url, type: type, reference: reference })
-  const referenceTitle = (reference && (reference?.value as BuiltInPage | Page | Post).title) || ''
+  const referenceTitle =
+    (reference &&
+      reference.value &&
+      typeof reference.value !== 'number' &&
+      reference?.value.title) ||
+    ''
   const buttonLabel = label ? label : referenceTitle
 
   if (!href) return null

--- a/src/components/PostPreview/index.tsx
+++ b/src/components/PostPreview/index.tsx
@@ -33,7 +33,7 @@ export const PostPreview = (props: {
     <Link href={`/blog/${slug}`} className={cn('group no-underline flex flex-grow', className)}>
       <article
         className={cn(
-          'flex flex-col @md:flex-row bg-card text-card-foreground rounded-lg shadow-sm hover:shadow-md transition-shadow overflow-hidden',
+          'flex flex-col @md:flex-row w-full bg-card text-card-foreground border rounded-lg  shadow-sm hover:shadow-md transition-shadow overflow-hidden',
           className,
         )}
       >
@@ -46,7 +46,7 @@ export const PostPreview = (props: {
             />
           )}
         </div>
-        <div className="flex flex-col justify-between px-6 py-4 flex-grow @md:border-y border-b border-x rounded-b-lg @md:rounded-b-none @md:border-r @md:rounded-tr-lg @md:rounded-br-lg">
+        <div className="flex flex-col justify-between px-6 py-4 flex-grow border-t md:border-t-0 md:border-l">
           <div>
             {titleToUse && (
               <div className="mb-3">

--- a/src/components/PostPreview/index.tsx
+++ b/src/components/PostPreview/index.tsx
@@ -33,16 +33,16 @@ export const PostPreview = (props: {
     <Link href={`/blog/${slug}`} className={cn('group no-underline flex flex-grow', className)}>
       <article
         className={cn(
-          'flex flex-col @md:flex-row w-full bg-card text-card-foreground border rounded-lg  shadow-sm hover:shadow-md transition-shadow overflow-hidden',
+          'flex flex-col @md:flex-row w-full bg-card text-card-foreground border rounded-lg shadow-sm hover:shadow-md transition-shadow overflow-hidden',
           className,
         )}
       >
-        <div className="w-full @md:w-56 @xl:w-72 @2xl:w-80 @md:flex-shrink-0 h-48 @md:h-auto overflow-hidden">
+        <div className="w-full @md:w-56 @xl:w-72 @2xl:w-80 @md:flex-shrink-0 h-48 @md:h-auto overflow-hidden flex items-center">
           {featuredImage && typeof featuredImage !== 'number' && (
             <ImageMedia
-              imgClassName="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+              imgClassName="w-full object-cover transition-transform duration-300"
               resource={featuredImage}
-              pictureClassName="w-full h-full"
+              pictureClassName="w-full"
             />
           )}
         </div>

--- a/src/components/PostPreview/index.tsx
+++ b/src/components/PostPreview/index.tsx
@@ -46,7 +46,7 @@ export const PostPreview = (props: {
             />
           )}
         </div>
-        <div className="flex flex-col justify-between px-6 py-4 flex-grow border-t md:border-t-0 md:border-l">
+        <div className="flex flex-col justify-between px-6 py-4 flex-grow border-t @md:border-t-0 @md:border-l">
           <div>
             {titleToUse && (
               <div className="mb-3">

--- a/src/components/PostPreviewSmallRow.tsx
+++ b/src/components/PostPreviewSmallRow.tsx
@@ -22,13 +22,13 @@ export const PostPreviewSmallRow = (props: { className?: string; doc?: Post }) =
         <div className="flex-shrink-0 overflow-hidden">
           {featuredImage && typeof featuredImage !== 'number' ? (
             <ImageMedia
-              imgClassName="w-20 h-20 object-cover scale-110 group-hover:scale-100 transition-all duration-200"
+              imgClassName="w-28 h-20 object-contain scale-100 group-hover:scale-110 transition-all duration-200"
               resource={featuredImage}
               size="72px"
-              pictureClassName="w-20 h-20 overflow-hidden rounded aspect-square"
+              pictureClassName="w-28 h-20 overflow-hidden rounded aspect-square"
             />
           ) : (
-            <div className="w-20 h-20 bg-muted text-muted-foreground flex justify-center items-center">
+            <div className="w-28 h-20 bg-muted text-muted-foreground flex justify-center items-center">
               <BookText />
             </div>
           )}

--- a/src/components/PostPreviewSmallRow.tsx
+++ b/src/components/PostPreviewSmallRow.tsx
@@ -22,10 +22,9 @@ export const PostPreviewSmallRow = (props: { className?: string; doc?: Post }) =
         <div className="flex-shrink-0 overflow-hidden">
           {featuredImage && typeof featuredImage !== 'number' ? (
             <ImageMedia
-              imgClassName="w-28 h-20 object-contain scale-100 group-hover:scale-110 transition-all duration-200"
+              imgClassName="w-28 max-h-28 object-cover transition-all duration-200"
               resource={featuredImage}
-              size="72px"
-              pictureClassName="w-28 h-20 overflow-hidden rounded aspect-square"
+              pictureClassName="w-28 max-h-28 overflow-hidden rounded aspect-square"
             />
           ) : (
             <div className="w-28 h-20 bg-muted text-muted-foreground flex justify-center items-center">


### PR DESCRIPTION
### Descriptions
**Blog updates**
* Fixes main blog view if blog card does not have a description
* Adds proper margin between blog cards and sidebar with filters
* Adds border around both image and blog card because it looked weird only being around the card with a white image.

![Kapture 2025-09-29 at 18 59 58](https://github.com/user-attachments/assets/1973d68e-a207-45d5-aa8b-960fbaf3de17)
<img width="3140" height="3608" alt="Blog-Northwest-Avalanche-Center-09-29-2025_06_59_PM" src="https://github.com/user-attachments/assets/832fc0a8-7dc6-4e79-b0e0-39c6c747ae4a" />

**Button block updates**
* Adds y margin around button incase buttons are back to back
* Fixes label - if a label is input, it will be used, otherwise it will be taken from the title of the reference page. If the link is external, the user is forced to enter a label in `validateLabel`

Pages
<img width="1376" height="436" alt="Screenshot 2025-09-29 at 19 00 50" src="https://github.com/user-attachments/assets/9705a8b5-be5b-4169-8b15-622b25010041" />

Homepage (nothing different about this rendering. It was just where it was mentioned in the ticket)
<img width="400" height="414" alt="Screenshot 2025-09-29 at 19 02 03" src="https://github.com/user-attachments/assets/c87d58a1-0a9f-4ba6-9d0a-9e1cc45b78af" />


### Issues
Resolves #537 
Resolves #558 