### PR TITLE
Mobile tweaks

### DIFF
--- a/src/app/(frontend)/[center]/layout.tsx
+++ b/src/app/(frontend)/[center]/layout.tsx
@@ -73,7 +73,7 @@ export default async function RootLayout({ children, params }: Args) {
         <NextTopLoader color="#3982e8" showSpinner={false} />
         <PostHogTenantRegister />
         <AvalancheCenterProvider platforms={platforms} metadata={metadata}>
-          <div className={cn('flex flex-col min-h-screen', center)}>
+          <div className={cn('flex flex-col min-h-screen max-w-screen overflow-x-hidden', center)}>
             <ThemeSetter theme={center} />
             <Header center={center} />
             <main className="flex-grow">

--- a/src/app/(frontend)/[center]/observations/page.tsx
+++ b/src/app/(frontend)/[center]/observations/page.tsx
@@ -51,7 +51,7 @@ export default async function Page({ params }: Args) {
       <WidgetHashHandler initialHash="/view/observations" />
       <div className="flex flex-col gap-4">
         <div className="container">
-          <div className="flex justify-between items-center gap-4 prose dark:prose-invert max-w-none">
+          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-1 sm:gap-4 prose dark:prose-invert max-w-none">
             <h1 className="font-bold">Observations</h1>
             <Button asChild variant="secondary" className="no-underline">
               <Link href="/observations/submit">Submit Observation</Link>

--- a/src/blocks/Content/Component.tsx
+++ b/src/blocks/Content/Component.tsx
@@ -26,7 +26,7 @@ export const ContentBlock = (props: ContentBlockProps) => {
   return (
     <div className={`${bgColorClass}`}>
       <div className="container py-10">
-        <div className="grid grid-cols-2 lg:grid-cols-12 gap-y-8 gap-x-16">
+        <div className="grid grid-cols-2 lg:grid-cols-12 gap-y-6 gap-x-16">
           {columns?.map((col, index) => {
             const { richText } = col
             return (

--- a/src/blocks/ImageQuote/Component.tsx
+++ b/src/blocks/ImageQuote/Component.tsx
@@ -17,9 +17,9 @@ export const ImageQuote = (props: Props) => {
   return (
     <div className={`${bgColorClass}`}>
       <div className="container py-10">
-        <div className="grid md:grid-cols-12 gap-x-6 gap-y-6">
+        <div className="grid md:grid-cols-12 gap-6">
           <div
-            className={`items-center md:col-span-4 self-start ${imageLayout === 'right' ? 'order-last ms-6' : 'me-6 '}`}
+            className={`items-center md:col-span-4 self-start ${imageLayout === 'right' ? 'order-last md:ms-6' : 'md:me-6'}`}
           >
             {image && <ImageMedia imgClassName={cn(imgClassName)} resource={image} />}
           </div>

--- a/src/components/Breadcrumbs/Breadcrumbs.client.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.client.tsx
@@ -82,9 +82,9 @@ export function Breadcrumbs() {
   }
 
   return (
-    <Breadcrumb className="container py-4 md:py-6">
-      <BreadcrumbList>
-        <BreadcrumbItem>
+    <Breadcrumb className="container py-4 md:py-6 flex-nowrap whitespace-nowrap overflow-hidden">
+      <BreadcrumbList className="flex-nowrap">
+        <BreadcrumbItem className="shrink-0">
           <BreadcrumbLink
             asChild
             onClick={() => onClick({ name: 'Home', href: '/', isLast: false }, '0')}
@@ -95,10 +95,14 @@ export function Breadcrumbs() {
         {breadcrumbItems.length > 0 && <BreadcrumbSeparator />}
         {breadcrumbItems.map((item, index) => (
           <React.Fragment key={`${item.name}__${item.href}__${index}`}>
-            <BreadcrumbItem>
+            <BreadcrumbItem className={item.isLast ? 'min-w-0' : 'shrink-0'}>
               {item.isLast || !item.href ? (
                 <BreadcrumbPage
-                  className={cn('capitalize', !item.isLast && 'text-muted-foreground')}
+                  className={cn(
+                    'capitalize',
+                    !item.isLast && 'text-muted-foreground',
+                    item.isLast && 'truncate block',
+                  )}
                   onClick={() => onClick(item, index.toString())}
                 >
                   {item.name}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -62,7 +62,7 @@ export async function Footer({ center }: { center?: string }) {
   return (
     <footer className="mt-auto bg-footer text-footer-foreground">
       <div className="container py-8 gap-8 grid md:grid-cols-3">
-        <div>
+        <div className="flex flex-col items-center md:items-start">
           {footerForm?.title && <h4 className="font-medium text-xl mb-2">{footerForm.title}</h4>}
           {footerForm?.subtitle && <p className="mb-2">{footerForm.subtitle}</p>}
           {footerForm?.type === 'form' && (
@@ -88,65 +88,63 @@ export async function Footer({ center }: { center?: string }) {
             </Link>
           )}
         </div>
-        <div>
-          <div className="flex flex-col items-start">
-            <h4 className="font-medium text-xl mb-2">{tenant.name}</h4>
-            {address && <div className="whitespace-pre-line">{address}</div>}
-            {phone && (
-              <div className="flex">
-                {phoneLabel && <p className="capitalize">{phoneLabel}:&nbsp;</p>}
-                <a className="text-secondary" href={`tel:${phone}`}>
-                  {phone}
-                </a>
-              </div>
-            )}
-            {phoneSecondary && (
-              <div className="flex">
-                {phoneSecondaryLabel && <p className="capitalize">{phoneSecondaryLabel}:&nbsp;</p>}
-                <a className="text-secondary" href={`tel:${phoneSecondary}`}>
-                  {phoneSecondary}
-                </a>
-              </div>
-            )}
-            {email && (
-              <a className="mb-4 text-secondary underline" href={`mailto:${email}`}>
-                {email}
+        <div className="flex flex-col items-center md:items-start">
+          <h4 className="font-medium text-xl mb-2">{tenant.name}</h4>
+          {address && <div className="whitespace-pre-line text-center md:text-left">{address}</div>}
+          {phone && (
+            <div className="flex">
+              {phoneLabel && <p className="capitalize">{phoneLabel}:&nbsp;</p>}
+              <a className="text-secondary" href={`tel:${phone}`}>
+                {phone}
               </a>
-            )}
-            {socialMedia && (
-              // Icon colors controlled by color class
-              <div className="flex items-center gap-x-2 mb-2 text-secondary">
-                {socialMedia.instagram && (
-                  <a href={socialMedia.instagram} target="_blank" className="p-1">
-                    <Icons.instagram />
-                  </a>
-                )}
-                {socialMedia.facebook && (
-                  <a href={socialMedia.facebook} target="_blank" className="p-1">
-                    <Icons.facebook />
-                  </a>
-                )}
-                {socialMedia.twitter && (
-                  <a href={socialMedia.twitter} target="_blank" className="p-1">
-                    <Icons.twitter />
-                  </a>
-                )}
-                {socialMedia.linkedin && (
-                  <a href={socialMedia.linkedin} target="_blank" className="p-1">
-                    <Icons.linkedin />
-                  </a>
-                )}
-                {socialMedia.youtube && (
-                  <a href={socialMedia.youtube} target="_blank" className="p-1">
-                    <Icons.youtube />
-                  </a>
-                )}
-              </div>
-            )}
-            {socialMedia?.hashtag && (
-              <p className="mb-4 text-secondary underline">{socialMedia?.hashtag}</p>
-            )}
-          </div>
+            </div>
+          )}
+          {phoneSecondary && (
+            <div className="flex">
+              {phoneSecondaryLabel && <p className="capitalize">{phoneSecondaryLabel}:&nbsp;</p>}
+              <a className="text-secondary" href={`tel:${phoneSecondary}`}>
+                {phoneSecondary}
+              </a>
+            </div>
+          )}
+          {email && (
+            <a className="mb-4 text-secondary underline" href={`mailto:${email}`}>
+              {email}
+            </a>
+          )}
+          {socialMedia && (
+            // Icon colors controlled by color class
+            <div className="flex items-center gap-x-2 mb-2 text-secondary">
+              {socialMedia.instagram && (
+                <a href={socialMedia.instagram} target="_blank" className="p-1">
+                  <Icons.instagram />
+                </a>
+              )}
+              {socialMedia.facebook && (
+                <a href={socialMedia.facebook} target="_blank" className="p-1">
+                  <Icons.facebook />
+                </a>
+              )}
+              {socialMedia.twitter && (
+                <a href={socialMedia.twitter} target="_blank" className="p-1">
+                  <Icons.twitter />
+                </a>
+              )}
+              {socialMedia.linkedin && (
+                <a href={socialMedia.linkedin} target="_blank" className="p-1">
+                  <Icons.linkedin />
+                </a>
+              )}
+              {socialMedia.youtube && (
+                <a href={socialMedia.youtube} target="_blank" className="p-1">
+                  <Icons.youtube />
+                </a>
+              )}
+            </div>
+          )}
+          {socialMedia?.hashtag && (
+            <p className="mb-4 text-secondary underline">{socialMedia?.hashtag}</p>
+          )}
         </div>
       </div>
       <div className="container text-center pb-8">


### PR DESCRIPTION
## Description

I was testing out sierraavalanchecenter.org on mobile and noticed a few things I wanted to fix. 

There is extra vertical space between content columns in many places (on the home page for example). I thought this would be due to incorrect `gap-{n}` class names but it's actually just an extra `<p>` after the embedded block. This might be intentional or it might just be a common accident because Payload adds an extra paragraph after embedding a block feature. We may want to communicate this to users. 

## Key Changes

Each change has it's own commit for reference. 

#### 1 - Removed starting/ending margin on ImageQuote block components on mobile

Before: 
<img width="361" height="740" alt="CleanShot 2025-10-19 at 18 33 50" src="https://github.com/user-attachments/assets/9835548f-352e-4e2c-9835-28c585ae6d51" />
After:
<img width="361" height="742" alt="CleanShot 2025-10-19 at 18 34 10" src="https://github.com/user-attachments/assets/053229ce-3c74-4c05-8f53-c7cbb2f198ae" />

#### 2 - Matched vertical gap in content columns to other block components
Really minor but figured we might as well be consistent. Most block components use gap-6.

#### 3 - Centered content in footer on mobile

Before:
<img width="361" height="1067" alt="CleanShot 2025-10-19 at 19 15 16" src="https://github.com/user-attachments/assets/4d0a9728-6a7c-43e7-9c44-eb52ebb6e8e4" />
After: 
<img width="361" height="983" alt="CleanShot 2025-10-19 at 19 16 05" src="https://github.com/user-attachments/assets/3a928321-06db-4cbf-a7b2-d8697ac38500" />

Note that the embed still appears not centered because of the styles in the iframe itself. That iframe would need to be modified in order for it to be centered. 

#### 4 - Ensuring breadcrumbs never wrap on mobile 

Before:
<img width="362" height="709" alt="CleanShot 2025-10-19 at 19 22 36" src="https://github.com/user-attachments/assets/fcb0d169-4f49-4ba6-aa2e-ea83c0544f57" />
After: 
<img width="362" height="707" alt="CleanShot 2025-10-19 at 19 22 54" src="https://github.com/user-attachments/assets/5102afda-a24b-4df5-b214-4856435fa4c4" />

#### 5 - Ensuring pages can't expand our content beyond 100vw -- this was happening on /observations due to the submit button but could happen in many other scenarios. I thought we'd already added this. 

#### 6 - Stack submit button vertically on observations page on mobile

Before:
<img width="362" height="707" alt="CleanShot 2025-10-19 at 19 41 48" src="https://github.com/user-attachments/assets/ccc55c09-d5d5-45a3-a32a-403ce47db802" />
After: 
<img width="364" height="706" alt="CleanShot 2025-10-19 at 19 41 26" src="https://github.com/user-attachments/assets/b59dd7a9-a60c-40c5-95f9-70f17ff40817" />
