### PR TITLE
Select clause results in missing nested relationships

### DIFF
--- a/src/utilities/findDocumentsWithBlockReferences.ts
+++ b/src/utilities/findDocumentsWithBlockReferences.ts
@@ -97,12 +97,6 @@ export async function findDocumentsWithBlockReferences(
                 },
               ],
             },
-            select: {
-              id: true,
-              slug: true,
-              tenant: true,
-              layout: true,
-            },
             depth: 1,
           })
 
@@ -137,11 +131,6 @@ export async function findDocumentsWithBlockReferences(
                   [`layout.${mapping.fieldName}`]: { equals: reference.id },
                 },
               ],
-            },
-            select: {
-              id: true,
-              slug: true,
-              tenant: true,
             },
             depth: 1,
           })
@@ -182,11 +171,6 @@ export async function findDocumentsWithBlockReferences(
             },
           ],
         },
-        select: {
-          id: true,
-          slug: true,
-          tenant: true,
-        },
         depth: 1,
       })
 
@@ -225,12 +209,6 @@ export async function findDocumentsWithBlockReferences(
                 },
               ],
             },
-            select: {
-              id: true,
-              slug: true,
-              tenant: true,
-              layout: true,
-            },
             depth: 1,
           })
 
@@ -258,10 +236,6 @@ export async function findDocumentsWithBlockReferences(
             collection: 'homePages',
             where: {
               [`layout.${mapping.fieldName}`]: { equals: reference.id },
-            },
-            select: {
-              id: true,
-              tenant: true,
             },
             depth: 1,
           })

--- a/src/utilities/findDocumentsWithRelationshipReferences.ts
+++ b/src/utilities/findDocumentsWithRelationshipReferences.ts
@@ -33,11 +33,6 @@ export async function findDocumentsWithRelationshipReferences(
               },
             ],
           },
-          select: {
-            id: true,
-            slug: true,
-            tenant: true,
-          },
           depth: 1,
         })
 
@@ -76,11 +71,6 @@ export async function findDocumentsWithRelationshipReferences(
               },
             ],
           },
-          select: {
-            id: true,
-            slug: true,
-            tenant: true,
-          },
           depth: 1,
         })
 
@@ -111,10 +101,6 @@ export async function findDocumentsWithRelationshipReferences(
           collection: 'homePages',
           where: {
             [mapping.fieldPath]: { equals: reference.id },
-          },
-          select: {
-            id: true,
-            tenant: true,
           },
           depth: 1,
         })


### PR DESCRIPTION
Observed behavior where if you use a select clause, nested relationships are not populated. 

This was resulting in block relationships not being found and pages not being revalidated. 

When querying pages, if you include a select clause in the `.findMany()` you get a response like:
```
{
  docs: [
    {
      id: 57,
      layout: [
        {
          id: "68e84d268eca518241596403",
          team: {
            id: 7,
            tenant: 3,
            name: "Advisory Board",
            members: [
              9,
              10,
              11,
              12,
            ],
            contentHash: "464206efa1259eeb5fd237bac67573231de590e37dfac2b9a50a49f68240193a",
            updatedAt: "2025-10-10T00:02:34.395Z",
            createdAt: "2025-10-10T00:02:34.395Z",
          },
          blockName: null,
          blockType: "team",
        },
        {
          id: "68e85397cae092fe7e3fa548",
          backgroundColor: "transparent",
          sponsorsLayout: "static",
          wrapInContainer: true,
          blockName: null,
          blockType: "sponsorsBlock",
          sponsors: [
          ],
        },
      ],
      slug: "who-we-are",
      tenant: {
        id: 3,
        customDomain: "sierraavalanchecenter.org",
        slug: "sac",
      },
    },
  ],
  hasNextPage: false,
  hasPrevPage: false,
  limit: 10,
  nextPage: null,
  page: 1,
  pagingCounter: 1,
  prevPage: null,
  totalDocs: 1,
  totalPages: 1,
}
```
Note how `docs[0].layout[1].sponsors` is an empty array. 

Without a select clause you get a response with the correctly sponsors relationships (some fields removed for brevity):
```
{
  docs: [
    {
      id: 57,
      title: "Who We Are",
      layout: [
        {
          id: "68e84d268eca518241596403",
          team: {
            id: 7,
            tenant: 3,
            name: "Advisory Board",
            members: [
              9,
              10,
              11,
              12,
            ],
            contentHash: "464206efa1259eeb5fd237bac67573231de590e37dfac2b9a50a49f68240193a",
            updatedAt: "2025-10-10T00:02:34.395Z",
            createdAt: "2025-10-10T00:02:34.395Z",
          },
          blockName: null,
          blockType: "team",
        },
        {
          id: "68e85397cae092fe7e3fa548",
          backgroundColor: "transparent",
          sponsorsLayout: "static",
          wrapInContainer: true,
          blockName: null,
          blockType: "sponsorsBlock",
          sponsors: [
            {
              id: 3,
              tenant: 3,
              name: "Acme Corp.",
              photo: 40,
              link: "https://acme.com",
              startDate: null,
              endDate: null,
              contentHash: "0822f8ec3dce7067c3f4fd051cd2ae4ac531977b56ba8fa459a092fe4db2eb55",
              updatedAt: "2025-10-10T00:51:16.335Z",
              createdAt: "2025-10-10T00:02:47.746Z",
            },
          ],
        },
      ],
      publishedAt: "2025-10-10T00:02:44.933Z",
      slug: "who-we-are",
      tenant: {
        id: 3,
        customDomain: "sierraavalanchecenter.org",
        slug: "sac",
      },
      contentHash: "a91bb95ad70c29ddde51542beb97ccd9f99cc7ad0de99f8ddc30f373df6bc170",
      updatedAt: "2025-10-10T00:30:22.036Z",
      createdAt: "2025-10-10T00:02:46.491Z",
      _status: "published",
    },
  ],
  hasNextPage: false,
  hasPrevPage: false,
  limit: 10,
  nextPage: null,
  page: 1,
  pagingCounter: 1,
  prevPage: null,
  totalDocs: 1,
  totalPages: 1,
}
```

Setting different values for `depth` had no effect. Using a `populate` clause with this doesn't work either, even when targeting specific nested attributes. 

This may be a Payload bug. Likely worth opening an issue in their repo at some point but fixing this here for now. It's OK that we're getting back a larger response body than we need. Not a huge performance concern at this point. 