### PR TITLE
bugfix: allow single ACs to see colors in color picker & improve column layout

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,105 +1,150 @@
-import { TenantFieldComponent as TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6 } from '@/fields/tenantField/TenantFieldComponent'
-import { default as default_55a7d1ebef7afeed563b856ae2e2cbf4 } from '@/components/ColorPicker'
-import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { default as default_ef94af202ba9f4dd0fd10062e0964050 } from '@/components/AlignContentPicker'
-import { AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { SponsorsLayoutDescription as SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de } from '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription'
-import { HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { QueriedPostsComponent as QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e } from '@/blocks/BlogList/fields/QueriedPostsComponent'
-import { default as default_923dc5ccc0b72de4298251644cbfe39e } from '@/components/ColumnLayoutPicker'
-import { OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
-import { ViewPageButton as ViewPageButton_5587abba969d5f30cb1f479b0a70bb80 } from '@/collections/Pages/components/ViewPageButton'
+import { SponsorsLayoutDescription as SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de } from '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription'
 import { DuplicatePageFor as DuplicatePageFor_8f1d8961a356bec6784e5c591c016925 } from '@/collections/Pages/components/DuplicatePageFor'
+import { ViewPageButton as ViewPageButton_5587abba969d5f30cb1f479b0a70bb80 } from '@/collections/Pages/components/ViewPageButton'
 import { ViewPostButton as ViewPostButton_c85c9ca228f12030489338b3f3f7139d } from '@/collections/Posts/components/ViewPostButton'
-import { UserStatusCell as UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee } from '@/collections/Users/components/UserStatusCell'
-import { InviteUser as InviteUser_6042b6804e11048cd4fbe6206cbc2b0f } from '@/collections/Users/components/InviteUser'
-import { ResendInviteButton as ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735 } from '@/collections/Users/components/ResendInviteButton'
 import { CollectionsField as CollectionsField_49c0311020325b59204cc21d2f536b8d } from '@/collections/Roles/components/CollectionsField'
 import { RulesCell as RulesCell_649699f5b285e7a5429592dc58fd6f0c } from '@/collections/Roles/components/RulesCell'
-import { LinkLabelDescription as LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721 } from '@/fields/navLink/components/LinkLabelDescription'
 import { AvalancheCenterName as AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad } from '@/collections/Settings/components/AvalancheCenterName'
 import { USFSLogoDescription as USFSLogoDescription_d2eea91290575f9a545768dce25713f4 } from '@/collections/Settings/components/USFSLogoDescription'
-import { DiagnosticsDisplay as DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6 } from '@/globals/Diagnostics/components/DiagnosticsDisplay'
-import { LogoutButton as LogoutButton_db9ac62598c46d0f1db201f6af05442e } from '@/components/LogoutButton'
+import { InviteUser as InviteUser_6042b6804e11048cd4fbe6206cbc2b0f } from '@/collections/Users/components/InviteUser'
+import { ResendInviteButton as ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735 } from '@/collections/Users/components/ResendInviteButton'
+import { UserStatusCell as UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee } from '@/collections/Users/components/UserStatusCell'
+import { default as default_ef94af202ba9f4dd0fd10062e0964050 } from '@/components/AlignContentPicker'
+import { default as default_1a7510af427896d367a49dbf838d2de6 } from '@/components/BeforeDashboard'
+import { default as default_55a7d1ebef7afeed563b856ae2e2cbf4 } from '@/components/ColorPicker'
+import { default as default_923dc5ccc0b72de4298251644cbfe39e } from '@/components/ColumnLayoutPicker'
+import { GlobalViewRedirect as GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e } from '@/components/GlobalViewRedirect'
 import { AvyFxIcon as AvyFxIcon_5698f736c9797d81d0dacf1b1321e327 } from '@/components/Icon/AvyFxIcon'
 import { AvyFxLogo as AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4 } from '@/components/Logo/AvyFxLogo'
-import { GlobalViewRedirect as GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e } from '@/components/GlobalViewRedirect'
-import { default as default_cb0ad5752e1389a2a940bb73c2c0e7d2 } from '@/components/ViewTypeAction'
-import { default as default_1a7510af427896d367a49dbf838d2de6 } from '@/components/BeforeDashboard'
+import { LogoutButton as LogoutButton_db9ac62598c46d0f1db201f6af05442e } from '@/components/LogoutButton'
 import { default as default_2aead22399b7847b21b134dc4a7931e0 } from '@/components/TenantSelector/TenantSelector'
+import { default as default_cb0ad5752e1389a2a940bb73c2c0e7d2 } from '@/components/ViewTypeAction'
+import { LinkLabelDescription as LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721 } from '@/fields/navLink/components/LinkLabelDescription'
+import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
+import { TenantFieldComponent as TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6 } from '@/fields/tenantField/TenantFieldComponent'
+import { DiagnosticsDisplay as DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6 } from '@/globals/Diagnostics/components/DiagnosticsDisplay'
 import { TenantSelectionProvider as TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d } from '@/providers/TenantSelectionProvider'
 import { ViewTypeProvider as ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0 } from '@/providers/ViewTypeProvider'
-import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
-import { AdminErrorBoundary as AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688 } from '@payloadcms/plugin-sentry/client'
 import { AcceptInvite as AcceptInvite_a090ee9cb5b31ae357daa74987d3109a } from '@/views/AcceptInvite'
+import { AdminErrorBoundary as AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688 } from '@payloadcms/plugin-sentry/client'
+import {
+  MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+} from '@payloadcms/plugin-seo/client'
+import {
+  AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+} from '@payloadcms/richtext-lexical/client'
+import {
+  LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
+  RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
+  RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+} from '@payloadcms/richtext-lexical/rsc'
+import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
 
 export const importMap = {
-  "@/fields/tenantField/TenantFieldComponent#TenantFieldComponent": TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6,
-  "@/components/ColorPicker#default": default_55a7d1ebef7afeed563b856ae2e2cbf4,
-  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@/components/AlignContentPicker#default": default_ef94af202ba9f4dd0fd10062e0964050,
-  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient": FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#ParagraphFeatureClient": ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@/blocks/SponsorsBlock/components/SponsorsLayoutDescription#SponsorsLayoutDescription": SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de,
-  "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#OrderedListFeatureClient": OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#UnorderedListFeatureClient": UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@/blocks/BlogList/fields/QueriedPostsComponent#QueriedPostsComponent": QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e,
-  "@/components/ColumnLayoutPicker#default": default_923dc5ccc0b72de4298251644cbfe39e,
-  "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
-  "@/collections/Pages/components/ViewPageButton#ViewPageButton": ViewPageButton_5587abba969d5f30cb1f479b0a70bb80,
-  "@/collections/Pages/components/DuplicatePageFor#DuplicatePageFor": DuplicatePageFor_8f1d8961a356bec6784e5c591c016925,
-  "@/collections/Posts/components/ViewPostButton#ViewPostButton": ViewPostButton_c85c9ca228f12030489338b3f3f7139d,
-  "@/collections/Users/components/UserStatusCell#UserStatusCell": UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee,
-  "@/collections/Users/components/InviteUser#InviteUser": InviteUser_6042b6804e11048cd4fbe6206cbc2b0f,
-  "@/collections/Users/components/ResendInviteButton#ResendInviteButton": ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735,
-  "@/collections/Roles/components/CollectionsField#CollectionsField": CollectionsField_49c0311020325b59204cc21d2f536b8d,
-  "@/collections/Roles/components/RulesCell#RulesCell": RulesCell_649699f5b285e7a5429592dc58fd6f0c,
-  "@/fields/navLink/components/LinkLabelDescription#LinkLabelDescription": LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721,
-  "@/collections/Settings/components/AvalancheCenterName#AvalancheCenterName": AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad,
-  "@/collections/Settings/components/USFSLogoDescription#USFSLogoDescription": USFSLogoDescription_d2eea91290575f9a545768dce25713f4,
-  "@/globals/Diagnostics/components/DiagnosticsDisplay#DiagnosticsDisplay": DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6,
-  "@/components/LogoutButton#LogoutButton": LogoutButton_db9ac62598c46d0f1db201f6af05442e,
-  "@/components/Icon/AvyFxIcon#AvyFxIcon": AvyFxIcon_5698f736c9797d81d0dacf1b1321e327,
-  "@/components/Logo/AvyFxLogo#AvyFxLogo": AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4,
-  "@/components/GlobalViewRedirect#GlobalViewRedirect": GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e,
-  "@/components/ViewTypeAction#default": default_cb0ad5752e1389a2a940bb73c2c0e7d2,
-  "@/components/BeforeDashboard#default": default_1a7510af427896d367a49dbf838d2de6,
-  "@/components/TenantSelector/TenantSelector#default": default_2aead22399b7847b21b134dc4a7931e0,
-  "@/providers/TenantSelectionProvider#TenantSelectionProvider": TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d,
-  "@/providers/ViewTypeProvider#ViewTypeProvider": ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0,
-  "@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler": VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
-  "@payloadcms/plugin-sentry/client#AdminErrorBoundary": AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688,
-  "@/views/AcceptInvite#AcceptInvite": AcceptInvite_a090ee9cb5b31ae357daa74987d3109a
+  '@/fields/tenantField/TenantFieldComponent#TenantFieldComponent':
+    TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6,
+  '@/components/ColorPicker#default': default_55a7d1ebef7afeed563b856ae2e2cbf4,
+  '@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell':
+    RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
+  '@payloadcms/richtext-lexical/rsc#RscEntryLexicalField':
+    RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+  '@payloadcms/richtext-lexical/rsc#LexicalDiffComponent':
+    LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
+  '@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient':
+    InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient':
+    HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#BlocksFeatureClient':
+    BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@/components/AlignContentPicker#default': default_ef94af202ba9f4dd0fd10062e0964050,
+  '@payloadcms/richtext-lexical/client#AlignFeatureClient':
+    AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient':
+    FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#LinkFeatureClient':
+    LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#BoldFeatureClient':
+    BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#ItalicFeatureClient':
+    ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#UnderlineFeatureClient':
+    UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#ParagraphFeatureClient':
+    ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription#SponsorsLayoutDescription':
+    SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de,
+  '@payloadcms/richtext-lexical/client#HeadingFeatureClient':
+    HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#OrderedListFeatureClient':
+    OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#UnorderedListFeatureClient':
+    UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@/blocks/BlogList/fields/QueriedPostsComponent#QueriedPostsComponent':
+    QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e,
+  '@/components/ColumnLayoutPicker#default': default_923dc5ccc0b72de4298251644cbfe39e,
+  '@payloadcms/plugin-seo/client#OverviewComponent':
+    OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  '@payloadcms/plugin-seo/client#MetaImageComponent':
+    MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  '@payloadcms/plugin-seo/client#MetaDescriptionComponent':
+    MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  '@payloadcms/plugin-seo/client#PreviewComponent':
+    PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  '@/fields/slug/SlugComponent#SlugComponent': SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
+  '@/collections/Pages/components/ViewPageButton#ViewPageButton':
+    ViewPageButton_5587abba969d5f30cb1f479b0a70bb80,
+  '@/collections/Pages/components/DuplicatePageFor#DuplicatePageFor':
+    DuplicatePageFor_8f1d8961a356bec6784e5c591c016925,
+  '@/collections/Posts/components/ViewPostButton#ViewPostButton':
+    ViewPostButton_c85c9ca228f12030489338b3f3f7139d,
+  '@/collections/Users/components/UserStatusCell#UserStatusCell':
+    UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee,
+  '@/collections/Users/components/InviteUser#InviteUser':
+    InviteUser_6042b6804e11048cd4fbe6206cbc2b0f,
+  '@/collections/Users/components/ResendInviteButton#ResendInviteButton':
+    ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735,
+  '@/collections/Roles/components/CollectionsField#CollectionsField':
+    CollectionsField_49c0311020325b59204cc21d2f536b8d,
+  '@/collections/Roles/components/RulesCell#RulesCell': RulesCell_649699f5b285e7a5429592dc58fd6f0c,
+  '@/fields/navLink/components/LinkLabelDescription#LinkLabelDescription':
+    LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721,
+  '@/collections/Settings/components/AvalancheCenterName#AvalancheCenterName':
+    AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad,
+  '@/collections/Settings/components/USFSLogoDescription#USFSLogoDescription':
+    USFSLogoDescription_d2eea91290575f9a545768dce25713f4,
+  '@/globals/Diagnostics/components/DiagnosticsDisplay#DiagnosticsDisplay':
+    DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6,
+  '@/components/LogoutButton#LogoutButton': LogoutButton_db9ac62598c46d0f1db201f6af05442e,
+  '@/components/Icon/AvyFxIcon#AvyFxIcon': AvyFxIcon_5698f736c9797d81d0dacf1b1321e327,
+  '@/components/Logo/AvyFxLogo#AvyFxLogo': AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4,
+  '@/components/GlobalViewRedirect#GlobalViewRedirect':
+    GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e,
+  '@/components/ViewTypeAction#default': default_cb0ad5752e1389a2a940bb73c2c0e7d2,
+  '@/components/BeforeDashboard#default': default_1a7510af427896d367a49dbf838d2de6,
+  '@/components/TenantSelector/TenantSelector#default': default_2aead22399b7847b21b134dc4a7931e0,
+  '@/providers/TenantSelectionProvider#TenantSelectionProvider':
+    TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d,
+  '@/providers/ViewTypeProvider#ViewTypeProvider':
+    ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0,
+  '@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler':
+    VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
+  '@payloadcms/plugin-sentry/client#AdminErrorBoundary':
+    AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688,
+  '@/views/AcceptInvite#AcceptInvite': AcceptInvite_a090ee9cb5b31ae357daa74987d3109a,
 }

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,150 +1,105 @@
-import { QueriedPostsComponent as QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e } from '@/blocks/BlogList/fields/QueriedPostsComponent'
+import { TenantFieldComponent as TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6 } from '@/fields/tenantField/TenantFieldComponent'
+import { default as default_55a7d1ebef7afeed563b856ae2e2cbf4 } from '@/components/ColorPicker'
+import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { default as default_ef94af202ba9f4dd0fd10062e0964050 } from '@/components/AlignContentPicker'
+import { AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { SponsorsLayoutDescription as SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de } from '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription'
-import { DuplicatePageFor as DuplicatePageFor_8f1d8961a356bec6784e5c591c016925 } from '@/collections/Pages/components/DuplicatePageFor'
+import { HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { QueriedPostsComponent as QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e } from '@/blocks/BlogList/fields/QueriedPostsComponent'
+import { default as default_923dc5ccc0b72de4298251644cbfe39e } from '@/components/ColumnLayoutPicker'
+import { OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
 import { ViewPageButton as ViewPageButton_5587abba969d5f30cb1f479b0a70bb80 } from '@/collections/Pages/components/ViewPageButton'
+import { DuplicatePageFor as DuplicatePageFor_8f1d8961a356bec6784e5c591c016925 } from '@/collections/Pages/components/DuplicatePageFor'
 import { ViewPostButton as ViewPostButton_c85c9ca228f12030489338b3f3f7139d } from '@/collections/Posts/components/ViewPostButton'
-import { CollectionsField as CollectionsField_49c0311020325b59204cc21d2f536b8d } from '@/collections/Roles/components/CollectionsField'
-import { RulesCell as RulesCell_649699f5b285e7a5429592dc58fd6f0c } from '@/collections/Roles/components/RulesCell'
-import { AvalancheCenterName as AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad } from '@/collections/Settings/components/AvalancheCenterName'
-import { USFSLogoDescription as USFSLogoDescription_d2eea91290575f9a545768dce25713f4 } from '@/collections/Settings/components/USFSLogoDescription'
+import { UserStatusCell as UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee } from '@/collections/Users/components/UserStatusCell'
 import { InviteUser as InviteUser_6042b6804e11048cd4fbe6206cbc2b0f } from '@/collections/Users/components/InviteUser'
 import { ResendInviteButton as ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735 } from '@/collections/Users/components/ResendInviteButton'
-import { UserStatusCell as UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee } from '@/collections/Users/components/UserStatusCell'
-import { default as default_ef94af202ba9f4dd0fd10062e0964050 } from '@/components/AlignContentPicker'
-import { default as default_1a7510af427896d367a49dbf838d2de6 } from '@/components/BeforeDashboard'
-import { default as default_55a7d1ebef7afeed563b856ae2e2cbf4 } from '@/components/ColorPicker'
-import { default as default_923dc5ccc0b72de4298251644cbfe39e } from '@/components/ColumnLayoutPicker'
-import { GlobalViewRedirect as GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e } from '@/components/GlobalViewRedirect'
+import { CollectionsField as CollectionsField_49c0311020325b59204cc21d2f536b8d } from '@/collections/Roles/components/CollectionsField'
+import { RulesCell as RulesCell_649699f5b285e7a5429592dc58fd6f0c } from '@/collections/Roles/components/RulesCell'
+import { LinkLabelDescription as LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721 } from '@/fields/navLink/components/LinkLabelDescription'
+import { AvalancheCenterName as AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad } from '@/collections/Settings/components/AvalancheCenterName'
+import { USFSLogoDescription as USFSLogoDescription_d2eea91290575f9a545768dce25713f4 } from '@/collections/Settings/components/USFSLogoDescription'
+import { DiagnosticsDisplay as DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6 } from '@/globals/Diagnostics/components/DiagnosticsDisplay'
+import { LogoutButton as LogoutButton_db9ac62598c46d0f1db201f6af05442e } from '@/components/LogoutButton'
 import { AvyFxIcon as AvyFxIcon_5698f736c9797d81d0dacf1b1321e327 } from '@/components/Icon/AvyFxIcon'
 import { AvyFxLogo as AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4 } from '@/components/Logo/AvyFxLogo'
-import { LogoutButton as LogoutButton_db9ac62598c46d0f1db201f6af05442e } from '@/components/LogoutButton'
-import { default as default_2aead22399b7847b21b134dc4a7931e0 } from '@/components/TenantSelector/TenantSelector'
+import { GlobalViewRedirect as GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e } from '@/components/GlobalViewRedirect'
 import { default as default_cb0ad5752e1389a2a940bb73c2c0e7d2 } from '@/components/ViewTypeAction'
-import { LinkLabelDescription as LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721 } from '@/fields/navLink/components/LinkLabelDescription'
-import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
-import { TenantFieldComponent as TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6 } from '@/fields/tenantField/TenantFieldComponent'
-import { DiagnosticsDisplay as DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6 } from '@/globals/Diagnostics/components/DiagnosticsDisplay'
+import { default as default_1a7510af427896d367a49dbf838d2de6 } from '@/components/BeforeDashboard'
+import { default as default_2aead22399b7847b21b134dc4a7931e0 } from '@/components/TenantSelector/TenantSelector'
 import { TenantSelectionProvider as TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d } from '@/providers/TenantSelectionProvider'
 import { ViewTypeProvider as ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0 } from '@/providers/ViewTypeProvider'
-import { AcceptInvite as AcceptInvite_a090ee9cb5b31ae357daa74987d3109a } from '@/views/AcceptInvite'
-import { AdminErrorBoundary as AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688 } from '@payloadcms/plugin-sentry/client'
-import {
-  MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-} from '@payloadcms/plugin-seo/client'
-import {
-  AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-} from '@payloadcms/richtext-lexical/client'
-import {
-  LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
-  RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
-  RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
-} from '@payloadcms/richtext-lexical/rsc'
 import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
+import { AdminErrorBoundary as AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688 } from '@payloadcms/plugin-sentry/client'
+import { AcceptInvite as AcceptInvite_a090ee9cb5b31ae357daa74987d3109a } from '@/views/AcceptInvite'
 
 export const importMap = {
-  '@/fields/tenantField/TenantFieldComponent#TenantFieldComponent':
-    TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6,
-  '@/components/ColorPicker#default': default_55a7d1ebef7afeed563b856ae2e2cbf4,
-  '@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell':
-    RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
-  '@payloadcms/richtext-lexical/rsc#RscEntryLexicalField':
-    RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
-  '@payloadcms/richtext-lexical/rsc#LexicalDiffComponent':
-    LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
-  '@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient':
-    InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient':
-    HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#BlocksFeatureClient':
-    BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@/components/AlignContentPicker#default': default_ef94af202ba9f4dd0fd10062e0964050,
-  '@payloadcms/richtext-lexical/client#AlignFeatureClient':
-    AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient':
-    FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#LinkFeatureClient':
-    LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#BoldFeatureClient':
-    BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#ItalicFeatureClient':
-    ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#UnderlineFeatureClient':
-    UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#ParagraphFeatureClient':
-    ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription#SponsorsLayoutDescription':
-    SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de,
-  '@payloadcms/richtext-lexical/client#HeadingFeatureClient':
-    HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#OrderedListFeatureClient':
-    OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#UnorderedListFeatureClient':
-    UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@/blocks/BlogList/fields/QueriedPostsComponent#QueriedPostsComponent':
-    QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e,
-  '@/components/ColumnLayoutPicker#default': default_923dc5ccc0b72de4298251644cbfe39e,
-  '@payloadcms/plugin-seo/client#OverviewComponent':
-    OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@payloadcms/plugin-seo/client#MetaImageComponent':
-    MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@payloadcms/plugin-seo/client#MetaDescriptionComponent':
-    MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@payloadcms/plugin-seo/client#PreviewComponent':
-    PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@/fields/slug/SlugComponent#SlugComponent': SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
-  '@/collections/Pages/components/ViewPageButton#ViewPageButton':
-    ViewPageButton_5587abba969d5f30cb1f479b0a70bb80,
-  '@/collections/Pages/components/DuplicatePageFor#DuplicatePageFor':
-    DuplicatePageFor_8f1d8961a356bec6784e5c591c016925,
-  '@/collections/Posts/components/ViewPostButton#ViewPostButton':
-    ViewPostButton_c85c9ca228f12030489338b3f3f7139d,
-  '@/collections/Users/components/UserStatusCell#UserStatusCell':
-    UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee,
-  '@/collections/Users/components/InviteUser#InviteUser':
-    InviteUser_6042b6804e11048cd4fbe6206cbc2b0f,
-  '@/collections/Users/components/ResendInviteButton#ResendInviteButton':
-    ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735,
-  '@/collections/Roles/components/CollectionsField#CollectionsField':
-    CollectionsField_49c0311020325b59204cc21d2f536b8d,
-  '@/collections/Roles/components/RulesCell#RulesCell': RulesCell_649699f5b285e7a5429592dc58fd6f0c,
-  '@/fields/navLink/components/LinkLabelDescription#LinkLabelDescription':
-    LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721,
-  '@/collections/Settings/components/AvalancheCenterName#AvalancheCenterName':
-    AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad,
-  '@/collections/Settings/components/USFSLogoDescription#USFSLogoDescription':
-    USFSLogoDescription_d2eea91290575f9a545768dce25713f4,
-  '@/globals/Diagnostics/components/DiagnosticsDisplay#DiagnosticsDisplay':
-    DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6,
-  '@/components/LogoutButton#LogoutButton': LogoutButton_db9ac62598c46d0f1db201f6af05442e,
-  '@/components/Icon/AvyFxIcon#AvyFxIcon': AvyFxIcon_5698f736c9797d81d0dacf1b1321e327,
-  '@/components/Logo/AvyFxLogo#AvyFxLogo': AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4,
-  '@/components/GlobalViewRedirect#GlobalViewRedirect':
-    GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e,
-  '@/components/ViewTypeAction#default': default_cb0ad5752e1389a2a940bb73c2c0e7d2,
-  '@/components/BeforeDashboard#default': default_1a7510af427896d367a49dbf838d2de6,
-  '@/components/TenantSelector/TenantSelector#default': default_2aead22399b7847b21b134dc4a7931e0,
-  '@/providers/TenantSelectionProvider#TenantSelectionProvider':
-    TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d,
-  '@/providers/ViewTypeProvider#ViewTypeProvider':
-    ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0,
-  '@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler':
-    VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
-  '@payloadcms/plugin-sentry/client#AdminErrorBoundary':
-    AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688,
-  '@/views/AcceptInvite#AcceptInvite': AcceptInvite_a090ee9cb5b31ae357daa74987d3109a,
+  "@/fields/tenantField/TenantFieldComponent#TenantFieldComponent": TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6,
+  "@/components/ColorPicker#default": default_55a7d1ebef7afeed563b856ae2e2cbf4,
+  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@/components/AlignContentPicker#default": default_ef94af202ba9f4dd0fd10062e0964050,
+  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient": FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#ParagraphFeatureClient": ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@/blocks/SponsorsBlock/components/SponsorsLayoutDescription#SponsorsLayoutDescription": SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de,
+  "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#OrderedListFeatureClient": OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#UnorderedListFeatureClient": UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@/blocks/BlogList/fields/QueriedPostsComponent#QueriedPostsComponent": QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e,
+  "@/components/ColumnLayoutPicker#default": default_923dc5ccc0b72de4298251644cbfe39e,
+  "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
+  "@/collections/Pages/components/ViewPageButton#ViewPageButton": ViewPageButton_5587abba969d5f30cb1f479b0a70bb80,
+  "@/collections/Pages/components/DuplicatePageFor#DuplicatePageFor": DuplicatePageFor_8f1d8961a356bec6784e5c591c016925,
+  "@/collections/Posts/components/ViewPostButton#ViewPostButton": ViewPostButton_c85c9ca228f12030489338b3f3f7139d,
+  "@/collections/Users/components/UserStatusCell#UserStatusCell": UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee,
+  "@/collections/Users/components/InviteUser#InviteUser": InviteUser_6042b6804e11048cd4fbe6206cbc2b0f,
+  "@/collections/Users/components/ResendInviteButton#ResendInviteButton": ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735,
+  "@/collections/Roles/components/CollectionsField#CollectionsField": CollectionsField_49c0311020325b59204cc21d2f536b8d,
+  "@/collections/Roles/components/RulesCell#RulesCell": RulesCell_649699f5b285e7a5429592dc58fd6f0c,
+  "@/fields/navLink/components/LinkLabelDescription#LinkLabelDescription": LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721,
+  "@/collections/Settings/components/AvalancheCenterName#AvalancheCenterName": AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad,
+  "@/collections/Settings/components/USFSLogoDescription#USFSLogoDescription": USFSLogoDescription_d2eea91290575f9a545768dce25713f4,
+  "@/globals/Diagnostics/components/DiagnosticsDisplay#DiagnosticsDisplay": DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6,
+  "@/components/LogoutButton#LogoutButton": LogoutButton_db9ac62598c46d0f1db201f6af05442e,
+  "@/components/Icon/AvyFxIcon#AvyFxIcon": AvyFxIcon_5698f736c9797d81d0dacf1b1321e327,
+  "@/components/Logo/AvyFxLogo#AvyFxLogo": AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4,
+  "@/components/GlobalViewRedirect#GlobalViewRedirect": GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e,
+  "@/components/ViewTypeAction#default": default_cb0ad5752e1389a2a940bb73c2c0e7d2,
+  "@/components/BeforeDashboard#default": default_1a7510af427896d367a49dbf838d2de6,
+  "@/components/TenantSelector/TenantSelector#default": default_2aead22399b7847b21b134dc4a7931e0,
+  "@/providers/TenantSelectionProvider#TenantSelectionProvider": TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d,
+  "@/providers/ViewTypeProvider#ViewTypeProvider": ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0,
+  "@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler": VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
+  "@payloadcms/plugin-sentry/client#AdminErrorBoundary": AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688,
+  "@/views/AcceptInvite#AcceptInvite": AcceptInvite_a090ee9cb5b31ae357daa74987d3109a
 }

--- a/src/blocks/Content/config.ts
+++ b/src/blocks/Content/config.ts
@@ -1,4 +1,4 @@
-import type { Block } from 'payload'
+import type { Block, SelectFieldValidation } from 'payload'
 
 import colorPickerField from '@/fields/color'
 import {
@@ -17,6 +17,25 @@ import { MediaBlockLexical } from '../MediaBlock/config'
 import { SingleBlogPostBlockLexical } from '../SingleBlogPost/config'
 import { SponsorsBlock } from '../SponsorsBlock/config'
 
+const validateColumnLayout: SelectFieldValidation = (value, { siblingData }) => {
+  if (!value || typeof value !== 'string') return true
+  if (
+    siblingData &&
+    typeof siblingData === 'object' &&
+    'columns' in siblingData &&
+    Array.isArray(siblingData.columns)
+  ) {
+    const numOfCols = siblingData.columns?.length ?? 0
+    const selectedColCount = parseInt(value.split('_')[0])
+
+    if (selectedColCount !== numOfCols) {
+      return `Selected layout requires ${selectedColCount} column${selectedColCount !== 1 ? 's' : ''}, but ${numOfCols} column${numOfCols !== 1 ? 's' : ''} exist${numOfCols === 1 ? 's' : ''}`
+    }
+  }
+
+  return true
+}
+
 export const Content: Block = {
   slug: 'content',
   interfaceName: 'ContentBlock',
@@ -26,6 +45,7 @@ export const Content: Block = {
     colorPickerField('Background color'),
     {
       name: 'layout',
+      label: 'Column layout',
       type: 'select',
       required: true,
       defaultValue: '1_1',
@@ -45,6 +65,7 @@ export const Content: Block = {
           Field: '@/components/ColumnLayoutPicker',
         },
       },
+      validate: validateColumnLayout,
     },
     {
       name: 'columns',
@@ -53,6 +74,8 @@ export const Content: Block = {
         plural: 'Columns',
         singular: 'Column',
       },
+      required: true,
+      defaultValue: [],
       type: 'array',
       admin: {
         initCollapsed: false,

--- a/src/blocks/Content/config.ts
+++ b/src/blocks/Content/config.ts
@@ -29,6 +29,7 @@ const validateColumnLayout: SelectFieldValidation = (value, { siblingData }) => 
     const selectedColCount = parseInt(value.split('_')[0])
 
     if (selectedColCount !== numOfCols) {
+      // TODO - figure out why error is not showing with custom field
       return `Selected layout requires ${selectedColCount} column${selectedColCount !== 1 ? 's' : ''}, but ${numOfCols} column${numOfCols !== 1 ? 's' : ''} exist${numOfCols === 1 ? 's' : ''}`
     }
   }
@@ -75,7 +76,7 @@ export const Content: Block = {
         singular: 'Column',
       },
       required: true,
-      defaultValue: [],
+      defaultValue: [{}],
       type: 'array',
       admin: {
         initCollapsed: false,

--- a/src/components/ColorPicker/index.tsx
+++ b/src/components/ColorPicker/index.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useTenantSelection } from '@/providers/TenantSelectionProvider/index.client'
+import { getSlugFromTenantId } from '@/utilities/getSlugFromTenantId'
 import { cn } from '@/utilities/ui'
-import { FieldLabel, useField } from '@payloadcms/ui'
+import { FieldLabel, useDocumentInfo, useField } from '@payloadcms/ui'
 import { TextFieldClientProps } from 'payload'
+import { useEffect, useState } from 'react'
 
 const ColorPicker = (props: TextFieldClientProps) => {
   const colorOptions = [
@@ -22,20 +23,20 @@ const ColorPicker = (props: TextFieldClientProps) => {
   ]
 
   const { path, field } = props
-
+  const { data } = useDocumentInfo()
   const { value, setValue } = useField({ path })
-  const { selectedTenantID: tenant } = useTenantSelection() as { selectedTenantID: number }
+  const [tenantSlug, setTenantSlug] = useState<string | null>(null)
 
-  // TODO map to slug directly
-  const tenantColorClass: Record<number, string> = {
-    1: 'dvac',
-    2: 'nwac',
-    3: 'sac',
-    4: 'snfac',
-  }
+  useEffect(() => {
+    async function fetchUser() {
+      const userData = await getSlugFromTenantId(data?.tenant)
+      setTenantSlug(userData)
+    }
+    fetchUser()
+  }, [data?.tenant])
 
   return (
-    <div className={cn(`flex flex-col mb-6 ${tenantColorClass[tenant]}`)}>
+    <div className={cn(`flex flex-col mb-6 ${tenantSlug}`)}>
       <FieldLabel htmlFor={path} label={field.label} required={field.required} />
       <ul className="flex flex-wrap max-w-[260px] list-none pl-0">
         {colorOptions.map((color, i) => {

--- a/src/components/ColorPicker/index.tsx
+++ b/src/components/ColorPicker/index.tsx
@@ -27,14 +27,14 @@ const ColorPicker = (props: TextFieldClientProps) => {
   return (
     <div className={cn(`flex flex-col mb-6 ${tenantSlug}`)}>
       <FieldLabel htmlFor={path} label={field.label} required={field.required} />
-      <ul className="flex flex-wrap max-w-[260px] list-none pl-0">
+      <ul className="flex flex-wrap list-none pl-0">
         {colorOptions.map((color, i) => {
           const bgColor = `bg-${color}`
           return (
             <li key={i} className={cn('border', { 'border-solid': color === value })}>
               <div
                 className={cn(
-                  `relative w-[2em] h-[2em] m-2 p-2 rounded-full cursor-pointer ${bgColor}`,
+                  `relative w-[2em] h-[2em] m-2 p-2 rounded-full cursor-pointer ${bgColor} border border-solid border-gray-600`,
                   {
                     'bg-center bg-[length:20px_20px] bg-[image:repeating-conic-gradient(#ddd_0%_25%,white_0%_50%)]':
                       color === 'transparent',

--- a/src/components/ColorPicker/index.tsx
+++ b/src/components/ColorPicker/index.tsx
@@ -22,30 +22,29 @@ const ColorPicker = (props: TextFieldClientProps) => {
     fetchUser()
   }, [data?.tenant])
 
-  if (!tenantSlug) return null
-
   return (
     <div className={cn(`flex flex-col mb-6 ${tenantSlug}`)}>
       <FieldLabel htmlFor={path} label={field.label} required={field.required} />
       <ul className="flex flex-wrap list-none pl-0">
-        {colorOptions.map((color, i) => {
-          const bgColor = `bg-${color}`
-          return (
-            <li key={i} className={cn('border', { 'border-solid': color === value })}>
-              <div
-                className={cn(
-                  `relative w-[2em] h-[2em] m-2 p-2 rounded-full cursor-pointer ${bgColor} border border-solid border-gray-600`,
-                  {
-                    'bg-center bg-[length:20px_20px] bg-[image:repeating-conic-gradient(#ddd_0%_25%,white_0%_50%)]':
-                      color === 'transparent',
-                  },
-                )}
-                aria-label={color}
-                onClick={() => setValue(color)}
-              />
-            </li>
-          )
-        })}
+        {tenantSlug &&
+          colorOptions.map((color, i) => {
+            const bgColor = `bg-${color}`
+            return (
+              <li key={i} className={cn('border', { 'border-solid': color === value })}>
+                <div
+                  className={cn(
+                    `relative w-[2em] h-[2em] m-2 p-2 rounded-full cursor-pointer ${bgColor} border border-solid border-gray-600`,
+                    {
+                      'bg-center bg-[length:20px_20px] bg-[image:repeating-conic-gradient(#ddd_0%_25%,white_0%_50%)]':
+                        color === 'transparent',
+                    },
+                  )}
+                  aria-label={color}
+                  onClick={() => setValue(color)}
+                />
+              </li>
+            )
+          })}
       </ul>
     </div>
   )

--- a/src/components/ColorPicker/index.tsx
+++ b/src/components/ColorPicker/index.tsx
@@ -36,7 +36,7 @@ const ColorPicker = (props: TextFieldClientProps) => {
                 className={cn(
                   `relative w-[2em] h-[2em] m-2 p-2 rounded-full cursor-pointer ${bgColor}`,
                   {
-                    'bg-white bg-[repeating-linear-gradient(45deg,#aaa_25%,transparent_25%,transparent_75%,#aaa_75%,#aaa),repeating-linear-gradient(45deg,#aaa_25%,#e5e5f7_25%,#e5e5f7_75%,#aaa_75%,#aaa)] bg-[position:0_0,10px_10px] bg-[size:20px_20px] bg-repeat':
+                    'bg-center bg-[length:20px_20px] bg-[image:repeating-conic-gradient(#ddd_0%_25%,white_0%_50%)]':
                       color === 'transparent',
                   },
                 )}

--- a/src/components/ColorPicker/index.tsx
+++ b/src/components/ColorPicker/index.tsx
@@ -7,21 +7,8 @@ import { TextFieldClientProps } from 'payload'
 import { useEffect, useState } from 'react'
 
 const ColorPicker = (props: TextFieldClientProps) => {
-  const colorOptions = [
-    'white',
-    'brand-100',
-    'brand-200',
-    'brand-300',
-    'brand-400',
-    'brand-500',
-    'brand-600',
-    'brand-700',
-    'brand-800',
-    'brand-900',
-    'brand-950',
-    'transparent',
-  ]
-
+  const brandShades = [100, 200, 300, 400, 500, 600, 700, 800, 900, 950]
+  const colorOptions = ['white', ...brandShades.map((n) => `brand-${n}`), 'transparent']
   const { path, field } = props
   const { data } = useDocumentInfo()
   const { value, setValue } = useField({ path })
@@ -34,6 +21,8 @@ const ColorPicker = (props: TextFieldClientProps) => {
     }
     fetchUser()
   }, [data?.tenant])
+
+  if (!tenantSlug) return null
 
   return (
     <div className={cn(`flex flex-col mb-6 ${tenantSlug}`)}>

--- a/src/components/ColumnLayoutPicker/index.tsx
+++ b/src/components/ColumnLayoutPicker/index.tsx
@@ -51,7 +51,7 @@ const ColumnLayoutPicker = (props: ColumnLayoutPickerProps) => {
               key={option.value}
               value={option.value}
               aria-label={option.label}
-              className={`pointer-events-auto ${isDisabled ? 'cursor-pointer' : 'cursor-not-allowed opacity-80'}`}
+              className={`${isDisabled ? 'pointer-events-auto cursor-not-allowed opacity-80' : 'cursor-pointer'}`}
               disabled={isDisabled}
             >
               <Icon style={{ width: '20px', height: '20px' }} />

--- a/src/components/ColumnLayoutPicker/index.tsx
+++ b/src/components/ColumnLayoutPicker/index.tsx
@@ -12,31 +12,27 @@ const ColumnLayoutPicker = (props: ColumnLayoutPickerProps) => {
   const layoutOptions = [
     { label: 'full', value: '1_1', icon: Square },
     { label: '1:1', value: '2_11', icon: Columns2 },
-    { label: '1:1:1', value: '3_111', icon: Columns3 },
     { label: '1:2', value: '2_12', icon: Columns12 },
     { label: '2:1', value: '2_21', icon: Columns21 },
-    { label: '1:1:1:1', value: '4_1111', icon: Columns4 },
+    { label: '1:1:1', value: '3_111', icon: Columns3 },
     { label: '1:1:2', value: '3_112', icon: Columns112 },
     { label: '1:2:1', value: '3_121', icon: Columns121 },
     { label: '2:1:1', value: '3_211', icon: Columns211 },
+    { label: '1:1:1:1', value: '4_1111', icon: Columns4 },
   ]
   const { path, field } = props
 
   const { value, setValue } = useField<string>({ path })
 
-  const currentValue = value || 'one_1'
+  const currentValue = value || '1_1'
 
   const fields = useFormFields(([fields]) => fields)
   const columnsPath = path.replace(/layout$/, 'columns')
   const numOfCols = fields[columnsPath].rows?.length || 0
-
-  const filteredLayoutOptions = layoutOptions.filter((option) => {
-    const colCount = parseInt(option.value.split('_')[0])
-    return colCount === numOfCols
-  })
+  if (numOfCols === 0) return null
 
   return (
-    <div className="flex items-start mb-6">
+    <div className="mb-6">
       <FieldLabel htmlFor={path} label={field.label} required={field.required} />
       <ToggleGroup
         type="single"
@@ -45,20 +41,25 @@ const ColumnLayoutPicker = (props: ColumnLayoutPickerProps) => {
         variant="outline"
         className="justify-start"
       >
-        {filteredLayoutOptions.map((option) => {
+        {layoutOptions.map((option) => {
           const Icon = option.icon
+          const colCount = parseInt(option.value.split('_')[0])
+          const isDisabled = colCount !== numOfCols
+
           return (
             <ToggleGroupItem
               key={option.value}
               value={option.value}
               aria-label={option.label}
-              className="cursor-pointer"
+              className={`pointer-events-auto ${isDisabled ? 'cursor-pointer' : 'cursor-not-allowed opacity-80'}`}
+              disabled={isDisabled}
             >
               <Icon style={{ width: '20px', height: '20px' }} />
             </ToggleGroupItem>
           )
         })}
       </ToggleGroup>
+      <div className="field-description">Options update based on the number of columns.</div>
     </div>
   )
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -559,26 +559,24 @@ export interface Post {
 export interface ContentBlock {
   backgroundColor: string;
   layout: '1_1' | '2_11' | '3_111' | '2_12' | '2_21' | '4_1111' | '3_112' | '3_121' | '3_211';
-  columns?:
-    | {
-        richText?: {
-          root: {
-            type: string;
-            children: {
-              type: any;
-              version: number;
-              [k: string]: unknown;
-            }[];
-            direction: ('ltr' | 'rtl') | null;
-            format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-            indent: number;
-            version: number;
-          };
+  columns: {
+    richText?: {
+      root: {
+        type: string;
+        children: {
+          type: any;
+          version: number;
           [k: string]: unknown;
-        } | null;
-        id?: string | null;
-      }[]
-    | null;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    } | null;
+    id?: string | null;
+  }[];
   id?: string | null;
   blockName?: string | null;
   blockType: 'content';

--- a/src/utilities/getSlugFromTenantId.ts
+++ b/src/utilities/getSlugFromTenantId.ts
@@ -1,0 +1,17 @@
+'use server'
+import config from '@payload-config'
+import { getPayload } from 'payload'
+
+export async function getSlugFromTenantId(id: number) {
+  const payload = await getPayload({ config })
+  const tenant = await payload.findByID({
+    collection: 'tenants',
+    id: id,
+    select: {
+      id: true,
+      slug: true,
+    },
+  })
+
+  return tenant.slug
+}


### PR DESCRIPTION
## Description
- Fixes bug where CMS users with a single AC were not seeing their brand colors in the color picker
- Improves column layout field in content block by showing all layout possibilities and adds validation
  - Also changes default value of content block to always have a column added 

## Related Issues
Fixes #583 

## Key Changes
Switched from using the tenant selector (which is not there for single AVs) to the tenant on the doc.
Added validation for a column layout and a default value.

## Screenshots / Demo
<img width="504" height="198" alt="Screenshot 2025-10-10 at 14 01 34" src="https://github.com/user-attachments/assets/00ebde9b-1642-46d8-9446-ad5c3779e16a" />
