### PR TITLE
Bugfix: still allow traffic to /blog if blog hidden from navigation

### DIFF
--- a/src/app/(frontend)/[center]/blog/page.tsx
+++ b/src/app/(frontend)/[center]/blog/page.tsx
@@ -7,7 +7,6 @@ import { PageRange } from '@/components/PageRange'
 import { Pagination } from '@/components/Pagination'
 import { PostCollection } from '@/components/PostCollection'
 import { POSTS_LIMIT } from '@/utilities/constants'
-import { notFound } from 'next/navigation'
 import { PostsSort } from './posts-sort'
 import { PostsTags } from './posts-tags'
 
@@ -25,22 +24,6 @@ export default async function Page({ params, searchParams }: Args) {
   const selectedTag = resolvedSearchParams?.tags
 
   const payload = await getPayload({ config: configPromise })
-
-  const navigationRes = await payload.find({
-    collection: 'navigations',
-    depth: 0,
-    where: {
-      'tenant.slug': {
-        equals: center,
-      },
-    },
-  })
-
-  const navigation = navigationRes.docs[0]
-
-  if (navigation.blog?.options?.enabled === false) {
-    return notFound()
-  }
 
   const posts = await payload.find({
     collection: 'posts',

--- a/src/collections/Navigations/index.tsx
+++ b/src/collections/Navigations/index.tsx
@@ -75,7 +75,7 @@ export const Navigations: CollectionConfig = {
             'This nav item navigates to your blog landing page and does not have any dropdown items.',
           hasConfigurableNavItems: false,
           enabledToggleDescription:
-            'If hidden, the blog landing page will not be accessible to visitors.',
+            'If hidden from the nav, the blog landing page will still be accessible to visitors for filtered blog lists.',
         }),
         topLevelNavTab({
           name: 'events',
@@ -83,7 +83,7 @@ export const Navigations: CollectionConfig = {
             'This nav item navigates to your events landing page and does not have any dropdown items.',
           hasConfigurableNavItems: false,
           enabledToggleDescription:
-            'If hidden, the events landing page will not be accessible to visitors.',
+            'If hidden from the nav, the events landing page will still be accessible to visitors for filtered event lists.',
         }),
         topLevelNavTab({ name: 'about' }),
         topLevelNavTab({ name: 'support' }),

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1560,7 +1560,7 @@ export interface Navigation {
   blog?: {
     options?: {
       /**
-       * If hidden, the blog landing page will not be accessible to visitors.
+       * If hidden from the nav, the blog landing page will still be accessible to visitors for filtered blog lists.
        */
       enabled?: boolean | null;
     };
@@ -1619,7 +1619,7 @@ export interface Navigation {
   events?: {
     options?: {
       /**
-       * If hidden, the events landing page will not be accessible to visitors.
+       * If hidden from the nav, the events landing page will still be accessible to visitors for filtered event lists.
        */
       enabled?: boolean | null;
     };


### PR DESCRIPTION
## Description

We had assumed that traffic to the /blog landing page should 404 if the blog was disabled from the navigation. But we use this route for filtered blog lists. A listing of blogs based on filters is still wanted for the custom links we have in the BlogListBlock. 

## Related Issues

#596 

## Key Changes

- Updates descriptions for enabled/disable toggle on top level nav item field in navigation
- Removes notFound() on /blog if blog is disabled in navigation
