### PR TITLE
Fix post preview avatars & hide date and/or authors on blocks if unchecked

### DIFF
--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -36,13 +36,15 @@ export const Posts: CollectionConfig<'posts'> = {
   slug: 'posts',
   access: accessByTenantRoleOrReadPublished('posts'),
   defaultPopulate: {
+    _status: true,
+    authors: true,
     description: true,
     featuredImage: true,
+    publishedAt: true,
+    showAuthors: true,
+    showDate: true,
     slug: true,
     title: true,
-    _status: true,
-    publishedAt: true,
-    authors: true,
   },
   admin: {
     group: 'Content',

--- a/src/components/AuthorAvatar/index.tsx
+++ b/src/components/AuthorAvatar/index.tsx
@@ -1,8 +1,9 @@
 'use client'
-
 import { Media, Post } from '@/payload-types'
+import { useEffect, useState } from 'react'
 
 import { getAuthorInitials } from '@/utilities/getAuthorInitials'
+import { getDocumentById } from '@/utilities/getDocumentById'
 import { cn } from '@/utilities/ui'
 import { format, parseISO } from 'date-fns'
 import { MediaAvatar } from '../Media/AvatarImageMedia'
@@ -14,27 +15,51 @@ export const AuthorAvatar = (props: {
   showDate?: boolean | null
 }) => {
   const { authors, date, showAuthors, showDate } = props
-  const combinedAuthorsNames: string[] = [],
-    combinedAuthorsInitials: string[] = [],
-    combinedAuthorsPhotos: Media[] = []
-  authors?.forEach((author) => {
-    if (
-      author &&
-      typeof author !== 'number' &&
-      typeof author.name === 'string' &&
-      typeof author.photo !== 'number'
-    ) {
-      combinedAuthorsNames.push(author.name)
-      combinedAuthorsInitials.push(getAuthorInitials(author.name ?? ''))
-      combinedAuthorsPhotos.push(author.photo)
+  const [combinedAuthorsNames, setCombinedAuthorsNames] = useState<string[]>([])
+  const [combinedAuthorsInitials, setCombinedAuthorsInitials] = useState<string[]>([])
+  const [combinedAuthorsPhotos, setCombinedAuthorsPhotos] = useState<(number | Media)[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const loadAuthors = async () => {
+      const names: string[] = []
+      const initials: string[] = []
+      const photos: (number | Media)[] = []
+
+      if (authors) {
+        for (const author of authors) {
+          if (author && typeof author !== 'number') {
+            names.push(author.name)
+            initials.push(getAuthorInitials(author.name ?? ''))
+
+            const authorPhoto =
+              typeof author.photo === 'number'
+                ? ((await getDocumentById('media', author.photo)) as Media)
+                : author.photo
+
+            photos.push(authorPhoto)
+          }
+        }
+      }
+
+      setCombinedAuthorsNames(names)
+      setCombinedAuthorsInitials(initials)
+      setCombinedAuthorsPhotos(photos)
+      setIsLoading(false)
     }
-  })
+
+    loadAuthors()
+  }, [authors])
+
+  if (isLoading) {
+    return null // or return a loading skeleton
+  }
 
   return (
     <>
-      <div className="flex items-center mb-6 gap-3">
+      <div className={cn('flex items-center mb-4', { 'gap-3': showAuthors })}>
         {showAuthors && (
-          <div className={cn(`${combinedAuthorsPhotos.length > 1 && 'flex -space-x-2'}`)}>
+          <div className={cn('flex', { '-space-x-2': combinedAuthorsPhotos.length > 1 })}>
             {combinedAuthorsPhotos.map((authorPhoto, index) => (
               <MediaAvatar
                 resource={authorPhoto}

--- a/src/components/PostPreview/index.tsx
+++ b/src/components/PostPreview/index.tsx
@@ -10,7 +10,14 @@ import { Button } from '../ui/button'
 
 export type PostPreviewData = Pick<
   Post,
-  'authors' | 'description' | 'featuredImage' | 'publishedAt' | 'slug' | 'title'
+  | 'authors'
+  | 'description'
+  | 'featuredImage'
+  | 'publishedAt'
+  | 'showAuthors'
+  | 'showDate'
+  | 'slug'
+  | 'title'
 >
 
 export const PostPreview = (props: {
@@ -23,7 +30,8 @@ export const PostPreview = (props: {
 
   if (!doc) return null
 
-  const { authors, description, featuredImage, publishedAt, slug, title } = doc
+  const { authors, description, featuredImage, publishedAt, slug, title, showAuthors, showDate } =
+    doc
 
   const titleToUse = titleFromProps || title
   const sanitizedDescription = description?.replace(/\s/g, ' ') // replace non-breaking space with white space
@@ -54,8 +62,8 @@ export const PostPreview = (props: {
                   <AuthorAvatar
                     authors={authors ?? []}
                     date={publishedAt ?? ''}
-                    showAuthors={true}
-                    showDate={true}
+                    showAuthors={showAuthors ?? true}
+                    showDate={showDate ?? true}
                   />
                 )}
                 <h3 className="text-lg @lg:text-xl font-semibold mt-2 mb-2 leading-tight group-hover:underline">

--- a/src/utilities/getDocumentById.ts
+++ b/src/utilities/getDocumentById.ts
@@ -1,0 +1,19 @@
+'use server'
+import type { Config } from 'src/payload-types'
+
+import configPromise from '@payload-config'
+import { getPayload } from 'payload'
+
+type Collection = keyof Config['collections']
+
+export async function getDocumentById(collection: Collection, id: number, depth = 1) {
+  const payload = await getPayload({ config: configPromise })
+
+  const doc = await payload.findByID({
+    collection,
+    depth,
+    id,
+  })
+
+  return doc
+}


### PR DESCRIPTION
## Description
This will had the date and authors if unchecked on posts

## Related Issues
Fixes #650 

## Key Changes
- Pass `showAuthors` and `showDate` props to SinglePostPreview
- Update the way multi-person avatar images are handled for block. It was returning the id rather than the resource data.

## Screenshots / Demo
<img width="2196" height="2452" alt="Blog-Northwest-Avalanche-Center-11-04-2025_12_12_PM" src="https://github.com/user-attachments/assets/1d4540c8-379b-4607-9442-610043cc1f14" />
<img width="2080" height="2378" alt="Northwest-Avalanche-Center-11-04-2025_12_13_PM" src="https://github.com/user-attachments/assets/2dc88fed-ecb0-463f-b74b-784ef2f93e4f" />


## Migration Explanation
None

## Future enhancements / Questions
There are no other places in the codebase for us to pass these props so this should be the last place we need to update