### PR TITLE
Misc PR: enable prose, add button block to posts & slug validation

### DIFF
--- a/src/blocks/Banner/Component.tsx
+++ b/src/blocks/Banner/Component.tsx
@@ -18,7 +18,7 @@ export const BannerBlock = ({ className, content, style }: Props) => {
           'border-warning bg-warning/30': style === 'warning',
         })}
       >
-        <RichText data={content} enableGutter={false} enableProse={false} />
+        <RichText data={content} enableGutter={false} />
       </div>
     </div>
   )

--- a/src/blocks/ImageTextList/Component.tsx
+++ b/src/blocks/ImageTextList/Component.tsx
@@ -59,7 +59,7 @@ export const ImageTextList = (props: Props) => {
                   <div className={`${isSideLayout ? 'col-span-3' : 'mt-4'}`}>
                     <h3 className="text-lg font-bold">{title}</h3>
                     <div className="mt-2">
-                      <RichText data={richText} enableGutter={false} enableProse={false} />
+                      <RichText data={richText} enableGutter={false} />
                     </div>
                   </div>
                 </div>

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -27,6 +27,7 @@ import { revalidatePost, revalidatePostDelete } from './hooks/revalidatePost'
 
 import { accessByTenantRoleOrReadPublished } from '@/access/byTenantRoleOrReadPublished'
 import { filterByTenant } from '@/access/filterByTenant'
+import { ButtonBlock } from '@/blocks/Button/config'
 import { contentHashField } from '@/fields/contentHashField'
 import { slugField } from '@/fields/slug'
 import { tenantField } from '@/fields/tenantField'
@@ -118,6 +119,7 @@ export const Posts: CollectionConfig<'posts'> = {
             ...rootFeatures,
             BlocksFeature({
               blocks: [
+                ButtonBlock,
                 Banner,
                 BlogListBlockLexical,
                 DocumentBlock,

--- a/src/components/RichText/index.tsx
+++ b/src/components/RichText/index.tsx
@@ -111,19 +111,18 @@ const jsxConverters: JSXConvertersFunction<NodeTypes> = ({ defaultConverters }) 
 type Props = {
   data: SerializedEditorState
   enableGutter?: boolean
-  enableProse?: boolean
 } & React.HTMLAttributes<HTMLDivElement>
 
 export default function RichText(props: Props) {
-  const { className, enableProse = true, enableGutter = true, ...rest } = props
+  const { className, enableGutter = true, ...rest } = props
   return (
     <RichTextLexical
       converters={jsxConverters}
       className={cn(
+        'mx-auto prose md:prose-md dark:prose-invert',
         {
           'container ': enableGutter,
           'max-w-none': !enableGutter,
-          'mx-auto prose md:prose-md dark:prose-invert': enableProse,
         },
         className,
       )}

--- a/src/fields/slug/index.ts
+++ b/src/fields/slug/index.ts
@@ -1,4 +1,5 @@
 import { ensureUniqueSlug } from '@/fields/slug/ensureUniqueSlug'
+import { validateSlug } from '@/utilities/validateSlug'
 
 export const slugField = (fieldToUse: string = 'title') => ({
   name: 'slug',
@@ -9,6 +10,7 @@ export const slugField = (fieldToUse: string = 'title') => ({
   hooks: {
     beforeValidate: [ensureUniqueSlug],
   },
+  validate: validateSlug,
   admin: {
     position: 'sidebar',
     components: {

--- a/src/utilities/validateSlug.ts
+++ b/src/utilities/validateSlug.ts
@@ -7,7 +7,8 @@ export const validateSlug: TextFieldSingleValidation = (value) => {
   if (value?.includes('/')) {
     return 'Slug cannot contain /'
   }
-  const slugPattern = /^[a-z0-9]+(?:-+[a-z0-9]+)*$/
+  // checks for kebab-case strings: allows letters, numbers and -
+  const slugPattern = /^[a-zA-Z0-9]+(?:-+[a-zA-Z0-9]+)*$/
 
-  return slugPattern.test(value) || 'Invalid slug'
+  return slugPattern.test(value) || 'Invalid slug: must be letters, numbers, or -'
 }

--- a/src/utilities/validateSlug.ts
+++ b/src/utilities/validateSlug.ts
@@ -1,0 +1,13 @@
+import { TextFieldSingleValidation } from 'payload'
+
+export const validateSlug: TextFieldSingleValidation = (value) => {
+  if (value === null || value === undefined) {
+    return 'Slug must not be blank'
+  }
+  if (value?.includes('/')) {
+    return 'Slug cannot contain /'
+  }
+  const slugPattern = /^[a-z0-9]+(?:-+[a-z0-9]+)*$/
+
+  return slugPattern.test(value) || 'Invalid slug'
+}


### PR DESCRIPTION
## Description
- Enable prose on `ImageTextLists` block
- Add `ButtonBlock` to posts editor 
- Disallow slashes and empty strings in slugs for posts and pages

## Related Issues
Fixes #605
Fixes #592
Fixes  #586
