### PR TITLE
ESLint rule to warn on type assertion

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,12 @@ const eslintConfig = [
           caughtErrorsIgnorePattern: '^(_|ignore)',
         },
       ],
+      '@typescript-eslint/consistent-type-assertions': [
+        'warn',
+        {
+          assertionStyle: 'never',
+        },
+      ],
     },
   },
   globalIgnores(['.next/', 'src/migrations/']),

--- a/src/app/(frontend)/[center]/[...segments]/page.tsx
+++ b/src/app/(frontend)/[center]/[...segments]/page.tsx
@@ -106,6 +106,7 @@ export async function generateMetadata(
   },
   parent: Promise<ResolvedMetadata>,
 ): Promise<Metadata> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const parentMeta = (await parent) as Metadata
   const { center, segments } = await paramsPromise
 

--- a/src/app/(frontend)/[center]/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/[slug]/page.tsx
@@ -107,6 +107,7 @@ export async function generateMetadata(
   },
   parent: Promise<ResolvedMetadata>,
 ): Promise<Metadata> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const parentMeta = (await parent) as Metadata
   const { center, slug } = await paramsPromise
 

--- a/src/app/(frontend)/[center]/blog/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/blog/[slug]/page.tsx
@@ -107,6 +107,7 @@ export async function generateMetadata(
   { params: paramsPromise }: Args,
   parent: Promise<ResolvedMetadata>,
 ): Promise<Metadata> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const parentMeta = (await parent) as Metadata
   const { center, slug = '' } = await paramsPromise
   const post = await queryPostBySlug({ center: center, slug: slug })

--- a/src/app/(frontend)/[center]/blog/page.tsx
+++ b/src/app/(frontend)/[center]/blog/page.tsx
@@ -97,6 +97,7 @@ export async function generateMetadata(
   _props: Args,
   parent: Promise<ResolvedMetadata>,
 ): Promise<Metadata> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const parentMeta = (await parent) as Metadata
 
   const parentTitle =

--- a/src/app/(frontend)/[center]/blog/page/[pageNumber]/page.tsx
+++ b/src/app/(frontend)/[center]/blog/page/[pageNumber]/page.tsx
@@ -101,6 +101,7 @@ export async function generateMetadata(
   { params }: Args,
   parent: Promise<ResolvedMetadata>,
 ): Promise<Metadata> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const parentMeta = (await parent) as Metadata
   const { pageNumber } = await params
 

--- a/src/app/(frontend)/[center]/forecasts/avalanche/[zone]/page.tsx
+++ b/src/app/(frontend)/[center]/forecasts/avalanche/[zone]/page.tsx
@@ -74,6 +74,7 @@ export async function generateMetadata(
   { params }: Args,
   parent: Promise<ResolvedMetadata>,
 ): Promise<Metadata> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const parentMeta = (await parent) as Metadata
   const { zone } = await params
 

--- a/src/app/(frontend)/[center]/forecasts/avalanche/page.tsx
+++ b/src/app/(frontend)/[center]/forecasts/avalanche/page.tsx
@@ -64,6 +64,7 @@ export async function generateMetadata(
   _props: Args,
   parent: Promise<ResolvedMetadata>,
 ): Promise<Metadata> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const parentMeta = (await parent) as Metadata
 
   const parentTitle =

--- a/src/app/(frontend)/[center]/observations/page.tsx
+++ b/src/app/(frontend)/[center]/observations/page.tsx
@@ -72,6 +72,7 @@ export async function generateMetadata(
   _props: Args,
   parent: Promise<ResolvedMetadata>,
 ): Promise<Metadata> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const parentMeta = (await parent) as Metadata
 
   const parentTitle =

--- a/src/app/(frontend)/[center]/observations/submit/page.tsx
+++ b/src/app/(frontend)/[center]/observations/submit/page.tsx
@@ -67,6 +67,7 @@ export async function generateMetadata(
   _props: Args,
   parent: Promise<ResolvedMetadata>,
 ): Promise<Metadata> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const parentMeta = (await parent) as Metadata
 
   const parentTitle =

--- a/src/app/(frontend)/[center]/weather/stations/map/page.tsx
+++ b/src/app/(frontend)/[center]/weather/stations/map/page.tsx
@@ -69,6 +69,7 @@ export async function generateMetadata(
   _props: Args,
   parent: Promise<ResolvedMetadata>,
 ): Promise<Metadata> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const parentMeta = (await parent) as Metadata
 
   const parentTitle =

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link'
 
 import { ImageMedia } from '@/components/Media/ImageMedia'
-import { Media, Tenant } from '@/payload-types'
 import { getURL } from '@/utilities/getURL'
 import { getHostnameFromTenant } from '@/utilities/tenancy/getHostnameFromTenant'
 import configPromise from '@payload-config'
