### PR TITLE
Docs: adding posthog authorized url instruction to onboarding docs

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -41,3 +41,4 @@ We also need to get the new tenant into our Vercel Edge Config. Adding a new ten
 ```
 4. Add this domain to our [list of domains](https://vercel.com/nwac/avy/settings/domains) for avy in Vercel.
 5. For domains not managed on Vercel, we'll need to coordinate with the avalanche center to set the appropriate DNS record in their DNS provider's console. Adding a non-Vercel-managed domain will display the records to add and once verified Vercel will automatically generate an SSL certificate. We should include the apex domain -> www. redirect for these custom domains.
+6. Add the tenant's custom domain to the list of authorized web analytics urls in PostHog under Settings -> Environment (/settings/environment#web-analytics-authorized-urls)


### PR DESCRIPTION
## Description

Adding posthog authorized url instruction to onboarding docs. We need to do this so analytics from the tenant's custom domain will be accepted by PostHog. 