### PR TITLE
Bump NAC widget version in seed script

### DIFF
--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -50,7 +50,7 @@ const collections: CollectionSlug[] = [
 ]
 const defaultNacWidgetsConfig = {
   requiredFields: {
-    version: '20251015',
+    version: '20251104',
     baseUrl: 'https://du6amfiq9m9h7.cloudfront.net/public/v2',
   },
 }


### PR DESCRIPTION
## Description

This is really just for local development and preview envs. I still need to update #251 to account for an aggressive caching bug on Safari before we can use the latest tag, even though `afp-public-widgets` is now publishing a latest tag. 
