### PR TITLE
Using slugs instead of ids for getEvents params

### DIFF
--- a/src/blocks/EventList/Component.tsx
+++ b/src/blocks/EventList/Component.tsx
@@ -51,16 +51,18 @@ export const EventListBlockComponent = (args: EventListComponentProps) => {
       }
 
       if (byGroups?.length) {
-        const groupIds = byGroups.map((g) => (typeof g === 'object' ? g.id : g)).filter(Boolean)
-        if (groupIds.length) {
-          eventsPageParams.append('groups', groupIds.join(','))
+        const groupSlugs = byGroups
+          .map((g) => (typeof g === 'object' ? g.slug : null))
+          .filter(Boolean)
+        if (groupSlugs.length) {
+          eventsPageParams.append('groups', groupSlugs.join(','))
         }
       }
 
       if (byTags?.length) {
-        const tagIds = byTags.map((t) => (typeof t === 'object' ? t.id : t)).filter(Boolean)
-        if (tagIds.length) {
-          eventsPageParams.append('tags', tagIds.join(','))
+        const tagSlugs = byTags.map((t) => (typeof t === 'object' ? t.slug : null)).filter(Boolean)
+        if (tagSlugs.length) {
+          eventsPageParams.append('tags', tagSlugs.join(','))
         }
       }
       eventsPageParams.append('startDate', format(new Date(), 'MM-dd-yyyy'))

--- a/src/blocks/EventTable/Component.tsx
+++ b/src/blocks/EventTable/Component.tsx
@@ -41,16 +41,18 @@ export const EventTableBlockComponent = (args: EventTableComponentProps) => {
       }
 
       if (byGroups?.length) {
-        const groupIds = byGroups.map((g) => (typeof g === 'object' ? g.id : g)).filter(Boolean)
-        if (groupIds.length) {
-          eventsPageParams.append('groups', groupIds.join(','))
+        const groupSlugs = byGroups
+          .map((g) => (typeof g === 'object' ? g.slug : null))
+          .filter(Boolean)
+        if (groupSlugs.length) {
+          eventsPageParams.append('groups', groupSlugs.join(','))
         }
       }
 
       if (byTags?.length) {
-        const tagIds = byTags.map((t) => (typeof t === 'object' ? t.id : t)).filter(Boolean)
-        if (tagIds.length) {
-          eventsPageParams.append('tags', tagIds.join(','))
+        const tagSlugs = byTags.map((t) => (typeof t === 'object' ? t.slug : null)).filter(Boolean)
+        if (tagSlugs.length) {
+          eventsPageParams.append('tags', tagSlugs.join(','))
         }
       }
       eventsPageParams.append('startDate', format(new Date(), 'MM-dd-yyyy'))


### PR DESCRIPTION
## Description

We were using ids for the group and tags query params when slug was expected. 

## Related Issues

#742 
