### PR TITLE
Adding top-level await to payload scripts

### DIFF
--- a/src/scripts/sanitize-db.ts
+++ b/src/scripts/sanitize-db.ts
@@ -67,4 +67,4 @@ async function sanitizeDatabase() {
   process.exit(0)
 }
 
-sanitizeDatabase()
+await sanitizeDatabase()

--- a/src/scripts/sync-blob-storage.ts
+++ b/src/scripts/sync-blob-storage.ts
@@ -154,4 +154,4 @@ async function main() {
   process.exit(0)
 }
 
-main()
+await main()

--- a/src/scripts/update-media-prefix.ts
+++ b/src/scripts/update-media-prefix.ts
@@ -60,4 +60,4 @@ async function main() {
   process.exit(0)
 }
 
-main()
+await main()


### PR DESCRIPTION
All of our payload-cli-run scripts are silently failing because the payload CLI doesn't await top-level async functions anymore. Must be a change from the last payload upgrade that we didn't notice. 

Notice that the sanitize-db and update-media-prefix scripts hit the first console.log but don't wait for the getPayload promise: https://github.com/NWACus/web/actions/runs/18386184432/job/52385103897

Weirdly sync-blob-storage seems to have been working correctly but I awaited it's `main` function too. 