### PR TITLE
Group Payload deps dependabot PRs together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,11 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 3
+    groups:
+      payloadcms:
+        patterns:
+          - 'payload'
+          - '@payloadcms/*'
     allow:
       - dependency-name: 'payload'
-      - dependency-name: '@payloadcms/admin-bar'
-      - dependency-name: '@payloadcms/db-sqlite'
-      - dependency-name: '@payloadcms/email-nodemailer'
-      - dependency-name: '@payloadcms/email-resend'
-      - dependency-name: '@payloadcms/next'
-      - dependency-name: '@payloadcms/plugin-form-builder'
-      - dependency-name: '@payloadcms/plugin-multi-tenant'
-      - dependency-name: '@payloadcms/plugin-redirects'
-      - dependency-name: '@payloadcms/plugin-sentry'
-      - dependency-name: '@payloadcms/plugin-seo'
-      - dependency-name: '@payloadcms/richtext-lexical'
-      - dependency-name: '@payloadcms/storage-vercel-blob'
-      - dependency-name: '@payloadcms/ui'
-      - dependency-name: '@payloadcms/live-preview-react'
+      - dependency-name: '@payloadcms/*'


### PR DESCRIPTION
## Description

Using this [group](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--) configuration should result in a single dependabot PR for Payload version upgrades.
