### PR TITLE
Script to log PRs that haven't been released yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "migrate:check": "cross-env NODE_OPTIONS=--no-deprecation payload run ./src/scripts/check-migrations.ts",
     "email:build": "email build",
     "email:dev": "email dev --dir ./src/emails --port 3001",
-    "email:export": "email export"
+    "email:export": "email export",
+    "unreleased": "./unreleased-prs.sh"
   },
   "lint-staged": {
     "**/*": "pnpm run prettify"

--- a/unreleased-prs.sh
+++ b/unreleased-prs.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Script to show PRs in main that haven't been released yet
+# Displays with dates and clickable GitHub links
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}Fetching latest release branch...${NC}"
+git fetch origin release:release 2>/dev/null || true
+
+echo -e "\n${GREEN}PRs in main that haven't been released yet:${NC}\n"
+
+# Get the GitHub repo URL from git remote
+REPO_URL=$(git config --get remote.origin.url | sed 's/\.git$//' | sed 's/git@github.com:/https:\/\/github.com\//')
+
+# Get commits in main but not in release, with dates
+git log release..main --first-parent --pretty=format:"%h|%ad|%s" --date=short | while IFS='|' read -r hash date message; do
+  # Extract PR number from commit message using regex
+  if [[ $message =~ Merge\ pull\ request\ \#([0-9]+) ]]; then
+    PR_NUMBER="${BASH_REMATCH[1]}"
+    PR_LINK="${REPO_URL}/pull/${PR_NUMBER}"
+    # Extract branch name from message
+    BRANCH_NAME=$(echo "$message" | sed 's/.*from [^/]*\///')
+    echo -e "${BLUE}#${PR_NUMBER}${NC} - ${date} - ${BRANCH_NAME}"
+    echo -e "  ${PR_LINK}"
+    echo ""
+  else
+    # Non-PR commit
+    echo -e "${date} - ${message}"
+    echo ""
+  fi
+done
+
+UNRELEASED_COUNT=$(git log release..main --first-parent --oneline | wc -l | tr -d ' ')
+echo -e "${YELLOW}Total unreleased PRs: ${UNRELEASED_COUNT}${NC}"


### PR DESCRIPTION
## Description

Just a little script to log PRs that haven't been released yet for easy viewing. 

Output looks like:

```
Fetching latest release branch...

PRs in main that haven't been released yet:

#638 - 2025-10-29 - bugfix/richtext-fields-uncaught-error
  https://github.com/NWACus/web/pull/638

#626 - 2025-10-27 - bugfix/content-block-uncaught-error
  https://github.com/NWACus/web/pull/626

#629 - 2025-10-23 - upgrade-payload
  https://github.com/NWACus/web/pull/629

#628 - 2025-10-23 - fix-handleReferenceURL-posts
  https://github.com/NWACus/web/pull/628

#594 - 2025-10-23 - deleted-relationships-safety
  https://github.com/NWACus/web/pull/594

#624 - 2025-10-23 - global-collection-redirect-loop
  https://github.com/NWACus/web/pull/624

#621 - 2025-10-23 - mobile-tweaks
  https://github.com/NWACus/web/pull/621

#573 - 2025-10-23 - isr-setting
  https://github.com/NWACus/web/pull/573

#619 - 2025-10-16 - hide-post-author-date
  https://github.com/NWACus/web/pull/619

#613 - 2025-10-15 - small-updates
  https://github.com/NWACus/web/pull/613

Total unreleased PRs: 11
```
