### PR TITLE
Bugfix: Previews broken for pages, posts

### DIFF
--- a/src/collections/Navigations/index.tsx
+++ b/src/collections/Navigations/index.tsx
@@ -3,7 +3,10 @@ import { filterByTenant } from '@/access/filterByTenant'
 import { contentHashField } from '@/fields/contentHashField'
 import { navLink } from '@/fields/navLink'
 import { tenantField } from '@/fields/tenantField'
+import { Tenant } from '@/payload-types'
 import { generatePreviewPath } from '@/utilities/generatePreviewPath'
+import { isTenantValue } from '@/utilities/isTenantValue'
+import { resolveTenant } from '@/utilities/tenancy/resolveTenant'
 import { CollectionConfig } from 'payload'
 import { topLevelNavTab } from './fields/topLevelNavTab'
 import { revalidateNavigation, revalidateNavigationDelete } from './hooks/revalidateNavigation'
@@ -25,24 +28,18 @@ export const Navigations: CollectionConfig = {
     group: 'Settings',
     livePreview: {
       url: async ({ data, req }) => {
-        let tenant = data.tenant
+        let tenant: Partial<Tenant> | null = null
 
-        if (typeof tenant === 'number') {
-          tenant = await req.payload.findByID({
-            collection: 'tenants',
-            id: tenant,
-            depth: 2,
-          })
+        if (isTenantValue(data.tenant)) {
+          tenant = await resolveTenant(data.tenant)
         }
 
-        const path = generatePreviewPath({
+        return generatePreviewPath({
           slug: '',
           collection: 'pages',
           tenant,
           req,
         })
-
-        return path
       },
     },
   },

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -31,6 +31,8 @@ import { ButtonBlock } from '@/blocks/Button/config'
 import { contentHashField } from '@/fields/contentHashField'
 import { slugField } from '@/fields/slug'
 import { tenantField } from '@/fields/tenantField'
+import { isTenantValue } from '@/utilities/isTenantValue'
+import { resolveTenant } from '@/utilities/tenancy/resolveTenant'
 
 export const Posts: CollectionConfig<'posts'> = {
   slug: 'posts',
@@ -57,34 +59,27 @@ export const Posts: CollectionConfig<'posts'> = {
     },
     livePreview: {
       url: async ({ data, req }) => {
-        let tenant = data.tenant
+        let tenant: Partial<Tenant> | null = null
 
-        if (typeof tenant === 'number') {
-          tenant = await req.payload.findByID({
-            collection: 'tenants',
-            id: tenant,
-            depth: 2,
-          })
+        if (isTenantValue(data.tenant)) {
+          tenant = await resolveTenant(data.tenant)
         }
 
-        const path = generatePreviewPath({
+        return generatePreviewPath({
           slug: typeof data?.slug === 'string' ? data.slug : '',
           collection: 'posts',
           tenant,
           req,
         })
-
-        return path
       },
     },
-    preview: (data, { req }) => {
-      const tenant =
-        data?.tenant &&
-        typeof data.tenant === 'object' &&
-        'id' in data.tenant &&
-        'slug' in data.tenant
-          ? (data.tenant as Tenant)
-          : null
+    preview: async (data, { req }) => {
+      let tenant: Partial<Tenant> | null = null
+
+      if (isTenantValue(data.tenant)) {
+        tenant = await resolveTenant(data.tenant)
+      }
+
       return generatePreviewPath({
         slug: typeof data?.slug === 'string' ? data.slug : '',
         collection: 'posts',

--- a/src/collections/Tenants/index.ts
+++ b/src/collections/Tenants/index.ts
@@ -24,6 +24,7 @@ export const Tenants: CollectionConfig = {
     plural: 'Avalanche Centers',
     singular: 'Avalanche Center',
   },
+  // update src/utilities/isTenantValue.ts if this changes
   defaultPopulate: {
     slug: true,
     customDomain: true, // required for byGlobalRoleOrTenantRoleAssignment

--- a/src/utilities/isTenantValue.ts
+++ b/src/utilities/isTenantValue.ts
@@ -1,0 +1,13 @@
+import { Tenant } from '@/payload-types'
+
+// used to assert an unknown value is a number | Tenant
+export const isTenantValue = (value: unknown): value is number | Tenant => {
+  return (
+    typeof value === 'number' ||
+    (typeof value === 'object' &&
+      value !== null &&
+      'id' in value &&
+      'slug' in value && // included by Tenants collection's defaultPopulate
+      'customDomain' in value) // included by Tenants collection's defaultPopulate
+  )
+}


### PR DESCRIPTION
## Description

Previews stopped working. The root cause seems to be that the tenant was no longer being provided as a populated tenant object in the preview functions when it was before. 

## Related Issues

#657 

## Key Changes

- Updates Pages, Posts, HomePages, Navigations `preview` functions to resolve tenants correctly (i.e. fetching the full tenant if tenant is passed as a number)
- Updates livePreview and preview functions to use the same pattern everywhere
- Creates an `isTenantValue` function for type assertions in vaguely typed preview functions (and elsewhere if ever needed)
- Leaves a comment on the defaultPopulate of the tenants collection to remind devs to update `isTenantValue` if the default populate changes
