### PR TITLE
Bugfix: Bio photos can be uncentered in Team blocks

### DIFF
--- a/src/blocks/Team/Team.tsx
+++ b/src/blocks/Team/Team.tsx
@@ -32,10 +32,10 @@ export const TeamBlock = ({ team }: Props) => {
           const name: string = member.name || 'Unknown'
           const initials = getAuthorInitials(name)
           return (
-            <div className="w-full flex  justify-center" key={`bio__${member.id}`}>
+            <div className="w-full flex justify-center" key={`bio__${member.id}`}>
               <div className="flex flex-col items-center space-y-4">
                 <Dialog>
-                  <DialogTrigger className="transition-transform duration-300 ease-in-out hover:scale-105 cursor-pointer">
+                  <DialogTrigger className="transition-transform duration-300 ease-in-out hover:scale-105 cursor-pointer flex flex-col items-center">
                     <MediaAvatar
                       resource={member.photo}
                       fallback={initials}


### PR DESCRIPTION
## Description

Fixes this issue where some Biography images are not centered in Team blocks:
![edited_37d7ff0e-6c5f-4bed-a878-c62142e0ba8d17540955173614401697](https://github.com/user-attachments/assets/e6e76cd2-2aa5-492e-9f0f-a0b9b572410e)