@@ -26,7 +25,7 @@ export default async function LandingPage() {
 
   const tenantIds = tenants.map((tenant) => tenant.id)
 
-  const tenantsLogo = (await payload
+  const tenantsLogo = await payload
     .find({
       collection: 'settings',
       where: {
@@ -39,7 +38,7 @@ export default async function LandingPage() {
         tenant: true,
       },
     })
-    .then((result) => result.docs)) as { logo: Media; tenant: Tenant }[]
+    .then((result) => result.docs)
 
   return (
     <div className="py-12">
@@ -53,7 +52,10 @@ export default async function LandingPage() {
             {tenants.map(async (tenant) => {
               const hostname = getHostnameFromTenant(tenant)
               const href = getURL(hostname)
-              const logo = tenantsLogo.find((logo) => logo.tenant.id === tenant.id)?.logo
+              const logo = tenantsLogo.find((logo) => {
+                const logoTenantId = typeof logo.tenant === 'number' ? logo.tenant : logo.tenant.id
+                return logoTenantId === tenant.id
+              })?.logo
               return (
                 <Link
                   key={tenant.slug}

--- a/src/blocks/BlogList/fields/QueriedPostsComponent.tsx
+++ b/src/blocks/BlogList/fields/QueriedPostsComponent.tsx
@@ -44,13 +44,12 @@ export const QueriedPostsComponent = ({ path, field }: QueriedPostsComponentProp
       setDisabled(true)
 
       try {
-        const tenantId = typeof tenant === 'number' ? tenant : (tenant as { id?: number })?.id
-        if (!tenantId) return
+        if (!tenant) return
 
         const params = new URLSearchParams({
           limit: String(maxPosts || 4),
           depth: '1',
-          'where[tenant][equals]': String(tenantId),
+          'where[tenant][equals]': String(tenant),
           'where[_status][equals]': 'published',
         })
 

--- a/src/collections/Pages/components/DuplicatePageFor/DuplicatePageForDrawer.tsx
+++ b/src/collections/Pages/components/DuplicatePageFor/DuplicatePageForDrawer.tsx
@@ -73,7 +73,7 @@ export const DuplicatePageForDrawer = () => {
           throw toast.error(errors[0].message || 'Error duplicating page.')
         }
       } catch (err) {
-        toast.error((err as Error).message || 'An unexpected error occurred.')
+        toast.error(err instanceof Error ? err.message : 'An unexpected error occurred.')
       }
     },
     [adminRoute, closeModal, pageData, router, selectedTenantId, startRouteTransition],

--- a/src/collections/Pages/components/DuplicatePageFor/index.tsx
+++ b/src/collections/Pages/components/DuplicatePageFor/index.tsx
@@ -1,18 +1,23 @@
 import { byGlobalRole } from '@/access/byGlobalRole'
-import { User } from '@/payload-types'
 import { roleAssignmentsForUser } from '@/utilities/rbac/roleAssignmentsForUser'
 import { ruleMatches } from '@/utilities/rbac/ruleMatches'
 import { EditMenuItemsServerProps, PayloadRequest } from 'payload'
 import { DuplicatePageForDrawer } from './DuplicatePageForDrawer'
 
 export const DuplicatePageFor = ({ user, payload }: EditMenuItemsServerProps) => {
+  if (!user) {
+    return null
+  }
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockedPayloadReq = {
     user,
     payload,
   } as PayloadRequest
+
   const isSuperAdmin = byGlobalRole('*', '*')({ req: mockedPayloadReq })
 
-  const roleAssignments = roleAssignmentsForUser(payload.logger, user as User)
+  const roleAssignments = roleAssignmentsForUser(payload.logger, user)
   const matchingTenantIds = roleAssignments
     .filter(
       (assignment) =>

--- a/src/collections/RoleAssignments/hooks/validateEscalation.ts
+++ b/src/collections/RoleAssignments/hooks/validateEscalation.ts
@@ -1,4 +1,4 @@
-import type { Role, RoleAssignment } from '@/payload-types'
+import type { RoleAssignment } from '@/payload-types'
 import { canAssignRole } from '@/utilities/rbac/escalationCheck'
 import type { CollectionBeforeValidateHook } from 'payload'
 import { ValidationError } from 'payload'
@@ -66,7 +66,7 @@ export const validateEscalation: CollectionBeforeValidateHook<RoleAssignment> = 
     }
   } else if (typeof role === 'object' && 'rules' in role) {
     // Role is already populated, check it directly
-    if (!canAssignRole(req.payload.logger, req.user, role as Role, tenantId)) {
+    if (!canAssignRole(req.payload.logger, req.user, role, tenantId)) {
       throw new ValidationError({
         errors: [
           {

--- a/src/collections/Roles/components/CollectionsField.tsx
+++ b/src/collections/Roles/components/CollectionsField.tsx
@@ -9,7 +9,7 @@ export const CollectionsField: TextFieldServerComponent = async ({
   clientField,
   readOnly,
 }) => {
-  const fieldPath = (path || field?.name || '') as string
+  const fieldPath = path || field?.name || ''
   const { type: _type, admin, ...clientFields } = clientField
 
   return (

--- a/src/collections/Users/components/InviteUser.tsx
+++ b/src/collections/Users/components/InviteUser.tsx
@@ -8,7 +8,8 @@ export function InviteUser({ payload, user }: BeforeListServerProps) {
     return null
   }
 
-  const mockedPayloadReq = {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const mockedPayloadReq: PayloadRequest = {
     user,
     payload,
   } as PayloadRequest

--- a/src/collections/Users/components/inviteUserAction.ts
+++ b/src/collections/Users/components/inviteUserAction.ts
@@ -80,6 +80,7 @@ export async function inviteUserAction({
       throw new Error('You are not allowed to perform that action.')
     }
 
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const mockedPayloadReq = {
       user: loggedInUser,
       payload,

--- a/src/collections/Users/components/resendInviteActions.ts
+++ b/src/collections/Users/components/resendInviteActions.ts
@@ -62,6 +62,7 @@ export async function checkExpiredInviteAction(
       throw new Error('You are not allowed to perform that action.')
     }
 
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const mockedPayloadReq = {
       user: loggedInUser,
       payload,
@@ -112,6 +113,7 @@ export async function resendInviteAction(
       throw new Error('You are not allowed to perform that action.')
     }
 
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const mockedPayloadReq = {
       user: loggedInUser,
       payload,

--- a/src/components/AuthorAvatar/index.tsx
+++ b/src/components/AuthorAvatar/index.tsx
@@ -34,7 +34,7 @@ export const AuthorAvatar = (props: {
 
             const authorPhoto =
               typeof author.photo === 'number'
-                ? ((await getDocumentById('media', author.photo)) as Media)
+                ? await getDocumentById('media', author.photo)
                 : author.photo
 
             photos.push(authorPhoto)

--- a/src/emails/forgot-password-email.tsx
+++ b/src/emails/forgot-password-email.tsx
@@ -31,6 +31,6 @@ export function ForgotPasswordEmail({ appUrl, resetUrl }: ForgotPasswordEmailPro
 ForgotPasswordEmail.PreviewProps = {
   appUrl: 'http://localhost:3000',
   resetUrl: 'http://localhost:3000/admin/reset/123456789',
-} as ForgotPasswordEmailProps
+}
 
 export default ForgotPasswordEmail

--- a/src/emails/invite-user-email.tsx
+++ b/src/emails/invite-user-email.tsx
@@ -32,6 +32,6 @@ export function InviteUserEmail({ appUrl, inviteUrl }: InviteUserEmailProps) {
 InviteUserEmail.PreviewProps = {
   appUrl: 'http://localhost:3000',
   inviteUrl: 'http://localhost:3000/admin/accept-invite?token=123456789',
-} as InviteUserEmailProps
+}
 
 export default InviteUserEmail

--- a/src/providers/TenantSelectionProvider/index.client.tsx
+++ b/src/providers/TenantSelectionProvider/index.client.tsx
@@ -171,7 +171,7 @@ export const TenantSelectionProviderClient = ({
         }
       }
     } catch (e) {
-      toast.error((e as Error).message || `Error fetching tenants`)
+      toast.error(e instanceof Error ? e.message : 'Error fetching tenants')
     }
   }, [config.serverURL, config.routes.api, tenantsCollectionSlug, useAsTitle, setCookie, userID])
 

--- a/src/utilities/getDocumentById.ts
+++ b/src/utilities/getDocumentById.ts
@@ -2,11 +2,15 @@
 import type { Config } from 'src/payload-types'
 
 import configPromise from '@payload-config'
-import { getPayload } from 'payload'
+import { DataFromCollectionSlug, getPayload } from 'payload'
 
 type Collection = keyof Config['collections']
 
-export async function getDocumentById(collection: Collection, id: number, depth = 1) {
+export async function getDocumentById<T extends Collection>(
+  collection: T,
+  id: number,
+  depth = 1,
+): Promise<DataFromCollectionSlug<T>> {
   const payload = await getPayload({ config: configPromise })
 
   const doc = await payload.findByID({

--- a/src/utilities/getGlobals.ts
+++ b/src/utilities/getGlobals.ts
@@ -18,13 +18,16 @@ async function getGlobal<T extends Global>(slug: T, depth = 0): Promise<GlobalRe
     depth,
   })
 
-  return global as GlobalReturnType[T]
+  return global
 }
 
 /**
  * Returns a unstable_cache function mapped with the cache tag for the slug
  */
-export const getCachedGlobal = <T extends Global>(slug: T, depth = 0) =>
+export const getCachedGlobal = <T extends Global>(
+  slug: T,
+  depth = 0,
+): (() => Promise<GlobalReturnType[T]>) =>
   unstable_cache(async () => getGlobal(slug, depth), [slug], {
     tags: [`global_${slug}`],
-  }) as () => Promise<GlobalReturnType[T]>
+  })

--- a/src/utilities/rbac/globalRoleAssignmentsForUser.ts
+++ b/src/utilities/rbac/globalRoleAssignmentsForUser.ts
@@ -1,9 +1,10 @@
 import { GlobalRoleAssignment, User } from '@/payload-types'
+import { ClientUser } from 'payload'
 import { Logger } from 'pino'
 
 export const globalRoleAssignmentsForUser = (
   logger: Logger,
-  user: User,
+  user: User | ClientUser,
 ): GlobalRoleAssignment[] => {
   const assignments: GlobalRoleAssignment[] = []
   if (

--- a/src/utilities/rbac/hasReadOnlyAccess.ts
+++ b/src/utilities/rbac/hasReadOnlyAccess.ts
@@ -12,7 +12,7 @@ export const hasReadOnlyAccess = (
   if (!user) return true
 
   try {
-    const assignments = globalRoleAssignmentsForUser(payload.logger, user as User)
+    const assignments = globalRoleAssignmentsForUser(payload.logger, user)
 
     const hasCreateAccess = assignments
       .map((assignment) => {

--- a/src/utilities/tenancy/getTenantFromCookie.ts
+++ b/src/utilities/tenancy/getTenantFromCookie.ts
@@ -1,8 +1,6 @@
 import { parseCookies } from 'payload'
 import { isNumber } from 'payload/shared'
 
-type IDType = 'number' | 'text'
-
 /**
  * A function that takes request headers and an idType and returns the current tenant ID from the cookie
  *
@@ -10,10 +8,16 @@ type IDType = 'number' | 'text'
  * @param idType can be 'number' | 'text', usually derived from payload.db.defaultIDType
  * @returns number | null when idType is 'number', string | null when idType is 'text'
  */
-export function getTenantFromCookie<T extends IDType>(
+export function getTenantFromCookie(headers: Headers, idType: 'number'): number | null
+export function getTenantFromCookie(headers: Headers, idType: 'text'): string | null
+export function getTenantFromCookie(
   headers: Headers,
-  idType: T,
-): T extends 'number' ? number | null : string | null {
+  idType: 'number' | 'text',
+): number | string | null
+export function getTenantFromCookie(
+  headers: Headers,
+  idType: 'number' | 'text',
+): number | string | null {
   const cookies = parseCookies(headers)
   const selectedTenant = cookies.get('payload-tenant') || null
   const result = selectedTenant
@@ -21,5 +25,5 @@ export function getTenantFromCookie<T extends IDType>(
       ? parseFloat(selectedTenant)
       : selectedTenant
     : null
-  return result as T extends 'number' ? number | null : string | null
+  return result
 }


### PR DESCRIPTION
## Description

Adds `@typescript-eslint/consistent-type-assertions` with `assertionStyle: never` to warn on usage of type assertions like `const variable = value as Type` and `const variable = <Type>value`. 

I fixed or decided it was safe to ignore many instances of these but I time-boxed myself on this and ran out of time. Anyone else, please feel free to jump in here and fix or decide to ignore any of the remaining usages:

```
./src/app/(frontend)/[center]/next/preview/route.ts
18:22  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
46:14  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
46:14  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/collections/Pages/endpoints/duplicatePageToTenant.ts
7:28  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
64:12  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
67:12  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/collections/Sponsors/index.ts
13:23  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/collections/Users/components/InviteUserDrawer.tsx
66:27  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/components/Header/utils.ts
73:20  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
91:27  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/components/TenantSelector/TenantSelector.client.tsx
35:25  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
61:16  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/endpoints/seed/index.ts
481:32  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
486:37  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
491:32  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/endpoints/seed/upsert.ts
62:17  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
184:17  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/fields/defaultLexical.ts
49:25  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
50:22  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/fields/slug/SlugComponent.tsx
28:12  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/middleware.ts
42:22  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/services/vercel.ts
62:22  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/utilities/findDocumentsWithBlockReferences.ts
16:18  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
31:16  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
40:15  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/utilities/generateOGImage.tsx
93:35  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/utilities/removeNonDeterministicKeys.ts
9:22  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
14:7  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions

./src/utilities/useClickableCard.ts
37:24  Warning: Do not use any type assertions.  @typescript-eslint/consistent-type-assertions
```
