### PR TITLE
Update tenant slug readonly

### DIFF
--- a/src/collections/Tenants/index.ts
+++ b/src/collections/Tenants/index.ts
@@ -57,7 +57,6 @@ export const Tenants: CollectionConfig = {
       admin: {
         description:
           'Used for subdomains and url paths for previews. This is a unique identifier for a tenant.',
-        readOnly: true,
       },
       index: true,
       required: true,


### PR DESCRIPTION
## Description
We cannot edit the tenant slug when we go to make a new tenant. We want to update this to allow a user to add a slug on creation but never be able to edit this after creation.

## Related Issues
Fixes #758 

## Key Changes
- Remove readonly from tenant slug and uses access instead 

## Screenshots / Demo
On creation

<img width="800" height="564" alt="Screenshot 2025-12-08 at 22 42 52" src="https://github.com/user-attachments/assets/d416e7fe-af87-43a3-b6ee-c0b7fbc201d3" />

---
On edit

<img width="812" height="582" alt="Screenshot 2025-12-08 at 22 44 20" src="https://github.com/user-attachments/assets/452166e0-94f5-4969-9693-a9375be28691" />

