### PR TITLE
Multi-tenant user enhancements

### DIFF
--- a/src/access/byTenantRole.ts
+++ b/src/access/byTenantRole.ts
@@ -46,6 +46,12 @@ export const byTenantRole: (method: ruleMethod, collection: ruleCollection) => A
 
       if (tenantFromCookie) {
         return matchingTenantIds.includes(tenantFromCookie)
+      } else {
+        return {
+          tenant: {
+            in: matchingTenantIds,
+          },
+        }
       }
     }
 

--- a/src/access/byTenantRole.ts
+++ b/src/access/byTenantRole.ts
@@ -9,7 +9,7 @@ import { Access, CollectionConfig } from 'payload'
 // tenant-scoped collections
 export const byTenantRole: (method: ruleMethod, collection: ruleCollection) => Access =
   (method: ruleMethod, collection: ruleCollection): Access =>
-  async ({ req: { user, payload } }) => {
+  async ({ req: { user, payload, headers } }) => {
     if (!user) {
       return false
     }
@@ -42,11 +42,10 @@ export const byTenantRole: (method: ruleMethod, collection: ruleCollection) => A
       .map((tenant) => tenant.id)
 
     if (matchingTenantIds.length > 0) {
-      // otherwise, return a where clause capturing the tenants they can take this action in
-      return {
-        tenant: {
-          in: matchingTenantIds,
-        },
+      const tenantFromCookie = getTenantFromCookie(headers, 'number')
+
+      if (tenantFromCookie) {
+        return matchingTenantIds.includes(tenantFromCookie)
       }
     }
 

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,153 +1,107 @@
-import { QueriedPostsComponent as QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e } from '@/blocks/BlogList/fields/QueriedPostsComponent'
-import { DefaultColumnAdder as DefaultColumnAdder_006f8c6c8800e6fe3753b3785f2c4a01 } from '@/blocks/Content/components/DefaultColumnAdder'
+import { TenantFieldComponent as TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6 } from '@/fields/tenantField/TenantFieldComponent'
+import { default as default_55a7d1ebef7afeed563b856ae2e2cbf4 } from '@/components/ColorPicker'
+import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { default as default_ef94af202ba9f4dd0fd10062e0964050 } from '@/components/AlignContentPicker'
+import { AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { SponsorsLayoutDescription as SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de } from '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription'
-import { DuplicatePageFor as DuplicatePageFor_8f1d8961a356bec6784e5c591c016925 } from '@/collections/Pages/components/DuplicatePageFor'
+import { HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { QueriedPostsComponent as QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e } from '@/blocks/BlogList/fields/QueriedPostsComponent'
+import { default as default_923dc5ccc0b72de4298251644cbfe39e } from '@/components/ColumnLayoutPicker'
+import { DefaultColumnAdder as DefaultColumnAdder_006f8c6c8800e6fe3753b3785f2c4a01 } from '@/blocks/Content/components/DefaultColumnAdder'
+import { OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
 import { ViewPageButton as ViewPageButton_5587abba969d5f30cb1f479b0a70bb80 } from '@/collections/Pages/components/ViewPageButton'
+import { DuplicatePageFor as DuplicatePageFor_8f1d8961a356bec6784e5c591c016925 } from '@/collections/Pages/components/DuplicatePageFor'
 import { ViewPostButton as ViewPostButton_c85c9ca228f12030489338b3f3f7139d } from '@/collections/Posts/components/ViewPostButton'
-import { CollectionsField as CollectionsField_49c0311020325b59204cc21d2f536b8d } from '@/collections/Roles/components/CollectionsField'
-import { RulesCell as RulesCell_649699f5b285e7a5429592dc58fd6f0c } from '@/collections/Roles/components/RulesCell'
-import { AvalancheCenterName as AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad } from '@/collections/Settings/components/AvalancheCenterName'
-import { USFSLogoDescription as USFSLogoDescription_d2eea91290575f9a545768dce25713f4 } from '@/collections/Settings/components/USFSLogoDescription'
+import { UserStatusCell as UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee } from '@/collections/Users/components/UserStatusCell'
 import { InviteUser as InviteUser_6042b6804e11048cd4fbe6206cbc2b0f } from '@/collections/Users/components/InviteUser'
 import { ResendInviteButton as ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735 } from '@/collections/Users/components/ResendInviteButton'
-import { UserStatusCell as UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee } from '@/collections/Users/components/UserStatusCell'
-import { default as default_ef94af202ba9f4dd0fd10062e0964050 } from '@/components/AlignContentPicker'
-import { default as default_1a7510af427896d367a49dbf838d2de6 } from '@/components/BeforeDashboard'
-import { default as default_55a7d1ebef7afeed563b856ae2e2cbf4 } from '@/components/ColorPicker'
-import { default as default_923dc5ccc0b72de4298251644cbfe39e } from '@/components/ColumnLayoutPicker'
-import { GlobalViewRedirect as GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e } from '@/components/GlobalViewRedirect'
+import { CollectionsField as CollectionsField_49c0311020325b59204cc21d2f536b8d } from '@/collections/Roles/components/CollectionsField'
+import { RulesCell as RulesCell_649699f5b285e7a5429592dc58fd6f0c } from '@/collections/Roles/components/RulesCell'
+import { LinkLabelDescription as LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721 } from '@/fields/navLink/components/LinkLabelDescription'
+import { AvalancheCenterName as AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad } from '@/collections/Settings/components/AvalancheCenterName'
+import { USFSLogoDescription as USFSLogoDescription_d2eea91290575f9a545768dce25713f4 } from '@/collections/Settings/components/USFSLogoDescription'
+import { DiagnosticsDisplay as DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6 } from '@/globals/Diagnostics/components/DiagnosticsDisplay'
+import { LogoutButton as LogoutButton_db9ac62598c46d0f1db201f6af05442e } from '@/components/LogoutButton'
 import { AvyFxIcon as AvyFxIcon_5698f736c9797d81d0dacf1b1321e327 } from '@/components/Icon/AvyFxIcon'
 import { AvyFxLogo as AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4 } from '@/components/Logo/AvyFxLogo'
-import { LogoutButton as LogoutButton_db9ac62598c46d0f1db201f6af05442e } from '@/components/LogoutButton'
-import { default as default_2aead22399b7847b21b134dc4a7931e0 } from '@/components/TenantSelector/TenantSelector'
+import { GlobalViewRedirect as GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e } from '@/components/GlobalViewRedirect'
 import { default as default_cb0ad5752e1389a2a940bb73c2c0e7d2 } from '@/components/ViewTypeAction'
-import { LinkLabelDescription as LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721 } from '@/fields/navLink/components/LinkLabelDescription'
-import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
-import { TenantFieldComponent as TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6 } from '@/fields/tenantField/TenantFieldComponent'
-import { DiagnosticsDisplay as DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6 } from '@/globals/Diagnostics/components/DiagnosticsDisplay'
+import { default as default_1a7510af427896d367a49dbf838d2de6 } from '@/components/BeforeDashboard'
+import { default as default_2aead22399b7847b21b134dc4a7931e0 } from '@/components/TenantSelector/TenantSelector'
 import { TenantSelectionProvider as TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d } from '@/providers/TenantSelectionProvider'
 import { ViewTypeProvider as ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0 } from '@/providers/ViewTypeProvider'
-import { AcceptInvite as AcceptInvite_a090ee9cb5b31ae357daa74987d3109a } from '@/views/AcceptInvite'
-import { AdminErrorBoundary as AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688 } from '@payloadcms/plugin-sentry/client'
-import {
-  MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-} from '@payloadcms/plugin-seo/client'
-import {
-  AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-} from '@payloadcms/richtext-lexical/client'
-import {
-  LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
-  RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
-  RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
-} from '@payloadcms/richtext-lexical/rsc'
 import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
+import { AdminErrorBoundary as AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688 } from '@payloadcms/plugin-sentry/client'
+import { AcceptInvite as AcceptInvite_a090ee9cb5b31ae357daa74987d3109a } from '@/views/AcceptInvite'
 
 export const importMap = {
-  '@/fields/tenantField/TenantFieldComponent#TenantFieldComponent':
-    TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6,
-  '@/components/ColorPicker#default': default_55a7d1ebef7afeed563b856ae2e2cbf4,
-  '@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell':
-    RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
-  '@payloadcms/richtext-lexical/rsc#RscEntryLexicalField':
-    RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
-  '@payloadcms/richtext-lexical/rsc#LexicalDiffComponent':
-    LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
-  '@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient':
-    InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient':
-    HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#BlocksFeatureClient':
-    BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@/components/AlignContentPicker#default': default_ef94af202ba9f4dd0fd10062e0964050,
-  '@payloadcms/richtext-lexical/client#AlignFeatureClient':
-    AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient':
-    FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#LinkFeatureClient':
-    LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#BoldFeatureClient':
-    BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#ItalicFeatureClient':
-    ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#UnderlineFeatureClient':
-    UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#ParagraphFeatureClient':
-    ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription#SponsorsLayoutDescription':
-    SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de,
-  '@payloadcms/richtext-lexical/client#HeadingFeatureClient':
-    HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#OrderedListFeatureClient':
-    OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@payloadcms/richtext-lexical/client#UnorderedListFeatureClient':
-    UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  '@/blocks/BlogList/fields/QueriedPostsComponent#QueriedPostsComponent':
-    QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e,
-  '@/components/ColumnLayoutPicker#default': default_923dc5ccc0b72de4298251644cbfe39e,
-  '@/blocks/Content/components/DefaultColumnAdder#DefaultColumnAdder':
-    DefaultColumnAdder_006f8c6c8800e6fe3753b3785f2c4a01,
-  '@payloadcms/plugin-seo/client#OverviewComponent':
-    OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@payloadcms/plugin-seo/client#MetaImageComponent':
-    MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@payloadcms/plugin-seo/client#MetaDescriptionComponent':
-    MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@payloadcms/plugin-seo/client#PreviewComponent':
-    PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  '@/fields/slug/SlugComponent#SlugComponent': SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
-  '@/collections/Pages/components/ViewPageButton#ViewPageButton':
-    ViewPageButton_5587abba969d5f30cb1f479b0a70bb80,
-  '@/collections/Pages/components/DuplicatePageFor#DuplicatePageFor':
-    DuplicatePageFor_8f1d8961a356bec6784e5c591c016925,
-  '@/collections/Posts/components/ViewPostButton#ViewPostButton':
-    ViewPostButton_c85c9ca228f12030489338b3f3f7139d,
-  '@/collections/Users/components/UserStatusCell#UserStatusCell':
-    UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee,
-  '@/collections/Users/components/InviteUser#InviteUser':
-    InviteUser_6042b6804e11048cd4fbe6206cbc2b0f,
-  '@/collections/Users/components/ResendInviteButton#ResendInviteButton':
-    ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735,
-  '@/collections/Roles/components/CollectionsField#CollectionsField':
-    CollectionsField_49c0311020325b59204cc21d2f536b8d,
-  '@/collections/Roles/components/RulesCell#RulesCell': RulesCell_649699f5b285e7a5429592dc58fd6f0c,
-  '@/fields/navLink/components/LinkLabelDescription#LinkLabelDescription':
-    LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721,
-  '@/collections/Settings/components/AvalancheCenterName#AvalancheCenterName':
-    AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad,
-  '@/collections/Settings/components/USFSLogoDescription#USFSLogoDescription':
-    USFSLogoDescription_d2eea91290575f9a545768dce25713f4,
-  '@/globals/Diagnostics/components/DiagnosticsDisplay#DiagnosticsDisplay':
-    DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6,
-  '@/components/LogoutButton#LogoutButton': LogoutButton_db9ac62598c46d0f1db201f6af05442e,
-  '@/components/Icon/AvyFxIcon#AvyFxIcon': AvyFxIcon_5698f736c9797d81d0dacf1b1321e327,
-  '@/components/Logo/AvyFxLogo#AvyFxLogo': AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4,
-  '@/components/GlobalViewRedirect#GlobalViewRedirect':
-    GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e,
-  '@/components/ViewTypeAction#default': default_cb0ad5752e1389a2a940bb73c2c0e7d2,
-  '@/components/BeforeDashboard#default': default_1a7510af427896d367a49dbf838d2de6,
-  '@/components/TenantSelector/TenantSelector#default': default_2aead22399b7847b21b134dc4a7931e0,
-  '@/providers/TenantSelectionProvider#TenantSelectionProvider':
-    TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d,
-  '@/providers/ViewTypeProvider#ViewTypeProvider':
-    ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0,
-  '@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler':
-    VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
-  '@payloadcms/plugin-sentry/client#AdminErrorBoundary':
-    AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688,
-  '@/views/AcceptInvite#AcceptInvite': AcceptInvite_a090ee9cb5b31ae357daa74987d3109a,
+  "@/fields/tenantField/TenantFieldComponent#TenantFieldComponent": TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6,
+  "@/components/ColorPicker#default": default_55a7d1ebef7afeed563b856ae2e2cbf4,
+  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@/components/AlignContentPicker#default": default_ef94af202ba9f4dd0fd10062e0964050,
+  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient": FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#ParagraphFeatureClient": ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@/blocks/SponsorsBlock/components/SponsorsLayoutDescription#SponsorsLayoutDescription": SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de,
+  "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#OrderedListFeatureClient": OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/richtext-lexical/client#UnorderedListFeatureClient": UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@/blocks/BlogList/fields/QueriedPostsComponent#QueriedPostsComponent": QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e,
+  "@/components/ColumnLayoutPicker#default": default_923dc5ccc0b72de4298251644cbfe39e,
+  "@/blocks/Content/components/DefaultColumnAdder#DefaultColumnAdder": DefaultColumnAdder_006f8c6c8800e6fe3753b3785f2c4a01,
+  "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
+  "@/collections/Pages/components/ViewPageButton#ViewPageButton": ViewPageButton_5587abba969d5f30cb1f479b0a70bb80,
+  "@/collections/Pages/components/DuplicatePageFor#DuplicatePageFor": DuplicatePageFor_8f1d8961a356bec6784e5c591c016925,
+  "@/collections/Posts/components/ViewPostButton#ViewPostButton": ViewPostButton_c85c9ca228f12030489338b3f3f7139d,
+  "@/collections/Users/components/UserStatusCell#UserStatusCell": UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee,
+  "@/collections/Users/components/InviteUser#InviteUser": InviteUser_6042b6804e11048cd4fbe6206cbc2b0f,
+  "@/collections/Users/components/ResendInviteButton#ResendInviteButton": ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735,
+  "@/collections/Roles/components/CollectionsField#CollectionsField": CollectionsField_49c0311020325b59204cc21d2f536b8d,
+  "@/collections/Roles/components/RulesCell#RulesCell": RulesCell_649699f5b285e7a5429592dc58fd6f0c,
+  "@/fields/navLink/components/LinkLabelDescription#LinkLabelDescription": LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721,
+  "@/collections/Settings/components/AvalancheCenterName#AvalancheCenterName": AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad,
+  "@/collections/Settings/components/USFSLogoDescription#USFSLogoDescription": USFSLogoDescription_d2eea91290575f9a545768dce25713f4,
+  "@/globals/Diagnostics/components/DiagnosticsDisplay#DiagnosticsDisplay": DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6,
+  "@/components/LogoutButton#LogoutButton": LogoutButton_db9ac62598c46d0f1db201f6af05442e,
+  "@/components/Icon/AvyFxIcon#AvyFxIcon": AvyFxIcon_5698f736c9797d81d0dacf1b1321e327,
+  "@/components/Logo/AvyFxLogo#AvyFxLogo": AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4,
+  "@/components/GlobalViewRedirect#GlobalViewRedirect": GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e,
+  "@/components/ViewTypeAction#default": default_cb0ad5752e1389a2a940bb73c2c0e7d2,
+  "@/components/BeforeDashboard#default": default_1a7510af427896d367a49dbf838d2de6,
+  "@/components/TenantSelector/TenantSelector#default": default_2aead22399b7847b21b134dc4a7931e0,
+  "@/providers/TenantSelectionProvider#TenantSelectionProvider": TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d,
+  "@/providers/ViewTypeProvider#ViewTypeProvider": ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0,
+  "@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler": VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
+  "@payloadcms/plugin-sentry/client#AdminErrorBoundary": AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688,
+  "@/views/AcceptInvite#AcceptInvite": AcceptInvite_a090ee9cb5b31ae357daa74987d3109a
 }

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,107 +1,153 @@
-import { TenantFieldComponent as TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6 } from '@/fields/tenantField/TenantFieldComponent'
-import { default as default_55a7d1ebef7afeed563b856ae2e2cbf4 } from '@/components/ColorPicker'
-import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { default as default_ef94af202ba9f4dd0fd10062e0964050 } from '@/components/AlignContentPicker'
-import { AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { SponsorsLayoutDescription as SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de } from '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription'
-import { HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { QueriedPostsComponent as QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e } from '@/blocks/BlogList/fields/QueriedPostsComponent'
-import { default as default_923dc5ccc0b72de4298251644cbfe39e } from '@/components/ColumnLayoutPicker'
 import { DefaultColumnAdder as DefaultColumnAdder_006f8c6c8800e6fe3753b3785f2c4a01 } from '@/blocks/Content/components/DefaultColumnAdder'
-import { OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
-import { ViewPageButton as ViewPageButton_5587abba969d5f30cb1f479b0a70bb80 } from '@/collections/Pages/components/ViewPageButton'
+import { SponsorsLayoutDescription as SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de } from '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription'
 import { DuplicatePageFor as DuplicatePageFor_8f1d8961a356bec6784e5c591c016925 } from '@/collections/Pages/components/DuplicatePageFor'
+import { ViewPageButton as ViewPageButton_5587abba969d5f30cb1f479b0a70bb80 } from '@/collections/Pages/components/ViewPageButton'
 import { ViewPostButton as ViewPostButton_c85c9ca228f12030489338b3f3f7139d } from '@/collections/Posts/components/ViewPostButton'
-import { UserStatusCell as UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee } from '@/collections/Users/components/UserStatusCell'
-import { InviteUser as InviteUser_6042b6804e11048cd4fbe6206cbc2b0f } from '@/collections/Users/components/InviteUser'
-import { ResendInviteButton as ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735 } from '@/collections/Users/components/ResendInviteButton'
 import { CollectionsField as CollectionsField_49c0311020325b59204cc21d2f536b8d } from '@/collections/Roles/components/CollectionsField'
 import { RulesCell as RulesCell_649699f5b285e7a5429592dc58fd6f0c } from '@/collections/Roles/components/RulesCell'
-import { LinkLabelDescription as LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721 } from '@/fields/navLink/components/LinkLabelDescription'
 import { AvalancheCenterName as AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad } from '@/collections/Settings/components/AvalancheCenterName'
 import { USFSLogoDescription as USFSLogoDescription_d2eea91290575f9a545768dce25713f4 } from '@/collections/Settings/components/USFSLogoDescription'
-import { DiagnosticsDisplay as DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6 } from '@/globals/Diagnostics/components/DiagnosticsDisplay'
-import { LogoutButton as LogoutButton_db9ac62598c46d0f1db201f6af05442e } from '@/components/LogoutButton'
+import { InviteUser as InviteUser_6042b6804e11048cd4fbe6206cbc2b0f } from '@/collections/Users/components/InviteUser'
+import { ResendInviteButton as ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735 } from '@/collections/Users/components/ResendInviteButton'
+import { UserStatusCell as UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee } from '@/collections/Users/components/UserStatusCell'
+import { default as default_ef94af202ba9f4dd0fd10062e0964050 } from '@/components/AlignContentPicker'
+import { default as default_1a7510af427896d367a49dbf838d2de6 } from '@/components/BeforeDashboard'
+import { default as default_55a7d1ebef7afeed563b856ae2e2cbf4 } from '@/components/ColorPicker'
+import { default as default_923dc5ccc0b72de4298251644cbfe39e } from '@/components/ColumnLayoutPicker'
+import { GlobalViewRedirect as GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e } from '@/components/GlobalViewRedirect'
 import { AvyFxIcon as AvyFxIcon_5698f736c9797d81d0dacf1b1321e327 } from '@/components/Icon/AvyFxIcon'
 import { AvyFxLogo as AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4 } from '@/components/Logo/AvyFxLogo'
-import { GlobalViewRedirect as GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e } from '@/components/GlobalViewRedirect'
-import { default as default_cb0ad5752e1389a2a940bb73c2c0e7d2 } from '@/components/ViewTypeAction'
-import { default as default_1a7510af427896d367a49dbf838d2de6 } from '@/components/BeforeDashboard'
+import { LogoutButton as LogoutButton_db9ac62598c46d0f1db201f6af05442e } from '@/components/LogoutButton'
 import { default as default_2aead22399b7847b21b134dc4a7931e0 } from '@/components/TenantSelector/TenantSelector'
+import { default as default_cb0ad5752e1389a2a940bb73c2c0e7d2 } from '@/components/ViewTypeAction'
+import { LinkLabelDescription as LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721 } from '@/fields/navLink/components/LinkLabelDescription'
+import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
+import { TenantFieldComponent as TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6 } from '@/fields/tenantField/TenantFieldComponent'
+import { DiagnosticsDisplay as DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6 } from '@/globals/Diagnostics/components/DiagnosticsDisplay'
 import { TenantSelectionProvider as TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d } from '@/providers/TenantSelectionProvider'
 import { ViewTypeProvider as ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0 } from '@/providers/ViewTypeProvider'
-import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
-import { AdminErrorBoundary as AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688 } from '@payloadcms/plugin-sentry/client'
 import { AcceptInvite as AcceptInvite_a090ee9cb5b31ae357daa74987d3109a } from '@/views/AcceptInvite'
+import { AdminErrorBoundary as AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688 } from '@payloadcms/plugin-sentry/client'
+import {
+  MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+} from '@payloadcms/plugin-seo/client'
+import {
+  AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+} from '@payloadcms/richtext-lexical/client'
+import {
+  LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
+  RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
+  RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+} from '@payloadcms/richtext-lexical/rsc'
+import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
 
 export const importMap = {
-  "@/fields/tenantField/TenantFieldComponent#TenantFieldComponent": TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6,
-  "@/components/ColorPicker#default": default_55a7d1ebef7afeed563b856ae2e2cbf4,
-  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@/components/AlignContentPicker#default": default_ef94af202ba9f4dd0fd10062e0964050,
-  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient": FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#ParagraphFeatureClient": ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@/blocks/SponsorsBlock/components/SponsorsLayoutDescription#SponsorsLayoutDescription": SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de,
-  "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#OrderedListFeatureClient": OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#UnorderedListFeatureClient": UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@/blocks/BlogList/fields/QueriedPostsComponent#QueriedPostsComponent": QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e,
-  "@/components/ColumnLayoutPicker#default": default_923dc5ccc0b72de4298251644cbfe39e,
-  "@/blocks/Content/components/DefaultColumnAdder#DefaultColumnAdder": DefaultColumnAdder_006f8c6c8800e6fe3753b3785f2c4a01,
-  "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
-  "@/collections/Pages/components/ViewPageButton#ViewPageButton": ViewPageButton_5587abba969d5f30cb1f479b0a70bb80,
-  "@/collections/Pages/components/DuplicatePageFor#DuplicatePageFor": DuplicatePageFor_8f1d8961a356bec6784e5c591c016925,
-  "@/collections/Posts/components/ViewPostButton#ViewPostButton": ViewPostButton_c85c9ca228f12030489338b3f3f7139d,
-  "@/collections/Users/components/UserStatusCell#UserStatusCell": UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee,
-  "@/collections/Users/components/InviteUser#InviteUser": InviteUser_6042b6804e11048cd4fbe6206cbc2b0f,
-  "@/collections/Users/components/ResendInviteButton#ResendInviteButton": ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735,
-  "@/collections/Roles/components/CollectionsField#CollectionsField": CollectionsField_49c0311020325b59204cc21d2f536b8d,
-  "@/collections/Roles/components/RulesCell#RulesCell": RulesCell_649699f5b285e7a5429592dc58fd6f0c,
-  "@/fields/navLink/components/LinkLabelDescription#LinkLabelDescription": LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721,
-  "@/collections/Settings/components/AvalancheCenterName#AvalancheCenterName": AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad,
-  "@/collections/Settings/components/USFSLogoDescription#USFSLogoDescription": USFSLogoDescription_d2eea91290575f9a545768dce25713f4,
-  "@/globals/Diagnostics/components/DiagnosticsDisplay#DiagnosticsDisplay": DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6,
-  "@/components/LogoutButton#LogoutButton": LogoutButton_db9ac62598c46d0f1db201f6af05442e,
-  "@/components/Icon/AvyFxIcon#AvyFxIcon": AvyFxIcon_5698f736c9797d81d0dacf1b1321e327,
-  "@/components/Logo/AvyFxLogo#AvyFxLogo": AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4,
-  "@/components/GlobalViewRedirect#GlobalViewRedirect": GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e,
-  "@/components/ViewTypeAction#default": default_cb0ad5752e1389a2a940bb73c2c0e7d2,
-  "@/components/BeforeDashboard#default": default_1a7510af427896d367a49dbf838d2de6,
-  "@/components/TenantSelector/TenantSelector#default": default_2aead22399b7847b21b134dc4a7931e0,
-  "@/providers/TenantSelectionProvider#TenantSelectionProvider": TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d,
-  "@/providers/ViewTypeProvider#ViewTypeProvider": ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0,
-  "@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler": VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
-  "@payloadcms/plugin-sentry/client#AdminErrorBoundary": AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688,
-  "@/views/AcceptInvite#AcceptInvite": AcceptInvite_a090ee9cb5b31ae357daa74987d3109a
+  '@/fields/tenantField/TenantFieldComponent#TenantFieldComponent':
+    TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6,
+  '@/components/ColorPicker#default': default_55a7d1ebef7afeed563b856ae2e2cbf4,
+  '@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell':
+    RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
+  '@payloadcms/richtext-lexical/rsc#RscEntryLexicalField':
+    RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+  '@payloadcms/richtext-lexical/rsc#LexicalDiffComponent':
+    LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
+  '@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient':
+    InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient':
+    HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#BlocksFeatureClient':
+    BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@/components/AlignContentPicker#default': default_ef94af202ba9f4dd0fd10062e0964050,
+  '@payloadcms/richtext-lexical/client#AlignFeatureClient':
+    AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient':
+    FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#LinkFeatureClient':
+    LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#BoldFeatureClient':
+    BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#ItalicFeatureClient':
+    ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#UnderlineFeatureClient':
+    UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#ParagraphFeatureClient':
+    ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription#SponsorsLayoutDescription':
+    SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de,
+  '@payloadcms/richtext-lexical/client#HeadingFeatureClient':
+    HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#OrderedListFeatureClient':
+    OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#UnorderedListFeatureClient':
+    UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@/blocks/BlogList/fields/QueriedPostsComponent#QueriedPostsComponent':
+    QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e,
+  '@/components/ColumnLayoutPicker#default': default_923dc5ccc0b72de4298251644cbfe39e,
+  '@/blocks/Content/components/DefaultColumnAdder#DefaultColumnAdder':
+    DefaultColumnAdder_006f8c6c8800e6fe3753b3785f2c4a01,
+  '@payloadcms/plugin-seo/client#OverviewComponent':
+    OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  '@payloadcms/plugin-seo/client#MetaImageComponent':
+    MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  '@payloadcms/plugin-seo/client#MetaDescriptionComponent':
+    MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  '@payloadcms/plugin-seo/client#PreviewComponent':
+    PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  '@/fields/slug/SlugComponent#SlugComponent': SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
+  '@/collections/Pages/components/ViewPageButton#ViewPageButton':
+    ViewPageButton_5587abba969d5f30cb1f479b0a70bb80,
+  '@/collections/Pages/components/DuplicatePageFor#DuplicatePageFor':
+    DuplicatePageFor_8f1d8961a356bec6784e5c591c016925,
+  '@/collections/Posts/components/ViewPostButton#ViewPostButton':
+    ViewPostButton_c85c9ca228f12030489338b3f3f7139d,
+  '@/collections/Users/components/UserStatusCell#UserStatusCell':
+    UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee,
+  '@/collections/Users/components/InviteUser#InviteUser':
+    InviteUser_6042b6804e11048cd4fbe6206cbc2b0f,
+  '@/collections/Users/components/ResendInviteButton#ResendInviteButton':
+    ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735,
+  '@/collections/Roles/components/CollectionsField#CollectionsField':
+    CollectionsField_49c0311020325b59204cc21d2f536b8d,
+  '@/collections/Roles/components/RulesCell#RulesCell': RulesCell_649699f5b285e7a5429592dc58fd6f0c,
+  '@/fields/navLink/components/LinkLabelDescription#LinkLabelDescription':
+    LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721,
+  '@/collections/Settings/components/AvalancheCenterName#AvalancheCenterName':
+    AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad,
+  '@/collections/Settings/components/USFSLogoDescription#USFSLogoDescription':
+    USFSLogoDescription_d2eea91290575f9a545768dce25713f4,
+  '@/globals/Diagnostics/components/DiagnosticsDisplay#DiagnosticsDisplay':
+    DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6,
+  '@/components/LogoutButton#LogoutButton': LogoutButton_db9ac62598c46d0f1db201f6af05442e,
+  '@/components/Icon/AvyFxIcon#AvyFxIcon': AvyFxIcon_5698f736c9797d81d0dacf1b1321e327,
+  '@/components/Logo/AvyFxLogo#AvyFxLogo': AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4,
+  '@/components/GlobalViewRedirect#GlobalViewRedirect':
+    GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e,
+  '@/components/ViewTypeAction#default': default_cb0ad5752e1389a2a940bb73c2c0e7d2,
+  '@/components/BeforeDashboard#default': default_1a7510af427896d367a49dbf838d2de6,
+  '@/components/TenantSelector/TenantSelector#default': default_2aead22399b7847b21b134dc4a7931e0,
+  '@/providers/TenantSelectionProvider#TenantSelectionProvider':
+    TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d,
+  '@/providers/ViewTypeProvider#ViewTypeProvider':
+    ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0,
+  '@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler':
+    VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
+  '@payloadcms/plugin-sentry/client#AdminErrorBoundary':
+    AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688,
+  '@/views/AcceptInvite#AcceptInvite': AcceptInvite_a090ee9cb5b31ae357daa74987d3109a,
 }

--- a/src/collections/Tenants/access/byGlobalRoleOrTenantIds.ts
+++ b/src/collections/Tenants/access/byGlobalRoleOrTenantIds.ts
@@ -66,23 +66,25 @@ export const byGlobalRoleOrTenantIdsWithOwnTenantsRead: (method: ruleMethod) => 
       .filter((tenant) => !!tenant && typeof tenant !== 'number') // captured in the getter
       .map((tenant) => tenant.id)
 
-    if (matchingTenantIds.length > 0) {
-      return {
-        id: {
-          in: matchingTenantIds,
-        },
-      }
+    let tenantIdsToMatch = matchingTenantIds
+
+    if (method === 'read') {
+      const tenantIdsUserHasRoleAssignmentsFor = roleAssignments
+        .map((assignment) => assignment.tenant)
+        .filter((tenant) => !!tenant && typeof tenant !== 'number')
+        .map((tenant) => tenant.id)
+
+      const uniqueTenantIdsToMatch = new Set([
+        ...matchingTenantIds,
+        ...tenantIdsUserHasRoleAssignmentsFor,
+      ])
+      tenantIdsToMatch = Array.from(uniqueTenantIdsToMatch)
     }
 
-    const tenantIdsUserHasRoleAssignmentsFor = roleAssignments
-      .map((assignment) => assignment.tenant)
-      .filter((tenant) => !!tenant && typeof tenant !== 'number')
-      .map((tenant) => tenant.id)
-
-    if (tenantIdsUserHasRoleAssignmentsFor.length > 0) {
+    if (tenantIdsToMatch.length > 0) {
       return {
         id: {
-          in: tenantIdsUserHasRoleAssignmentsFor,
+          in: tenantIdsToMatch,
         },
       }
     }

--- a/src/collections/Tenants/access/byGlobalRoleOrTenantIds.ts
+++ b/src/collections/Tenants/access/byGlobalRoleOrTenantIds.ts
@@ -41,9 +41,58 @@ export const byGlobalRoleOrTenantIds: (method: ruleMethod) => Access =
     return false
   }
 
+export const byGlobalRoleOrTenantIdsWithOwnTenantsRead: (method: ruleMethod) => Access =
+  (method: ruleMethod): Access =>
+  (args) => {
+    if (!args.req.user) {
+      return false
+    }
+
+    const globalAccess = byGlobalRole(method, 'tenants')(args)
+    if (typeof globalAccess === 'boolean' ? globalAccess : true) {
+      // if globalAccess returned anything but 'false', pass it along
+      return globalAccess
+    }
+
+    const roleAssignments = roleAssignmentsForUser(args.req.payload.logger, args.req.user)
+    const matchingTenantIds = roleAssignments
+      .filter(
+        (assignment) =>
+          assignment.role &&
+          typeof assignment.role !== 'number' && // captured in the getter
+          assignment.role.rules.some(ruleMatches(method, 'tenants')),
+      )
+      .map((assignment) => assignment.tenant)
+      .filter((tenant) => !!tenant && typeof tenant !== 'number') // captured in the getter
+      .map((tenant) => tenant.id)
+
+    if (matchingTenantIds.length > 0) {
+      return {
+        id: {
+          in: matchingTenantIds,
+        },
+      }
+    }
+
+    const tenantIdsUserHasRoleAssignmentsFor = roleAssignments
+      .map((assignment) => assignment.tenant)
+      .filter((tenant) => !!tenant && typeof tenant !== 'number')
+      .map((tenant) => tenant.id)
+
+    if (tenantIdsUserHasRoleAssignmentsFor.length > 0) {
+      return {
+        id: {
+          in: tenantIdsUserHasRoleAssignmentsFor,
+        },
+      }
+    }
+
+    return false
+  }
+
 export const accessByGlobalRoleOrTenantIds: CollectionConfig['access'] = {
   create: byGlobalRoleOrTenantIds('create'),
-  read: byGlobalRoleOrTenantIds('read'),
+  read: byGlobalRoleOrTenantIdsWithOwnTenantsRead('read'),
   update: byGlobalRoleOrTenantIds('update'),
   delete: byGlobalRoleOrTenantIds('delete'),
 }

--- a/src/collections/Tenants/index.ts
+++ b/src/collections/Tenants/index.ts
@@ -9,6 +9,7 @@ import {
   updateEdgeConfigAfterDelete,
 } from '@/collections/Tenants/hooks/updateEdgeConfig'
 import { contentHashField } from '@/fields/contentHashField'
+import { hasReadOnlyAccess } from '@/utilities/rbac/hasReadOnlyAccess'
 import type { CollectionConfig } from 'payload'
 
 export const Tenants: CollectionConfig = {
@@ -17,6 +18,7 @@ export const Tenants: CollectionConfig = {
   admin: {
     useAsTitle: 'name',
     group: 'Permissions',
+    hidden: ({ user }) => hasReadOnlyAccess(user, 'tenants'),
   },
   labels: {
     plural: 'Avalanche Centers',

--- a/src/providers/TenantSelectionProvider/index.client.tsx
+++ b/src/providers/TenantSelectionProvider/index.client.tsx
@@ -105,6 +105,15 @@ export const TenantSelectionProviderClient = ({
     document.cookie = 'payload-tenant=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'
   }, [])
 
+  const getTenantCookie = (): string | undefined => {
+    const value = `; ${document.cookie}`
+    const parts = value.split(`; payload-tenant=`)
+    if (parts.length === 2) {
+      return parts.pop()?.split(';').shift()
+    }
+    return undefined
+  }
+
   const setTenant = React.useCallback<ContextType['setTenant']>(
     ({ id, refresh }) => {
       if (id === undefined) {
@@ -186,7 +195,7 @@ export const TenantSelectionProviderClient = ({
   )
 
   React.useEffect(() => {
-    if (userChanged) {
+    if (userChanged || (initialValue && String(initialValue) !== getTenantCookie())) {
       if (userID) {
         // user logging in
         void syncTenants()
@@ -200,7 +209,7 @@ export const TenantSelectionProviderClient = ({
       }
       prevUserID.current = userID
     }
-  }, [userID, userChanged, syncTenants, deleteCookie, tenantOptions])
+  }, [userID, userChanged, syncTenants, deleteCookie, tenantOptions, initialValue])
 
   return (
     <span

--- a/src/utilities/tenancy/getTenantFromCookie.ts
+++ b/src/utilities/tenancy/getTenantFromCookie.ts
@@ -1,22 +1,25 @@
 import { parseCookies } from 'payload'
 import { isNumber } from 'payload/shared'
 
+type IDType = 'number' | 'text'
+
 /**
  * A function that takes request headers and an idType and returns the current tenant ID from the cookie
  *
  * @param headers Headers, usually derived from req.headers or next/headers
  * @param idType can be 'number' | 'text', usually derived from payload.db.defaultIDType
- * @returns string | number | null
+ * @returns number | null when idType is 'number', string | null when idType is 'text'
  */
-export function getTenantFromCookie(
+export function getTenantFromCookie<T extends IDType>(
   headers: Headers,
-  idType: 'number' | 'text',
-): null | number | string {
+  idType: T,
+): T extends 'number' ? number | null : string | null {
   const cookies = parseCookies(headers)
   const selectedTenant = cookies.get('payload-tenant') || null
-  return selectedTenant
+  const result = selectedTenant
     ? idType === 'number' && isNumber(selectedTenant)
       ? parseFloat(selectedTenant)
       : selectedTenant
     : null
+  return result as T extends 'number' ? number | null : string | null
 }


### PR DESCRIPTION
## Description

The key change here allows users to always `read` tenants that they have a tenant role assignment for. This was needed because if a user had `read` permission on `pages` for two tenants but no other permissions, the tenant selector would never be displayed (because the user couldn't `read` tenants). 

Now, a user can always `read` tenants that they have assignments for. 

## Related Issues

A temporary solution related to #625 until we have global pages is to allow centers to see existing centers' content as examples. 

## Key Changes

Uses a similar pattern to `roleAssignments` where [users can read their own assignments](https://github.com/NWACus/web/blob/main/src/collections/RoleAssignments/access/byTenantRoleWithSelfRead.ts#L7) but we [hide the `roleAssignments` collection from the nav if a user _only_ has `read`](https://github.com/NWACus/web/blob/main/src/collections/RoleAssignments/index.ts#L18). The `tenants` collection gets the same pattern now. 

