### PR TITLE
Bugfix: widget styling enhancements

### DIFF
--- a/src/app/(frontend)/[center]/layout.tsx
+++ b/src/app/(frontend)/[center]/layout.tsx
@@ -71,7 +71,7 @@ export default async function RootLayout({ children, params }: Args) {
       <TenantProvider tenant={tenant}>
         <PostHogTenantRegister />
         <AvalancheCenterProvider platforms={platforms} metadata={metadata}>
-          <div className={cn('flex flex-col min-h-screen max-w-screen overflow-x-hidden', center)}>
+          <div className={cn('flex flex-col min-h-screen max-w-screen overflow-x-clip', center)}>
             <ThemeSetter theme={center} />
             <Header center={center} />
             <main className="flex-grow">

--- a/src/app/(frontend)/[center]/nac-widgets.css
+++ b/src/app/(frontend)/[center]/nac-widgets.css
@@ -10,32 +10,13 @@
   display: initial;
 }
 
-/* Customizations */
+/* Overrides */
 
 #widget-container[data-widget='forecast'],
-#widget-container[data-widget='observations'] {
-  min-height: 100vh;
-}
-#widget-container[data-widget='map'],
+#widget-container[data-widget='observations'],
 #widget-container[data-widget='stations'] {
-  min-height: calc(100vh - 170px) !important;
+  min-height: 100vh !important;
 }
-
-@media (min-width: 768px) {
-  #widget-container[data-widget='map'],
-  #widget-container[data-widget='stations'] {
-    min-height: calc(100vh - 180px) !important;
-  }
-}
-
-@media (min-width: 1024px) {
-  #widget-container[data-widget='map'],
-  #widget-container[data-widget='stations'] {
-    min-height: calc(100vh - 220px) !important;
-  }
-}
-
-/* Overrides */
 
 #nac-app .nac-forecast-view.nac-html-body {
   @apply bg-background text-foreground !important;
@@ -60,19 +41,7 @@
 }
 
 #nac-app #nac-weather-map:not(.nac-map-fullscreen) {
-  height: calc(100vh - 240px) !important;
-}
-
-@media (min-width: 768px) {
-  #nac-app #nac-weather-map:not(.nac-map-fullscreen) {
-    height: calc(100vh - 260px) !important;
-  }
-}
-
-@media (min-width: 1024px) {
-  #nac-app #nac-weather-map:not(.nac-map-fullscreen) {
-    height: calc(100vh - 300px) !important;
-  }
+  min-height: 100vh !important;
 }
 
 #nac-app .nac-station-table-container {

--- a/src/app/(frontend)/globals.css
+++ b/src/app/(frontend)/globals.css
@@ -21,6 +21,6 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground min-h-[100vh] flex flex-col max-w-[100vw] overflow-x-hidden;
+    @apply bg-background text-foreground min-h-[100vh] flex flex-col max-w-[100vw] overflow-x-clip;
   }
 }

--- a/src/app/[...segmentsNotFound]/layout.tsx
+++ b/src/app/[...segmentsNotFound]/layout.tsx
@@ -106,7 +106,7 @@ const lato = localFont({
 export default function FallbackRootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html className={cn(lato.variable)} lang="en" suppressHydrationWarning>
-      <body className="w-screen h-screen overflow-x-hidden flex justify-center items-center">
+      <body className="w-screen h-screen overflow-x-clip flex justify-center items-center">
         {children}
       </body>
     </html>

--- a/src/blocks/GenericEmbed/Component.tsx
+++ b/src/blocks/GenericEmbed/Component.tsx
@@ -162,7 +162,7 @@ export const GenericEmbedBlock = ({
             title={`Embedded content ${id}`}
             srcDoc={sanitizedHtml}
             sandbox="allow-scripts allow-forms allow-same-origin"
-            className="w-full border-none m-0 overflow-x-hidden"
+            className="w-full border-none m-0 overflow-x-clip"
             style={{
               height: iframeHeight,
             }}
@@ -175,7 +175,7 @@ export const GenericEmbedBlock = ({
               alignContent === 'left' && 'items-start',
               alignContent === 'center' && 'items-center',
               alignContent === 'right' && 'items-end',
-              'overflow-x-hidden',
+              'overflow-x-clip',
             )}
             dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
           />

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -50,7 +50,7 @@ const collections: CollectionSlug[] = [
 ]
 const defaultNacWidgetsConfig = {
   requiredFields: {
-    version: '20250602',
+    version: '20251015',
     baseUrl: 'https://du6amfiq9m9h7.cloudfront.net/public/v2',
   },
 }


### PR DESCRIPTION
## Description

A few widget enhancements related to min-height, sticky header behavior on observations, and layout shift. 

## Related Issues

Resolves #616 

## Key Changes

The commits say it all, see below. 

## Future enhancements / Questions

It would be great to be able to specify the map height on our end instead of the danger map widget always using the height specified in the AFP widget config. But 🤷
