### PR TITLE
Setting engines.node to 22.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "typescript": "5.7.2"
   },
   "engines": {
-    "node": "^18.20.2 || >=20.9.0"
+    "node": "22.x"
   },
   "packageManager": "pnpm@10.6.4"
 }


### PR DESCRIPTION
## Description

Vercel recently released support for Node 24. Because our engines.node value was set to `^18.20.2 || >=20.9.0` this took precedence over our project settings in Vercel and upgraded us to Node 24. We observed a Node 24 specific bug after this last release. So we're explicitly setting our Node version to 22 to match our project configuration and avoid this bug. 

## Related Issues

Fixes #731 
