### PR TITLE
Events - fix filters

### DIFF
--- a/src/app/(frontend)/[center]/events/events-type-filter.tsx
+++ b/src/app/(frontend)/[center]/events/events-type-filter.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 type Props = {
   types: EventType[]
@@ -16,10 +16,13 @@ export const EventsTypeFilter = ({ types }: Props) => {
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
-  const [selectedTypes, setSelectedTypes] = useState<string[]>(() => {
+  const [selectedTypes, setSelectedTypes] = useState<string[]>([])
+
+  useEffect(() => {
     const typesParam = searchParams.get('types')
-    return typesParam ? typesParam.split(',').filter(Boolean) : []
-  })
+    const typesFromUrl = typesParam ? typesParam.split(',').filter(Boolean) : []
+    setSelectedTypes(typesFromUrl)
+  }, [searchParams])
 
   const updateParams = useCallback(
     (newTypes: string[]) => {
@@ -41,15 +44,12 @@ export const EventsTypeFilter = ({ types }: Props) => {
       const newTypes = selectedTypes.includes(typeId)
         ? selectedTypes.filter((t) => t !== typeId)
         : [...selectedTypes, typeId]
-      setSelectedTypes(newTypes)
       updateParams(newTypes)
     },
     [selectedTypes, updateParams],
   )
 
   const clearFilter = () => {
-    setSelectedTypes([])
-
     const params = new URLSearchParams(searchParams.toString())
     params.delete('types')
     router.push(`${pathname}?${params.toString()}`, { scroll: false })

--- a/src/app/(frontend)/[center]/events/page.tsx
+++ b/src/app/(frontend)/[center]/events/page.tsx
@@ -2,7 +2,7 @@ import configPromise from '@payload-config'
 import type { Metadata, ResolvedMetadata } from 'next/types'
 import { getPayload, Where } from 'payload'
 
-import { eventTypesData } from '@/collections/Events/constants'
+import { eventTypesData, QUICK_DATE_FILTERS } from '@/collections/Events/constants'
 import { EventCollection } from '@/components/EventCollection'
 import { PageRange } from '@/components/PageRange'
 import { Pagination } from '@/components/Pagination'
@@ -23,8 +23,17 @@ export default async function Page({ params, searchParams }: Args) {
   const { center } = await params
   const resolvedSearchParams = await searchParams
   const selectedTypes = resolvedSearchParams?.types?.split(',').filter(Boolean)
-  const selectedStartDate = resolvedSearchParams?.startDate || ''
-  const selectedEndDate = resolvedSearchParams?.endDate || ''
+  let selectedStartDate = resolvedSearchParams?.startDate || ''
+  let selectedEndDate = resolvedSearchParams?.endDate || ''
+
+  // Apply "upcoming" filter by default if no dates are provided
+  if (!selectedStartDate && !selectedEndDate) {
+    const upcomingFilter = QUICK_DATE_FILTERS.find((f) => f.id === 'upcoming')
+    if (upcomingFilter) {
+      selectedStartDate = upcomingFilter.startDate()
+      selectedEndDate = upcomingFilter.endDate() || ''
+    }
+  }
 
   const payload = await getPayload({ config: configPromise })
 


### PR DESCRIPTION
## Description
When interacting with events page filters and then selecting `Events` from the nav, the params would clear from teh URL but not the UI.

## Related Issues
No issue made. Discovered when working on (event table PR)

## Key Changes
- Clears UI filters on initial mount for date and type filter
- Date filter will select if dates match up with quick filters

## Screenshots / Demo
Before
![before_filters](https://github.com/user-attachments/assets/68c2a6e7-1e6c-45b3-b8be-741e98fd7384)

With fix
![after_eventsfilters](https://github.com/user-attachments/assets/55f77b0b-afc8-4d87-8bf2-1b8db5fc5ae7)

## Migration Explanation
Nope

## Future enhancements / Questions
Do we need to hide the filters on load until fully loaded to avoid seeing the filters set?
