### PR TITLE
Bugfix: global collection redirect loop

### DIFF
--- a/src/fields/tenantField/TenantFieldComponent.tsx
+++ b/src/fields/tenantField/TenantFieldComponent.tsx
@@ -27,10 +27,11 @@ export const TenantFieldComponent = (args: Props) => {
     setTenant,
   } = useTenantSelection()
 
+  const isGlobalCollection = !!unique
   const hasSetValueRef = React.useRef(false)
 
   React.useEffect(() => {
-    if (!hasSetValueRef.current) {
+    if (!hasSetValueRef.current && !isGlobalCollection) {
       // set value on load
       if (value && value !== selectedTenantID) {
         setTenant({ id: value, refresh: unique })
@@ -44,7 +45,7 @@ export const TenantFieldComponent = (args: Props) => {
       // Update the field on the document value when the tenant is changed
       setValue(selectedTenantID, !value || value === selectedTenantID)
     }
-  }, [value, selectedTenantID, setTenant, setValue, options, unique])
+  }, [value, selectedTenantID, setTenant, setValue, options, unique, isGlobalCollection])
 
   React.useEffect(() => {
     setEntityType(unique ? 'global' : 'document')


### PR DESCRIPTION
## Description

When visiting a global collection where some documents are published and some are drafts there would be an endless redirect loop due to the interaction between the `TenantFieldComponent` and the `GlobalViewRedirect` component. The `TenantFieldComponent` would receive the old state of the field after the redirect, triggering a `setTenant` call to align the current tenant with the document's tenant field. This would trigger another redirect by the `GlobalViewRedirect`. This would continue indefinitely. 

The solution is to respect the readOnly nature of the tenant field in global collections in the `TenantFieldComponent`. This is determined by inspecting the `unique` attribute on the tenant field (if true = global collection) and not updating the set tenant based on the tenant field value. A global collection document's tenant field should be readOnly. 

## Related Issues

#622 

## Key Changes

Respect the readOnly nature of the tenant field in a global collection document
