### PR TITLE
Bugfix: event page 404s

### DIFF
--- a/src/app/(frontend)/[center]/events/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/events/[slug]/page.tsx
@@ -16,7 +16,9 @@ import { Metadata, ResolvedMetadata } from 'next'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
+export const dynamic = 'force-static'
 export const dynamicParams = true
+export const revalidate = 600
 
 export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise })

--- a/src/collections/Courses/index.ts
+++ b/src/collections/Courses/index.ts
@@ -189,7 +189,6 @@ export const Courses: CollectionConfig = {
   hooks: {
     beforeValidate: [validateEventDates],
     beforeChange: [populatePublishedAt],
-    // TODO: need revalidation hooks here
   },
   versions: {
     drafts: {

--- a/src/collections/Events/hooks/revalidateEvent.ts
+++ b/src/collections/Events/hooks/revalidateEvent.ts
@@ -1,7 +1,7 @@
 import type { BasePayload, CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
 
 import { resolveTenant } from '@/utilities/tenancy/resolveTenant'
-import { revalidatePath, revalidateTag } from 'next/cache'
+import { revalidatePath } from 'next/cache'
 
 import type { Event } from '@/payload-types'
 import { revalidateBlockReferences } from '@/utilities/revalidateBlockReferences'
@@ -25,8 +25,6 @@ const revalidate = async ({
 
   revalidatePath(preRewritePath)
   revalidatePath(eventRewritePath)
-  revalidateTag(`events-sitemap-${tenantSlug}`)
-  revalidateTag(`navigation-${tenantSlug}`)
 
   await revalidateBlockReferences({
     collection: 'events',


### PR DESCRIPTION
## Description

My theory is that these pages weren't being statically generated correctly which was resulting in /[center]/[...segments] matching over /[center]/events/[slug] (which shouldn't be the behavior). 

This is only happening in production and development, not preview environments. 