### PR TITLE
Events - do not use `dbName` & fix `futureDate` and `pastDate`

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,111 +1,159 @@
-import { TenantFieldComponent as TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6 } from '@/fields/tenantField/TenantFieldComponent'
-import { default as default_55a7d1ebef7afeed563b856ae2e2cbf4 } from '@/components/ColorPicker'
-import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { default as default_ef94af202ba9f4dd0fd10062e0964050 } from '@/components/AlignContentPicker'
-import { AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { SponsorsLayoutDescription as SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de } from '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription'
-import { HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { QueriedPostsComponent as QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e } from '@/blocks/BlogList/fields/QueriedPostsComponent'
-import { default as default_923dc5ccc0b72de4298251644cbfe39e } from '@/components/ColumnLayoutPicker'
 import { DefaultColumnAdder as DefaultColumnAdder_006f8c6c8800e6fe3753b3785f2c4a01 } from '@/blocks/Content/components/DefaultColumnAdder'
-import { OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
-import { ViewPageButton as ViewPageButton_5587abba969d5f30cb1f479b0a70bb80 } from '@/collections/Pages/components/ViewPageButton'
-import { DuplicatePageFor as DuplicatePageFor_8f1d8961a356bec6784e5c591c016925 } from '@/collections/Pages/components/DuplicatePageFor'
-import { ViewPostButton as ViewPostButton_c85c9ca228f12030489338b3f3f7139d } from '@/collections/Posts/components/ViewPostButton'
-import { LocationMap as LocationMap_4b1c9ff6af70dfec8b61ae82b54165d8 } from '@/fields/location/components/LocationMap'
+import { SponsorsLayoutDescription as SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de } from '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription'
 import { CourseTypeField as CourseTypeField_348fff62462d32a00f93a0ac5be86e99 } from '@/collections/Courses/components/CourseTypeField'
-import { UserStatusCell as UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee } from '@/collections/Users/components/UserStatusCell'
-import { InviteUser as InviteUser_6042b6804e11048cd4fbe6206cbc2b0f } from '@/collections/Users/components/InviteUser'
-import { ResendInviteButton as ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735 } from '@/collections/Users/components/ResendInviteButton'
+import { DuplicatePageFor as DuplicatePageFor_8f1d8961a356bec6784e5c591c016925 } from '@/collections/Pages/components/DuplicatePageFor'
+import { ViewPageButton as ViewPageButton_5587abba969d5f30cb1f479b0a70bb80 } from '@/collections/Pages/components/ViewPageButton'
+import { ViewPostButton as ViewPostButton_c85c9ca228f12030489338b3f3f7139d } from '@/collections/Posts/components/ViewPostButton'
 import { CollectionsField as CollectionsField_49c0311020325b59204cc21d2f536b8d } from '@/collections/Roles/components/CollectionsField'
 import { RulesCell as RulesCell_649699f5b285e7a5429592dc58fd6f0c } from '@/collections/Roles/components/RulesCell'
-import { LinkLabelDescription as LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721 } from '@/fields/navLink/components/LinkLabelDescription'
 import { AvalancheCenterName as AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad } from '@/collections/Settings/components/AvalancheCenterName'
 import { USFSLogoDescription as USFSLogoDescription_d2eea91290575f9a545768dce25713f4 } from '@/collections/Settings/components/USFSLogoDescription'
-import { DiagnosticsDisplay as DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6 } from '@/globals/Diagnostics/components/DiagnosticsDisplay'
-import { LogoutButton as LogoutButton_db9ac62598c46d0f1db201f6af05442e } from '@/components/LogoutButton'
+import { InviteUser as InviteUser_6042b6804e11048cd4fbe6206cbc2b0f } from '@/collections/Users/components/InviteUser'
+import { ResendInviteButton as ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735 } from '@/collections/Users/components/ResendInviteButton'
+import { UserStatusCell as UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee } from '@/collections/Users/components/UserStatusCell'
+import { default as default_ef94af202ba9f4dd0fd10062e0964050 } from '@/components/AlignContentPicker'
+import { default as default_1a7510af427896d367a49dbf838d2de6 } from '@/components/BeforeDashboard'
+import { default as default_55a7d1ebef7afeed563b856ae2e2cbf4 } from '@/components/ColorPicker'
+import { default as default_923dc5ccc0b72de4298251644cbfe39e } from '@/components/ColumnLayoutPicker'
+import { GlobalViewRedirect as GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e } from '@/components/GlobalViewRedirect'
 import { AvyFxIcon as AvyFxIcon_5698f736c9797d81d0dacf1b1321e327 } from '@/components/Icon/AvyFxIcon'
 import { AvyFxLogo as AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4 } from '@/components/Logo/AvyFxLogo'
-import { GlobalViewRedirect as GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e } from '@/components/GlobalViewRedirect'
-import { default as default_cb0ad5752e1389a2a940bb73c2c0e7d2 } from '@/components/ViewTypeAction'
-import { default as default_1a7510af427896d367a49dbf838d2de6 } from '@/components/BeforeDashboard'
+import { LogoutButton as LogoutButton_db9ac62598c46d0f1db201f6af05442e } from '@/components/LogoutButton'
 import { default as default_2aead22399b7847b21b134dc4a7931e0 } from '@/components/TenantSelector/TenantSelector'
+import { default as default_cb0ad5752e1389a2a940bb73c2c0e7d2 } from '@/components/ViewTypeAction'
+import { LocationMap as LocationMap_4b1c9ff6af70dfec8b61ae82b54165d8 } from '@/fields/location/components/LocationMap'
+import { LinkLabelDescription as LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721 } from '@/fields/navLink/components/LinkLabelDescription'
+import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
+import { TenantFieldComponent as TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6 } from '@/fields/tenantField/TenantFieldComponent'
+import { DiagnosticsDisplay as DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6 } from '@/globals/Diagnostics/components/DiagnosticsDisplay'
 import { TenantSelectionProvider as TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d } from '@/providers/TenantSelectionProvider'
 import { ViewTypeProvider as ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0 } from '@/providers/ViewTypeProvider'
-import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
-import { AdminErrorBoundary as AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688 } from '@payloadcms/plugin-sentry/client'
 import { AcceptInvite as AcceptInvite_a090ee9cb5b31ae357daa74987d3109a } from '@/views/AcceptInvite'
+import { AdminErrorBoundary as AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688 } from '@payloadcms/plugin-sentry/client'
+import {
+  MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+} from '@payloadcms/plugin-seo/client'
+import {
+  AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+} from '@payloadcms/richtext-lexical/client'
+import {
+  LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
+  RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
+  RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+} from '@payloadcms/richtext-lexical/rsc'
+import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
 
 export const importMap = {
-  "@/fields/tenantField/TenantFieldComponent#TenantFieldComponent": TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6,
-  "@/components/ColorPicker#default": default_55a7d1ebef7afeed563b856ae2e2cbf4,
-  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@/components/AlignContentPicker#default": default_ef94af202ba9f4dd0fd10062e0964050,
-  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient": FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#ParagraphFeatureClient": ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@/blocks/SponsorsBlock/components/SponsorsLayoutDescription#SponsorsLayoutDescription": SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de,
-  "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#OrderedListFeatureClient": OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#UnorderedListFeatureClient": UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@/blocks/BlogList/fields/QueriedPostsComponent#QueriedPostsComponent": QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e,
-  "@/components/ColumnLayoutPicker#default": default_923dc5ccc0b72de4298251644cbfe39e,
-  "@/blocks/Content/components/DefaultColumnAdder#DefaultColumnAdder": DefaultColumnAdder_006f8c6c8800e6fe3753b3785f2c4a01,
-  "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
-  "@/collections/Pages/components/ViewPageButton#ViewPageButton": ViewPageButton_5587abba969d5f30cb1f479b0a70bb80,
-  "@/collections/Pages/components/DuplicatePageFor#DuplicatePageFor": DuplicatePageFor_8f1d8961a356bec6784e5c591c016925,
-  "@/collections/Posts/components/ViewPostButton#ViewPostButton": ViewPostButton_c85c9ca228f12030489338b3f3f7139d,
-  "@/fields/location/components/LocationMap#LocationMap": LocationMap_4b1c9ff6af70dfec8b61ae82b54165d8,
-  "@/collections/Courses/components/CourseTypeField#CourseTypeField": CourseTypeField_348fff62462d32a00f93a0ac5be86e99,
-  "@/collections/Users/components/UserStatusCell#UserStatusCell": UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee,
-  "@/collections/Users/components/InviteUser#InviteUser": InviteUser_6042b6804e11048cd4fbe6206cbc2b0f,
-  "@/collections/Users/components/ResendInviteButton#ResendInviteButton": ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735,
-  "@/collections/Roles/components/CollectionsField#CollectionsField": CollectionsField_49c0311020325b59204cc21d2f536b8d,
-  "@/collections/Roles/components/RulesCell#RulesCell": RulesCell_649699f5b285e7a5429592dc58fd6f0c,
-  "@/fields/navLink/components/LinkLabelDescription#LinkLabelDescription": LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721,
-  "@/collections/Settings/components/AvalancheCenterName#AvalancheCenterName": AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad,
-  "@/collections/Settings/components/USFSLogoDescription#USFSLogoDescription": USFSLogoDescription_d2eea91290575f9a545768dce25713f4,
-  "@/globals/Diagnostics/components/DiagnosticsDisplay#DiagnosticsDisplay": DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6,
-  "@/components/LogoutButton#LogoutButton": LogoutButton_db9ac62598c46d0f1db201f6af05442e,
-  "@/components/Icon/AvyFxIcon#AvyFxIcon": AvyFxIcon_5698f736c9797d81d0dacf1b1321e327,
-  "@/components/Logo/AvyFxLogo#AvyFxLogo": AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4,
-  "@/components/GlobalViewRedirect#GlobalViewRedirect": GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e,
-  "@/components/ViewTypeAction#default": default_cb0ad5752e1389a2a940bb73c2c0e7d2,
-  "@/components/BeforeDashboard#default": default_1a7510af427896d367a49dbf838d2de6,
-  "@/components/TenantSelector/TenantSelector#default": default_2aead22399b7847b21b134dc4a7931e0,
-  "@/providers/TenantSelectionProvider#TenantSelectionProvider": TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d,
-  "@/providers/ViewTypeProvider#ViewTypeProvider": ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0,
-  "@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler": VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
-  "@payloadcms/plugin-sentry/client#AdminErrorBoundary": AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688,
-  "@/views/AcceptInvite#AcceptInvite": AcceptInvite_a090ee9cb5b31ae357daa74987d3109a
+  '@/fields/tenantField/TenantFieldComponent#TenantFieldComponent':
+    TenantFieldComponent_504ac17ee612eaea8fbd999a5bf2d5a6,
+  '@/components/ColorPicker#default': default_55a7d1ebef7afeed563b856ae2e2cbf4,
+  '@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell':
+    RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
+  '@payloadcms/richtext-lexical/rsc#RscEntryLexicalField':
+    RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+  '@payloadcms/richtext-lexical/rsc#LexicalDiffComponent':
+    LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
+  '@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient':
+    InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient':
+    HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#BlocksFeatureClient':
+    BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@/components/AlignContentPicker#default': default_ef94af202ba9f4dd0fd10062e0964050,
+  '@payloadcms/richtext-lexical/client#AlignFeatureClient':
+    AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient':
+    FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#LinkFeatureClient':
+    LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#BoldFeatureClient':
+    BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#ItalicFeatureClient':
+    ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#UnderlineFeatureClient':
+    UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#ParagraphFeatureClient':
+    ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@/blocks/SponsorsBlock/components/SponsorsLayoutDescription#SponsorsLayoutDescription':
+    SponsorsLayoutDescription_6f00823041b5b0999b9929fb565110de,
+  '@payloadcms/richtext-lexical/client#HeadingFeatureClient':
+    HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#OrderedListFeatureClient':
+    OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@payloadcms/richtext-lexical/client#UnorderedListFeatureClient':
+    UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  '@/blocks/BlogList/fields/QueriedPostsComponent#QueriedPostsComponent':
+    QueriedPostsComponent_a2ad38d8499118f1bebc7752c0fff51e,
+  '@/components/ColumnLayoutPicker#default': default_923dc5ccc0b72de4298251644cbfe39e,
+  '@/blocks/Content/components/DefaultColumnAdder#DefaultColumnAdder':
+    DefaultColumnAdder_006f8c6c8800e6fe3753b3785f2c4a01,
+  '@payloadcms/plugin-seo/client#OverviewComponent':
+    OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  '@payloadcms/plugin-seo/client#MetaImageComponent':
+    MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  '@payloadcms/plugin-seo/client#MetaDescriptionComponent':
+    MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  '@payloadcms/plugin-seo/client#PreviewComponent':
+    PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  '@/fields/slug/SlugComponent#SlugComponent': SlugComponent_92cc057d0a2abb4f6cf0307edf59f986,
+  '@/collections/Pages/components/ViewPageButton#ViewPageButton':
+    ViewPageButton_5587abba969d5f30cb1f479b0a70bb80,
+  '@/collections/Pages/components/DuplicatePageFor#DuplicatePageFor':
+    DuplicatePageFor_8f1d8961a356bec6784e5c591c016925,
+  '@/collections/Posts/components/ViewPostButton#ViewPostButton':
+    ViewPostButton_c85c9ca228f12030489338b3f3f7139d,
+  '@/fields/location/components/LocationMap#LocationMap':
+    LocationMap_4b1c9ff6af70dfec8b61ae82b54165d8,
+  '@/collections/Courses/components/CourseTypeField#CourseTypeField':
+    CourseTypeField_348fff62462d32a00f93a0ac5be86e99,
+  '@/collections/Users/components/UserStatusCell#UserStatusCell':
+    UserStatusCell_bcfd328e5e7c9f1261310753bec8f6ee,
+  '@/collections/Users/components/InviteUser#InviteUser':
+    InviteUser_6042b6804e11048cd4fbe6206cbc2b0f,
+  '@/collections/Users/components/ResendInviteButton#ResendInviteButton':
+    ResendInviteButton_e262b7912e5bdc08a1a83eb2731de735,
+  '@/collections/Roles/components/CollectionsField#CollectionsField':
+    CollectionsField_49c0311020325b59204cc21d2f536b8d,
+  '@/collections/Roles/components/RulesCell#RulesCell': RulesCell_649699f5b285e7a5429592dc58fd6f0c,
+  '@/fields/navLink/components/LinkLabelDescription#LinkLabelDescription':
+    LinkLabelDescription_cc2cf53f1598892c0c926f3cb616a721,
+  '@/collections/Settings/components/AvalancheCenterName#AvalancheCenterName':
+    AvalancheCenterName_acb7f1a03857e27efe1942bb65ab80ad,
+  '@/collections/Settings/components/USFSLogoDescription#USFSLogoDescription':
+    USFSLogoDescription_d2eea91290575f9a545768dce25713f4,
+  '@/globals/Diagnostics/components/DiagnosticsDisplay#DiagnosticsDisplay':
+    DiagnosticsDisplay_eee0393496e2f0e3400424e01efca1c6,
+  '@/components/LogoutButton#LogoutButton': LogoutButton_db9ac62598c46d0f1db201f6af05442e,
+  '@/components/Icon/AvyFxIcon#AvyFxIcon': AvyFxIcon_5698f736c9797d81d0dacf1b1321e327,
+  '@/components/Logo/AvyFxLogo#AvyFxLogo': AvyFxLogo_f711e8d8656c7552b63fe9abc7b36dc4,
+  '@/components/GlobalViewRedirect#GlobalViewRedirect':
+    GlobalViewRedirect_951bb27256a1a1ac886a8bd1c394c17e,
+  '@/components/ViewTypeAction#default': default_cb0ad5752e1389a2a940bb73c2c0e7d2,
+  '@/components/BeforeDashboard#default': default_1a7510af427896d367a49dbf838d2de6,
+  '@/components/TenantSelector/TenantSelector#default': default_2aead22399b7847b21b134dc4a7931e0,
+  '@/providers/TenantSelectionProvider#TenantSelectionProvider':
+    TenantSelectionProvider_000be6f574298db4d640f76ae308cd1d,
+  '@/providers/ViewTypeProvider#ViewTypeProvider':
+    ViewTypeProvider_1dd5649a8d943d1e5c4f21c0e3cc22f0,
+  '@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler':
+    VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
+  '@payloadcms/plugin-sentry/client#AdminErrorBoundary':
+    AdminErrorBoundary_e5a9e14bdbe97e70ba60697217fe7688,
+  '@/views/AcceptInvite#AcceptInvite': AcceptInvite_a090ee9cb5b31ae357daa74987d3109a,
 }

--- a/src/blocks/EventList/Component.tsx
+++ b/src/blocks/EventList/Component.tsx
@@ -26,9 +26,8 @@ export const EventListBlockComponent = (args: EventListComponentProps) => {
     eventOptions,
   } = args
 
-  const { filterByEventTypes, filterByEventGroups, filterByEventTags, maxEvents } =
-    args.dynamicOptions || {}
-  const { staticEvents } = args.staticOptions || {}
+  const { byTypes, byGroups, byTags, maxEvents } = args.dynamicOpts || {}
+  const { staticEvents } = args.staticOpts || {}
 
   const { tenant } = useTenant()
   const [fetchedEvents, setFetchedEvents] = useState<Event[]>([])
@@ -47,23 +46,19 @@ export const EventListBlockComponent = (args: EventListComponentProps) => {
       // params supported by the events page
       const eventsPageParams = new URLSearchParams()
 
-      if (filterByEventTypes?.length) {
-        eventsPageParams.append('types', filterByEventTypes.join(','))
+      if (byTypes?.length) {
+        eventsPageParams.append('types', byTypes.join(','))
       }
 
-      if (filterByEventGroups?.length) {
-        const groupIds = filterByEventGroups
-          .map((g) => (typeof g === 'object' ? g.id : g))
-          .filter(Boolean)
+      if (byGroups?.length) {
+        const groupIds = byGroups.map((g) => (typeof g === 'object' ? g.id : g)).filter(Boolean)
         if (groupIds.length) {
           eventsPageParams.append('groups', groupIds.join(','))
         }
       }
 
-      if (filterByEventTags?.length) {
-        const tagIds = filterByEventTags
-          .map((t) => (typeof t === 'object' ? t.id : t))
-          .filter(Boolean)
+      if (byTags?.length) {
+        const tagIds = byTags.map((t) => (typeof t === 'object' ? t.id : t)).filter(Boolean)
         if (tagIds.length) {
           eventsPageParams.append('tags', tagIds.join(','))
         }
@@ -86,7 +81,7 @@ export const EventListBlockComponent = (args: EventListComponentProps) => {
     }
 
     fetchEvents()
-  }, [eventOptions, filterByEventTypes, filterByEventGroups, filterByEventTags, maxEvents, tenant])
+  }, [eventOptions, byTypes, byGroups, byTags, maxEvents, tenant])
 
   let displayEvents: Event[] = filterValidPublishedRelationships(staticEvents)
 

--- a/src/blocks/EventTable/Component.tsx
+++ b/src/blocks/EventTable/Component.tsx
@@ -15,9 +15,8 @@ type EventTableComponentProps = EventTableBlockProps & {
 
 export const EventTableBlockComponent = (args: EventTableComponentProps) => {
   const { heading, belowHeadingContent, className, eventOptions } = args
-  const { filterByEventTypes, filterByEventGroups, filterByEventTags, maxEvents } =
-    args.dynamicOptions || {}
-  const { staticEvents } = args.staticOptions || {}
+  const { byTypes, byGroups, byTags, maxEvents } = args.dynamicOpts || {}
+  const { staticEvents } = args.staticOpts || {}
 
   const { tenant } = useTenant()
   const [fetchedEvents, setFetchedEvents] = useState<Event[]>([])
@@ -40,23 +39,19 @@ export const EventTableBlockComponent = (args: EventTableComponentProps) => {
           depth: '1',
         })
 
-        if (filterByEventTypes?.length) {
-          params.append('types', filterByEventTypes.join(','))
+        if (byTypes?.length) {
+          params.append('types', byTypes.join(','))
         }
 
-        if (filterByEventGroups?.length) {
-          const groupIds = filterByEventGroups
-            .map((g) => (typeof g === 'object' ? g.id : g))
-            .filter(Boolean)
+        if (byGroups?.length) {
+          const groupIds = byGroups.map((g) => (typeof g === 'object' ? g.id : g)).filter(Boolean)
           if (groupIds.length) {
             params.append('groups', groupIds.join(','))
           }
         }
 
-        if (filterByEventTags?.length) {
-          const tagIds = filterByEventTags
-            .map((t) => (typeof t === 'object' ? t.id : t))
-            .filter(Boolean)
+        if (byTags?.length) {
+          const tagIds = byTags.map((t) => (typeof t === 'object' ? t.id : t)).filter(Boolean)
           if (tagIds.length) {
             params.append('tags', tagIds.join(','))
           }
@@ -82,7 +77,7 @@ export const EventTableBlockComponent = (args: EventTableComponentProps) => {
     }
 
     fetchEvents()
-  }, [eventOptions, filterByEventTypes, filterByEventGroups, filterByEventTags, maxEvents, tenant])
+  }, [eventOptions, byTypes, byGroups, byTags, maxEvents, tenant])
 
   let displayEvents: Event[] = filterValidPublishedRelationships(staticEvents)
 

--- a/src/collections/Courses/index.ts
+++ b/src/collections/Courses/index.ts
@@ -126,7 +126,7 @@ export const Courses: CollectionConfig = {
           const startDate = new Date(data.startDate)
 
           if (registrationDeadline >= startDate) {
-            return `Registration deadline must be before start date. ${registrationDeadline} ${startDate}`
+            return 'Registration deadline must be before start date.'
           }
         }
         return true

--- a/src/collections/Courses/index.ts
+++ b/src/collections/Courses/index.ts
@@ -126,7 +126,7 @@ export const Courses: CollectionConfig = {
           const startDate = new Date(data.startDate)
 
           if (registrationDeadline >= startDate) {
-            return 'Registration deadline must be before start date.'
+            return `Registration deadline must be before start date. ${registrationDeadline} ${startDate}`
           }
         }
         return true

--- a/src/endpoints/seed/blocks/event-list.ts
+++ b/src/endpoints/seed/blocks/event-list.ts
@@ -34,10 +34,10 @@ export const eventListBlock: EventListBlock = {
     },
   },
   eventOptions: 'dynamic',
-  dynamicOptions: {
+  dynamicOpts: {
     maxEvents: 4,
   },
-  staticOptions: {
+  staticOpts: {
     staticEvents: [], // Will be populated with actual event references during seeding
   },
 }

--- a/src/endpoints/seed/courses.ts
+++ b/src/endpoints/seed/courses.ts
@@ -1,6 +1,7 @@
 import { Media, Provider } from '@/payload-types'
 import { US_TIMEZONES } from '@/utilities/timezones'
 import { Payload, RequiredDataFromCollectionSlug } from 'payload'
+import { futureDate } from './utilities'
 
 export const getCoursesData = (
   featuredImage?: Media,
@@ -11,15 +12,6 @@ export const getCoursesData = (
     'Pro Avalanche Training'?: Provider
   },
 ): RequiredDataFromCollectionSlug<'courses'>[] => {
-  // Helper to create dates in the future
-  const futureDate = (monthOffset: number, day: number, hour: number = 18) => {
-    const date = new Date()
-    date.setMonth(date.getMonth() + monthOffset)
-    date.setDate(day)
-    date.setHours(hour, 0, 0, 0)
-    return date.toISOString()
-  }
-
   return [
     // AIARE Rec 1 - Mountain Education Center
     {

--- a/src/endpoints/seed/home-page.ts
+++ b/src/endpoints/seed/home-page.ts
@@ -158,7 +158,7 @@ export const homePage: (
         heading: 'Upcoming Events',
         backgroundColor: 'transparent',
         eventOptions: 'dynamic',
-        dynamicOptions: {
+        dynamicOpts: {
           maxEvents: 4,
         },
       },

--- a/src/endpoints/seed/pages/all-blocks-page.ts
+++ b/src/endpoints/seed/pages/all-blocks-page.ts
@@ -62,14 +62,14 @@ export const allBlocksPage: (
       {
         ...eventListBlock,
         eventOptions: 'dynamic',
-        dynamicOptions: {
+        dynamicOpts: {
           maxEvents: 4,
         },
       },
       {
         ...eventListBlock,
         eventOptions: 'static',
-        staticOptions: {
+        staticOpts: {
           staticEvents: events.slice(0, 3).map((event) => event.id), // Use first 3 events
         },
       },
@@ -86,10 +86,10 @@ export const allBlocksPage: (
         blockName: '',
         eventOptions: 'dynamic',
 
-        dynamicOptions: {
+        dynamicOpts: {
           maxEvents: 6,
         },
-        staticOptions: {
+        staticOpts: {
           staticEvents: [],
         },
         blockType: 'eventTable',

--- a/src/endpoints/seed/utilities.ts
+++ b/src/endpoints/seed/utilities.ts
@@ -93,8 +93,9 @@ export async function getSeedImageByFilename(filename: string, logger: Logger) {
 
 export const pastDate = (monthOffset: number, day: number, hour: number = 18) => {
   const date = new Date()
-  date.setMonth(date.getMonth() - monthOffset)
-  date.setDate(day)
+  const newMonth = date.getMonth() - monthOffset
+  const newYear = date.getFullYear() + Math.floor(newMonth / 12)
+  date.setFullYear(newYear, ((newMonth % 12) + 12) % 12, day)
   date.setHours(hour, 0, 0, 0)
   return date.toISOString()
 }
@@ -102,8 +103,9 @@ export const pastDate = (monthOffset: number, day: number, hour: number = 18) =>
 // Helper to create dates in the future
 export const futureDate = (monthOffset: number, day: number, hour: number = 18) => {
   const date = new Date()
-  date.setMonth(date.getMonth() + monthOffset)
-  date.setDate(day)
+  const newMonth = date.getMonth() + monthOffset
+  const newYear = date.getFullYear() + Math.floor(newMonth / 12)
+  date.setFullYear(newYear, newMonth % 12, day)
   date.setHours(hour, 0, 0, 0)
   return date.toISOString()
 }

--- a/src/fields/EventQuery/config.ts
+++ b/src/fields/EventQuery/config.ts
@@ -39,16 +39,16 @@ export const defaultStylingFields = (additionalFilters?: Field[]): Field[] => [
   {
     type: 'radio',
     name: 'eventOptions',
-    label: 'How do you want to choose your events?',
+    label: 'How do you want to select your events?',
     defaultValue: 'dynamic',
     required: true,
     options: [
       {
-        label: 'Do it for me',
+        label: 'Use filters',
         value: 'dynamic',
       },
       {
-        label: 'Let me choose',
+        label: 'Manually',
         value: 'static',
       },
     ],
@@ -57,8 +57,9 @@ export const defaultStylingFields = (additionalFilters?: Field[]): Field[] => [
 
 export const dynamicEventRelatedFields = (additionalFilters?: Field[]): Field[] => [
   {
-    name: 'dynamicOptions',
+    name: 'dynamicOpts',
     type: 'group',
+    label: 'Filter options',
     admin: {
       condition: (_, siblingData) => siblingData?.eventOptions === 'dynamic',
       description: 'Use Preview ↗ to see how events will appear',
@@ -66,9 +67,8 @@ export const dynamicEventRelatedFields = (additionalFilters?: Field[]): Field[] 
     fields: [
       ...(additionalFilters ?? []),
       {
-        name: 'filterByEventTypes',
+        name: 'byTypes',
         type: 'select',
-        dbName: 'filterByEventTypes',
         options: eventTypesData.map((type, index) => ({
           key: `${type.value}-${index}`,
           label: type.label,
@@ -81,7 +81,7 @@ export const dynamicEventRelatedFields = (additionalFilters?: Field[]): Field[] 
         },
       },
       {
-        name: 'filterByEventGroups',
+        name: 'byGroups',
         type: 'relationship',
         relationTo: 'eventGroups',
         hasMany: true,
@@ -92,7 +92,7 @@ export const dynamicEventRelatedFields = (additionalFilters?: Field[]): Field[] 
         filterOptions: getTenantFilter,
       },
       {
-        name: 'filterByEventTags',
+        name: 'byTags',
         type: 'relationship',
         relationTo: 'eventTags',
         hasMany: true,
@@ -123,8 +123,9 @@ export const dynamicEventRelatedFields = (additionalFilters?: Field[]): Field[] 
 
 export const staticEventRelatedFields: Field[] = [
   {
-    name: 'staticOptions',
+    name: 'staticOpts',
     type: 'group',
+    label: 'Select events',
     admin: {
       condition: (_, siblingData) => siblingData?.eventOptions === 'static',
     },

--- a/src/fields/EventQuery/config.ts
+++ b/src/fields/EventQuery/config.ts
@@ -83,6 +83,7 @@ export const dynamicEventRelatedFields = (additionalFilters?: Field[]): Field[] 
       {
         name: 'byGroups',
         type: 'relationship',
+        label: 'Filter by Event Group(s)',
         relationTo: 'eventGroups',
         hasMany: true,
         admin: {
@@ -94,6 +95,7 @@ export const dynamicEventRelatedFields = (additionalFilters?: Field[]): Field[] 
       {
         name: 'byTags',
         type: 'relationship',
+        label: 'Filter by Event Tag(s)',
         relationTo: 'eventTags',
         hasMany: true,
         admin: {

--- a/src/migrations/20251121_174744_add_courses_and_events.json
+++ b/src/migrations/20251121_174744_add_courses_and_events.json
@@ -714,8 +714,8 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
-    "filterByEventTypes": {
-      "name": "filterByEventTypes",
+    "home_pages_blocks_event_list_dynamic_opts_by_types": {
+      "name": "home_pages_blocks_event_list_dynamic_opts_by_types",
       "columns": {
         "order": {
           "name": "order",
@@ -747,22 +747,22 @@
         }
       },
       "indexes": {
-        "filterByEventTypes_order_idx": {
-          "name": "filterByEventTypes_order_idx",
+        "home_pages_blocks_event_list_dynamic_opts_by_types_order_idx": {
+          "name": "home_pages_blocks_event_list_dynamic_opts_by_types_order_idx",
           "columns": ["order"],
           "isUnique": false
         },
-        "filterByEventTypes_parent_idx": {
-          "name": "filterByEventTypes_parent_idx",
+        "home_pages_blocks_event_list_dynamic_opts_by_types_parent_idx": {
+          "name": "home_pages_blocks_event_list_dynamic_opts_by_types_parent_idx",
           "columns": ["parent_id"],
           "isUnique": false
         }
       },
       "foreignKeys": {
-        "filterByEventTypes_parent_fk": {
-          "name": "filterByEventTypes_parent_fk",
-          "tableFrom": "filterByEventTypes",
-          "tableTo": "pages_blocks_event_table",
+        "home_pages_blocks_event_list_dynamic_opts_by_types_parent_fk": {
+          "name": "home_pages_blocks_event_list_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "home_pages_blocks_event_list_dynamic_opts_by_types",
+          "tableTo": "home_pages_blocks_event_list",
           "columnsFrom": ["parent_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
@@ -834,8 +834,8 @@
           "autoincrement": false,
           "default": "'dynamic'"
         },
-        "dynamic_options_max_events": {
-          "name": "dynamic_options_max_events",
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
           "type": "numeric",
           "primaryKey": false,
           "notNull": false,
@@ -982,6 +982,65 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
+    "home_pages_blocks_event_table_dynamic_opts_by_types": {
+      "name": "home_pages_blocks_event_table_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_event_table_dynamic_opts_by_types_order_idx": {
+          "name": "home_pages_blocks_event_table_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_event_table_dynamic_opts_by_types_parent_idx": {
+          "name": "home_pages_blocks_event_table_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_event_table_dynamic_opts_by_types_parent_fk": {
+          "name": "home_pages_blocks_event_table_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "home_pages_blocks_event_table_dynamic_opts_by_types",
+          "tableTo": "home_pages_blocks_event_table",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "home_pages_blocks_event_table": {
       "name": "home_pages_blocks_event_table",
       "columns": {
@@ -1035,8 +1094,8 @@
           "autoincrement": false,
           "default": "'dynamic'"
         },
-        "dynamic_options_max_events": {
-          "name": "dynamic_options_max_events",
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
           "type": "numeric",
           "primaryKey": false,
           "notNull": false,
@@ -3662,8 +3721,8 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
-    "_filterByEventTypes_v": {
-      "name": "_filterByEventTypes_v",
+    "_home_pages_v_blocks_event_list_dynamic_opts_by_types": {
+      "name": "_home_pages_v_blocks_event_list_dynamic_opts_by_types",
       "columns": {
         "order": {
           "name": "order",
@@ -3695,22 +3754,22 @@
         }
       },
       "indexes": {
-        "_filterByEventTypes_v_order_idx": {
-          "name": "_filterByEventTypes_v_order_idx",
+        "_home_pages_v_blocks_event_list_dynamic_opts_by_types_order_idx": {
+          "name": "_home_pages_v_blocks_event_list_dynamic_opts_by_types_order_idx",
           "columns": ["order"],
           "isUnique": false
         },
-        "_filterByEventTypes_v_parent_idx": {
-          "name": "_filterByEventTypes_v_parent_idx",
+        "_home_pages_v_blocks_event_list_dynamic_opts_by_types_parent_idx": {
+          "name": "_home_pages_v_blocks_event_list_dynamic_opts_by_types_parent_idx",
           "columns": ["parent_id"],
           "isUnique": false
         }
       },
       "foreignKeys": {
-        "_filterByEventTypes_v_parent_fk": {
-          "name": "_filterByEventTypes_v_parent_fk",
-          "tableFrom": "_filterByEventTypes_v",
-          "tableTo": "_pages_v_blocks_event_table",
+        "_home_pages_v_blocks_event_list_dynamic_opts_by_types_parent_fk": {
+          "name": "_home_pages_v_blocks_event_list_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "_home_pages_v_blocks_event_list_dynamic_opts_by_types",
+          "tableTo": "_home_pages_v_blocks_event_list",
           "columnsFrom": ["parent_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
@@ -3782,8 +3841,8 @@
           "autoincrement": false,
           "default": "'dynamic'"
         },
-        "dynamic_options_max_events": {
-          "name": "dynamic_options_max_events",
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
           "type": "numeric",
           "primaryKey": false,
           "notNull": false,
@@ -3944,6 +4003,65 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
+    "_home_pages_v_blocks_event_table_dynamic_opts_by_types": {
+      "name": "_home_pages_v_blocks_event_table_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_event_table_dynamic_opts_by_types_order_idx": {
+          "name": "_home_pages_v_blocks_event_table_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_event_table_dynamic_opts_by_types_parent_idx": {
+          "name": "_home_pages_v_blocks_event_table_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_event_table_dynamic_opts_by_types_parent_fk": {
+          "name": "_home_pages_v_blocks_event_table_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "_home_pages_v_blocks_event_table_dynamic_opts_by_types",
+          "tableTo": "_home_pages_v_blocks_event_table",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "_home_pages_v_blocks_event_table": {
       "name": "_home_pages_v_blocks_event_table",
       "columns": {
@@ -3997,8 +4115,8 @@
           "autoincrement": false,
           "default": "'dynamic'"
         },
-        "dynamic_options_max_events": {
-          "name": "dynamic_options_max_events",
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
           "type": "numeric",
           "primaryKey": false,
           "notNull": false,
@@ -6696,6 +6814,65 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
+    "pages_blocks_event_list_dynamic_opts_by_types": {
+      "name": "pages_blocks_event_list_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_event_list_dynamic_opts_by_types_order_idx": {
+          "name": "pages_blocks_event_list_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "pages_blocks_event_list_dynamic_opts_by_types_parent_idx": {
+          "name": "pages_blocks_event_list_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_event_list_dynamic_opts_by_types_parent_fk": {
+          "name": "pages_blocks_event_list_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "pages_blocks_event_list_dynamic_opts_by_types",
+          "tableTo": "pages_blocks_event_list",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "pages_blocks_event_list": {
       "name": "pages_blocks_event_list",
       "columns": {
@@ -6757,8 +6934,8 @@
           "autoincrement": false,
           "default": "'dynamic'"
         },
-        "dynamic_options_max_events": {
-          "name": "dynamic_options_max_events",
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
           "type": "numeric",
           "primaryKey": false,
           "notNull": false,
@@ -6796,6 +6973,65 @@
           "tableFrom": "pages_blocks_event_list",
           "tableTo": "pages",
           "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_event_table_dynamic_opts_by_types": {
+      "name": "pages_blocks_event_table_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_event_table_dynamic_opts_by_types_order_idx": {
+          "name": "pages_blocks_event_table_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "pages_blocks_event_table_dynamic_opts_by_types_parent_idx": {
+          "name": "pages_blocks_event_table_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_event_table_dynamic_opts_by_types_parent_fk": {
+          "name": "pages_blocks_event_table_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "pages_blocks_event_table_dynamic_opts_by_types",
+          "tableTo": "pages_blocks_event_table",
+          "columnsFrom": ["parent_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -6858,8 +7094,8 @@
           "autoincrement": false,
           "default": "'dynamic'"
         },
-        "dynamic_options_max_events": {
-          "name": "dynamic_options_max_events",
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
           "type": "numeric",
           "primaryKey": false,
           "notNull": false,
@@ -9382,6 +9618,65 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
+    "_pages_v_blocks_event_list_dynamic_opts_by_types": {
+      "name": "_pages_v_blocks_event_list_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_event_list_dynamic_opts_by_types_order_idx": {
+          "name": "_pages_v_blocks_event_list_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_event_list_dynamic_opts_by_types_parent_idx": {
+          "name": "_pages_v_blocks_event_list_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_event_list_dynamic_opts_by_types_parent_fk": {
+          "name": "_pages_v_blocks_event_list_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "_pages_v_blocks_event_list_dynamic_opts_by_types",
+          "tableTo": "_pages_v_blocks_event_list",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "_pages_v_blocks_event_list": {
       "name": "_pages_v_blocks_event_list",
       "columns": {
@@ -9443,8 +9738,8 @@
           "autoincrement": false,
           "default": "'dynamic'"
         },
-        "dynamic_options_max_events": {
-          "name": "dynamic_options_max_events",
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
           "type": "numeric",
           "primaryKey": false,
           "notNull": false,
@@ -9489,6 +9784,65 @@
           "tableFrom": "_pages_v_blocks_event_list",
           "tableTo": "_pages_v",
           "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_event_table_dynamic_opts_by_types": {
+      "name": "_pages_v_blocks_event_table_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_event_table_dynamic_opts_by_types_order_idx": {
+          "name": "_pages_v_blocks_event_table_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_event_table_dynamic_opts_by_types_parent_idx": {
+          "name": "_pages_v_blocks_event_table_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_event_table_dynamic_opts_by_types_parent_fk": {
+          "name": "_pages_v_blocks_event_table_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "_pages_v_blocks_event_table_dynamic_opts_by_types",
+          "tableTo": "_pages_v_blocks_event_table",
+          "columnsFrom": ["parent_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -9551,8 +9905,8 @@
           "autoincrement": false,
           "default": "'dynamic'"
         },
-        "dynamic_options_max_events": {
-          "name": "dynamic_options_max_events",
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
           "type": "numeric",
           "primaryKey": false,
           "notNull": false,
@@ -13715,8 +14069,8 @@
           "notNull": false,
           "autoincrement": false
         },
-        "skill_rating": {
-          "name": "skill_rating",
+        "skill_level": {
+          "name": "skill_level",
           "type": "text",
           "primaryKey": false,
           "notNull": false,
@@ -14263,8 +14617,8 @@
           "notNull": false,
           "autoincrement": false
         },
-        "version_skill_rating": {
-          "name": "version_skill_rating",
+        "version_skill_level": {
+          "name": "version_skill_level",
           "type": "text",
           "primaryKey": false,
           "notNull": false,
@@ -23540,6 +23894,6 @@
   "internal": {
     "indexes": {}
   },
-  "id": "f624bf14-b01e-4803-b560-72a344e8fca7",
+  "id": "b45b232f-95c7-45e3-90f1-7fd0bdabee71",
   "prevId": "00000000-0000-0000-0000-000000000000"
 }

--- a/src/migrations/20251121_174744_add_courses_and_events.ts
+++ b/src/migrations/20251121_174744_add_courses_and_events.ts
@@ -1,19 +1,19 @@
 import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-sqlite'
 
 export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
-  await db.run(sql`CREATE TABLE \`filterByEventTypes\` (
+  await db.run(sql`CREATE TABLE \`home_pages_blocks_event_list_dynamic_opts_by_types\` (
   	\`order\` integer NOT NULL,
   	\`parent_id\` text NOT NULL,
   	\`value\` text,
   	\`id\` integer PRIMARY KEY NOT NULL,
-  	FOREIGN KEY (\`parent_id\`) REFERENCES \`pages_blocks_event_table\`(\`id\`) ON UPDATE no action ON DELETE cascade
+  	FOREIGN KEY (\`parent_id\`) REFERENCES \`home_pages_blocks_event_list\`(\`id\`) ON UPDATE no action ON DELETE cascade
   );
   `)
   await db.run(
-    sql`CREATE INDEX \`filterByEventTypes_order_idx\` ON \`filterByEventTypes\` (\`order\`);`,
+    sql`CREATE INDEX \`home_pages_blocks_event_list_dynamic_opts_by_types_order_idx\` ON \`home_pages_blocks_event_list_dynamic_opts_by_types\` (\`order\`);`,
   )
   await db.run(
-    sql`CREATE INDEX \`filterByEventTypes_parent_idx\` ON \`filterByEventTypes\` (\`parent_id\`);`,
+    sql`CREATE INDEX \`home_pages_blocks_event_list_dynamic_opts_by_types_parent_idx\` ON \`home_pages_blocks_event_list_dynamic_opts_by_types\` (\`parent_id\`);`,
   )
   await db.run(sql`CREATE TABLE \`home_pages_blocks_event_list\` (
   	\`_order\` integer NOT NULL,
@@ -24,7 +24,7 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   	\`heading\` text,
   	\`below_heading_content\` text,
   	\`event_options\` text DEFAULT 'dynamic',
-  	\`dynamic_options_max_events\` numeric DEFAULT 4,
+  	\`dynamic_opts_max_events\` numeric DEFAULT 4,
   	\`block_name\` text,
   	FOREIGN KEY (\`_parent_id\`) REFERENCES \`home_pages\`(\`id\`) ON UPDATE no action ON DELETE cascade
   );
@@ -62,6 +62,20 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   await db.run(
     sql`CREATE INDEX \`home_pages_blocks_single_event_event_idx\` ON \`home_pages_blocks_single_event\` (\`event_id\`);`,
   )
+  await db.run(sql`CREATE TABLE \`home_pages_blocks_event_table_dynamic_opts_by_types\` (
+  	\`order\` integer NOT NULL,
+  	\`parent_id\` text NOT NULL,
+  	\`value\` text,
+  	\`id\` integer PRIMARY KEY NOT NULL,
+  	FOREIGN KEY (\`parent_id\`) REFERENCES \`home_pages_blocks_event_table\`(\`id\`) ON UPDATE no action ON DELETE cascade
+  );
+  `)
+  await db.run(
+    sql`CREATE INDEX \`home_pages_blocks_event_table_dynamic_opts_by_types_order_idx\` ON \`home_pages_blocks_event_table_dynamic_opts_by_types\` (\`order\`);`,
+  )
+  await db.run(
+    sql`CREATE INDEX \`home_pages_blocks_event_table_dynamic_opts_by_types_parent_idx\` ON \`home_pages_blocks_event_table_dynamic_opts_by_types\` (\`parent_id\`);`,
+  )
   await db.run(sql`CREATE TABLE \`home_pages_blocks_event_table\` (
   	\`_order\` integer NOT NULL,
   	\`_parent_id\` integer NOT NULL,
@@ -70,7 +84,7 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   	\`heading\` text,
   	\`below_heading_content\` text,
   	\`event_options\` text DEFAULT 'dynamic',
-  	\`dynamic_options_max_events\` numeric DEFAULT 4,
+  	\`dynamic_opts_max_events\` numeric DEFAULT 4,
   	\`block_name\` text,
   	FOREIGN KEY (\`_parent_id\`) REFERENCES \`home_pages\`(\`id\`) ON UPDATE no action ON DELETE cascade
   );
@@ -84,19 +98,19 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   await db.run(
     sql`CREATE INDEX \`home_pages_blocks_event_table_path_idx\` ON \`home_pages_blocks_event_table\` (\`_path\`);`,
   )
-  await db.run(sql`CREATE TABLE \`_filterByEventTypes_v\` (
+  await db.run(sql`CREATE TABLE \`_home_pages_v_blocks_event_list_dynamic_opts_by_types\` (
   	\`order\` integer NOT NULL,
   	\`parent_id\` integer NOT NULL,
   	\`value\` text,
   	\`id\` integer PRIMARY KEY NOT NULL,
-  	FOREIGN KEY (\`parent_id\`) REFERENCES \`_pages_v_blocks_event_table\`(\`id\`) ON UPDATE no action ON DELETE cascade
+  	FOREIGN KEY (\`parent_id\`) REFERENCES \`_home_pages_v_blocks_event_list\`(\`id\`) ON UPDATE no action ON DELETE cascade
   );
   `)
   await db.run(
-    sql`CREATE INDEX \`_filterByEventTypes_v_order_idx\` ON \`_filterByEventTypes_v\` (\`order\`);`,
+    sql`CREATE INDEX \`_home_pages_v_blocks_event_list_dynamic_opts_by_types_order_idx\` ON \`_home_pages_v_blocks_event_list_dynamic_opts_by_types\` (\`order\`);`,
   )
   await db.run(
-    sql`CREATE INDEX \`_filterByEventTypes_v_parent_idx\` ON \`_filterByEventTypes_v\` (\`parent_id\`);`,
+    sql`CREATE INDEX \`_home_pages_v_blocks_event_list_dynamic_opts_by_types_parent_idx\` ON \`_home_pages_v_blocks_event_list_dynamic_opts_by_types\` (\`parent_id\`);`,
   )
   await db.run(sql`CREATE TABLE \`_home_pages_v_blocks_event_list\` (
   	\`_order\` integer NOT NULL,
@@ -107,7 +121,7 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   	\`heading\` text,
   	\`below_heading_content\` text,
   	\`event_options\` text DEFAULT 'dynamic',
-  	\`dynamic_options_max_events\` numeric DEFAULT 4,
+  	\`dynamic_opts_max_events\` numeric DEFAULT 4,
   	\`_uuid\` text,
   	\`block_name\` text,
   	FOREIGN KEY (\`_parent_id\`) REFERENCES \`_home_pages_v\`(\`id\`) ON UPDATE no action ON DELETE cascade
@@ -147,6 +161,20 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   await db.run(
     sql`CREATE INDEX \`_home_pages_v_blocks_single_event_event_idx\` ON \`_home_pages_v_blocks_single_event\` (\`event_id\`);`,
   )
+  await db.run(sql`CREATE TABLE \`_home_pages_v_blocks_event_table_dynamic_opts_by_types\` (
+  	\`order\` integer NOT NULL,
+  	\`parent_id\` integer NOT NULL,
+  	\`value\` text,
+  	\`id\` integer PRIMARY KEY NOT NULL,
+  	FOREIGN KEY (\`parent_id\`) REFERENCES \`_home_pages_v_blocks_event_table\`(\`id\`) ON UPDATE no action ON DELETE cascade
+  );
+  `)
+  await db.run(
+    sql`CREATE INDEX \`_home_pages_v_blocks_event_table_dynamic_opts_by_types_order_idx\` ON \`_home_pages_v_blocks_event_table_dynamic_opts_by_types\` (\`order\`);`,
+  )
+  await db.run(
+    sql`CREATE INDEX \`_home_pages_v_blocks_event_table_dynamic_opts_by_types_parent_idx\` ON \`_home_pages_v_blocks_event_table_dynamic_opts_by_types\` (\`parent_id\`);`,
+  )
   await db.run(sql`CREATE TABLE \`_home_pages_v_blocks_event_table\` (
   	\`_order\` integer NOT NULL,
   	\`_parent_id\` integer NOT NULL,
@@ -155,7 +183,7 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   	\`heading\` text,
   	\`below_heading_content\` text,
   	\`event_options\` text DEFAULT 'dynamic',
-  	\`dynamic_options_max_events\` numeric DEFAULT 4,
+  	\`dynamic_opts_max_events\` numeric DEFAULT 4,
   	\`_uuid\` text,
   	\`block_name\` text,
   	FOREIGN KEY (\`_parent_id\`) REFERENCES \`_home_pages_v\`(\`id\`) ON UPDATE no action ON DELETE cascade
@@ -170,6 +198,20 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   await db.run(
     sql`CREATE INDEX \`_home_pages_v_blocks_event_table_path_idx\` ON \`_home_pages_v_blocks_event_table\` (\`_path\`);`,
   )
+  await db.run(sql`CREATE TABLE \`pages_blocks_event_list_dynamic_opts_by_types\` (
+  	\`order\` integer NOT NULL,
+  	\`parent_id\` text NOT NULL,
+  	\`value\` text,
+  	\`id\` integer PRIMARY KEY NOT NULL,
+  	FOREIGN KEY (\`parent_id\`) REFERENCES \`pages_blocks_event_list\`(\`id\`) ON UPDATE no action ON DELETE cascade
+  );
+  `)
+  await db.run(
+    sql`CREATE INDEX \`pages_blocks_event_list_dynamic_opts_by_types_order_idx\` ON \`pages_blocks_event_list_dynamic_opts_by_types\` (\`order\`);`,
+  )
+  await db.run(
+    sql`CREATE INDEX \`pages_blocks_event_list_dynamic_opts_by_types_parent_idx\` ON \`pages_blocks_event_list_dynamic_opts_by_types\` (\`parent_id\`);`,
+  )
   await db.run(sql`CREATE TABLE \`pages_blocks_event_list\` (
   	\`_order\` integer NOT NULL,
   	\`_parent_id\` integer NOT NULL,
@@ -179,7 +221,7 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   	\`heading\` text,
   	\`below_heading_content\` text,
   	\`event_options\` text DEFAULT 'dynamic',
-  	\`dynamic_options_max_events\` numeric DEFAULT 4,
+  	\`dynamic_opts_max_events\` numeric DEFAULT 4,
   	\`block_name\` text,
   	FOREIGN KEY (\`_parent_id\`) REFERENCES \`pages\`(\`id\`) ON UPDATE no action ON DELETE cascade
   );
@@ -193,6 +235,20 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   await db.run(
     sql`CREATE INDEX \`pages_blocks_event_list_path_idx\` ON \`pages_blocks_event_list\` (\`_path\`);`,
   )
+  await db.run(sql`CREATE TABLE \`pages_blocks_event_table_dynamic_opts_by_types\` (
+  	\`order\` integer NOT NULL,
+  	\`parent_id\` text NOT NULL,
+  	\`value\` text,
+  	\`id\` integer PRIMARY KEY NOT NULL,
+  	FOREIGN KEY (\`parent_id\`) REFERENCES \`pages_blocks_event_table\`(\`id\`) ON UPDATE no action ON DELETE cascade
+  );
+  `)
+  await db.run(
+    sql`CREATE INDEX \`pages_blocks_event_table_dynamic_opts_by_types_order_idx\` ON \`pages_blocks_event_table_dynamic_opts_by_types\` (\`order\`);`,
+  )
+  await db.run(
+    sql`CREATE INDEX \`pages_blocks_event_table_dynamic_opts_by_types_parent_idx\` ON \`pages_blocks_event_table_dynamic_opts_by_types\` (\`parent_id\`);`,
+  )
   await db.run(sql`CREATE TABLE \`pages_blocks_event_table\` (
   	\`_order\` integer NOT NULL,
   	\`_parent_id\` integer NOT NULL,
@@ -201,7 +257,7 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   	\`heading\` text,
   	\`below_heading_content\` text,
   	\`event_options\` text DEFAULT 'dynamic',
-  	\`dynamic_options_max_events\` numeric DEFAULT 4,
+  	\`dynamic_opts_max_events\` numeric DEFAULT 4,
   	\`block_name\` text,
   	FOREIGN KEY (\`_parent_id\`) REFERENCES \`pages\`(\`id\`) ON UPDATE no action ON DELETE cascade
   );
@@ -239,6 +295,20 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   await db.run(
     sql`CREATE INDEX \`pages_blocks_single_event_event_idx\` ON \`pages_blocks_single_event\` (\`event_id\`);`,
   )
+  await db.run(sql`CREATE TABLE \`_pages_v_blocks_event_list_dynamic_opts_by_types\` (
+  	\`order\` integer NOT NULL,
+  	\`parent_id\` integer NOT NULL,
+  	\`value\` text,
+  	\`id\` integer PRIMARY KEY NOT NULL,
+  	FOREIGN KEY (\`parent_id\`) REFERENCES \`_pages_v_blocks_event_list\`(\`id\`) ON UPDATE no action ON DELETE cascade
+  );
+  `)
+  await db.run(
+    sql`CREATE INDEX \`_pages_v_blocks_event_list_dynamic_opts_by_types_order_idx\` ON \`_pages_v_blocks_event_list_dynamic_opts_by_types\` (\`order\`);`,
+  )
+  await db.run(
+    sql`CREATE INDEX \`_pages_v_blocks_event_list_dynamic_opts_by_types_parent_idx\` ON \`_pages_v_blocks_event_list_dynamic_opts_by_types\` (\`parent_id\`);`,
+  )
   await db.run(sql`CREATE TABLE \`_pages_v_blocks_event_list\` (
   	\`_order\` integer NOT NULL,
   	\`_parent_id\` integer NOT NULL,
@@ -248,7 +318,7 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   	\`heading\` text,
   	\`below_heading_content\` text,
   	\`event_options\` text DEFAULT 'dynamic',
-  	\`dynamic_options_max_events\` numeric DEFAULT 4,
+  	\`dynamic_opts_max_events\` numeric DEFAULT 4,
   	\`_uuid\` text,
   	\`block_name\` text,
   	FOREIGN KEY (\`_parent_id\`) REFERENCES \`_pages_v\`(\`id\`) ON UPDATE no action ON DELETE cascade
@@ -263,6 +333,20 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   await db.run(
     sql`CREATE INDEX \`_pages_v_blocks_event_list_path_idx\` ON \`_pages_v_blocks_event_list\` (\`_path\`);`,
   )
+  await db.run(sql`CREATE TABLE \`_pages_v_blocks_event_table_dynamic_opts_by_types\` (
+  	\`order\` integer NOT NULL,
+  	\`parent_id\` integer NOT NULL,
+  	\`value\` text,
+  	\`id\` integer PRIMARY KEY NOT NULL,
+  	FOREIGN KEY (\`parent_id\`) REFERENCES \`_pages_v_blocks_event_table\`(\`id\`) ON UPDATE no action ON DELETE cascade
+  );
+  `)
+  await db.run(
+    sql`CREATE INDEX \`_pages_v_blocks_event_table_dynamic_opts_by_types_order_idx\` ON \`_pages_v_blocks_event_table_dynamic_opts_by_types\` (\`order\`);`,
+  )
+  await db.run(
+    sql`CREATE INDEX \`_pages_v_blocks_event_table_dynamic_opts_by_types_parent_idx\` ON \`_pages_v_blocks_event_table_dynamic_opts_by_types\` (\`parent_id\`);`,
+  )
   await db.run(sql`CREATE TABLE \`_pages_v_blocks_event_table\` (
   	\`_order\` integer NOT NULL,
   	\`_parent_id\` integer NOT NULL,
@@ -271,7 +355,7 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   	\`heading\` text,
   	\`below_heading_content\` text,
   	\`event_options\` text DEFAULT 'dynamic',
-  	\`dynamic_options_max_events\` numeric DEFAULT 4,
+  	\`dynamic_opts_max_events\` numeric DEFAULT 4,
   	\`_uuid\` text,
   	\`block_name\` text,
   	FOREIGN KEY (\`_parent_id\`) REFERENCES \`_pages_v\`(\`id\`) ON UPDATE no action ON DELETE cascade
@@ -364,7 +448,7 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   	\`registration_url\` text,
   	\`external_event_url\` text,
   	\`registration_deadline\` text,
-  	\`skill_rating\` text,
+  	\`skill_level\` text,
   	\`content\` text,
   	\`slug\` text,
   	\`type\` text,
@@ -465,7 +549,7 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   	\`version_registration_url\` text,
   	\`version_external_event_url\` text,
   	\`version_registration_deadline\` text,
-  	\`version_skill_rating\` text,
+  	\`version_skill_level\` text,
   	\`version_content\` text,
   	\`version_slug\` text,
   	\`version_type\` text,
@@ -963,18 +1047,24 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
 }
 
 export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
-  await db.run(sql`DROP TABLE \`filterByEventTypes\`;`)
+  await db.run(sql`DROP TABLE \`home_pages_blocks_event_list_dynamic_opts_by_types\`;`)
   await db.run(sql`DROP TABLE \`home_pages_blocks_event_list\`;`)
   await db.run(sql`DROP TABLE \`home_pages_blocks_single_event\`;`)
+  await db.run(sql`DROP TABLE \`home_pages_blocks_event_table_dynamic_opts_by_types\`;`)
   await db.run(sql`DROP TABLE \`home_pages_blocks_event_table\`;`)
-  await db.run(sql`DROP TABLE \`_filterByEventTypes_v\`;`)
+  await db.run(sql`DROP TABLE \`_home_pages_v_blocks_event_list_dynamic_opts_by_types\`;`)
   await db.run(sql`DROP TABLE \`_home_pages_v_blocks_event_list\`;`)
   await db.run(sql`DROP TABLE \`_home_pages_v_blocks_single_event\`;`)
+  await db.run(sql`DROP TABLE \`_home_pages_v_blocks_event_table_dynamic_opts_by_types\`;`)
   await db.run(sql`DROP TABLE \`_home_pages_v_blocks_event_table\`;`)
+  await db.run(sql`DROP TABLE \`pages_blocks_event_list_dynamic_opts_by_types\`;`)
   await db.run(sql`DROP TABLE \`pages_blocks_event_list\`;`)
+  await db.run(sql`DROP TABLE \`pages_blocks_event_table_dynamic_opts_by_types\`;`)
   await db.run(sql`DROP TABLE \`pages_blocks_event_table\`;`)
   await db.run(sql`DROP TABLE \`pages_blocks_single_event\`;`)
+  await db.run(sql`DROP TABLE \`_pages_v_blocks_event_list_dynamic_opts_by_types\`;`)
   await db.run(sql`DROP TABLE \`_pages_v_blocks_event_list\`;`)
+  await db.run(sql`DROP TABLE \`_pages_v_blocks_event_table_dynamic_opts_by_types\`;`)
   await db.run(sql`DROP TABLE \`_pages_v_blocks_event_table\`;`)
   await db.run(sql`DROP TABLE \`_pages_v_blocks_single_event\`;`)
   await db.run(sql`DROP TABLE \`events_blocks_in_content\`;`)

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -717,25 +717,25 @@ export interface EventListBlock {
   /**
    * Use Preview ↗ to see how events will appear
    */
-  dynamicOptions?: {
+  dynamicOpts?: {
     /**
      * Optionally select event types to filter events.
      */
-    filterByEventTypes?: ('event' | 'awareness' | 'field-class')[] | null;
+    byTypes?: ('event' | 'awareness' | 'field-class')[] | null;
     /**
      * Optionally select event group to filter events.
      */
-    filterByEventGroups?: (number | EventGroup)[] | null;
+    byGroups?: (number | EventGroup)[] | null;
     /**
      * Optionally select event tags to filter events.
      */
-    filterByEventTags?: (number | EventTag)[] | null;
+    byTags?: (number | EventTag)[] | null;
     /**
      * Maximum number of events that will be displayed. Must be an integer.
      */
     maxEvents?: number | null;
   };
-  staticOptions?: {
+  staticOpts?: {
     /**
      * Choose new event from dropdown and/or drag and drop to change order
      */
@@ -978,25 +978,25 @@ export interface EventTableBlock {
   /**
    * Use Preview ↗ to see how events will appear
    */
-  dynamicOptions?: {
+  dynamicOpts?: {
     /**
      * Optionally select event types to filter events.
      */
-    filterByEventTypes?: ('event' | 'awareness' | 'field-class')[] | null;
+    byTypes?: ('event' | 'awareness' | 'field-class')[] | null;
     /**
      * Optionally select event group to filter events.
      */
-    filterByEventGroups?: (number | EventGroup)[] | null;
+    byGroups?: (number | EventGroup)[] | null;
     /**
      * Optionally select event tags to filter events.
      */
-    filterByEventTags?: (number | EventTag)[] | null;
+    byTags?: (number | EventTag)[] | null;
     /**
      * Maximum number of events that will be displayed. Must be an integer.
      */
     maxEvents?: number | null;
   };
-  staticOptions?: {
+  staticOpts?: {
     /**
      * Choose new event from dropdown and/or drag and drop to change order
      */
@@ -2921,15 +2921,15 @@ export interface EventListBlockSelect<T extends boolean = true> {
   heading?: T;
   belowHeadingContent?: T;
   eventOptions?: T;
-  dynamicOptions?:
+  dynamicOpts?:
     | T
     | {
-        filterByEventTypes?: T;
-        filterByEventGroups?: T;
-        filterByEventTags?: T;
+        byTypes?: T;
+        byGroups?: T;
+        byTags?: T;
         maxEvents?: T;
       };
-  staticOptions?:
+  staticOpts?:
     | T
     | {
         staticEvents?: T;
@@ -2955,15 +2955,15 @@ export interface EventTableBlockSelect<T extends boolean = true> {
   heading?: T;
   belowHeadingContent?: T;
   eventOptions?: T;
-  dynamicOptions?:
+  dynamicOpts?:
     | T
     | {
-        filterByEventTypes?: T;
-        filterByEventGroups?: T;
-        filterByEventTags?: T;
+        byTypes?: T;
+        byGroups?: T;
+        byTags?: T;
         maxEvents?: T;
       };
-  staticOptions?:
+  staticOpts?:
     | T
     | {
         staticEvents?: T;


### PR DESCRIPTION
## Description
Shortens database names to avoid using `dbName` which was causing a foreign key error
https://github.com/payloadcms/payload/issues/14350

Fixes `futureDate` and `pastDate` seed functions

## Related Issues
Fixes #714 

## Key Changes
- Shorten db names
- `futureDate` and `pastDate` functions were erroring out because the month offset was trying to set months to 13 & 14 which don't exist. I fixed this by adding a mod function and year to wrap the dates. 

## Migration Explanation
Need migration to update names
