### PR TITLE
Bugfix: enables the use of builtInPages in the navigation

### DIFF
--- a/src/components/Header/utils.ts
+++ b/src/components/Header/utils.ts
@@ -163,6 +163,7 @@ export function convertToNavLink(
 ): NavLink | undefined {
   let linkLabel: string | undefined = link.label || undefined
 
+  // external links
   if (link.type === 'external' && link.url) {
     invariant(linkLabel, `Label not set for external link with url ${link.url}`)
 
@@ -174,24 +175,14 @@ export function convertToNavLink(
     }
   }
 
-  if (
-    link.type === 'internal' &&
-    link.reference &&
-    (link.reference.relationTo === 'pages' ||
-      link.reference.relationTo === 'posts' ||
-      link.reference.relationTo === 'builtInPages')
-  ) {
+  // internal page/post/builtInPage reference links
+  if (link.type === 'internal' && link.reference) {
     const reference = link.reference
 
     invariant(
       typeof reference.value !== 'number',
       `Link reference.value is a number. Depth not set correctly on navigations collection query.`,
     )
-
-    // Do not render documents in draft state (builtInPages don't have _status)
-    if ('_status' in reference.value && reference.value._status === 'draft') {
-      return undefined
-    }
 
     if (
       !linkLabel &&
@@ -207,34 +198,41 @@ export function convertToNavLink(
       `Could not determine label for link with reference ${JSON.stringify(reference)}`,
     )
 
-    let url: string
-    if (link.reference.relationTo === 'builtInPages' && 'url' in reference.value) {
-      url = normalizePath(reference.value.url, { ensureLeadingSlash: true })
-    } else if (link.reference.relationTo === 'posts' && 'slug' in reference.value) {
-      url = `/blog/${reference.value.slug}`
-    } else if ('slug' in reference.value) {
-      url = `/${reference.value.slug}`
-    } else {
-      return undefined
+    if (reference.relationTo === 'pages' || reference.relationTo === 'posts') {
+      // Do not render documents in draft state
+      if ('_status' in reference.value && reference.value._status === 'draft') {
+        return undefined
+      }
+
+      let url =
+        link.reference.relationTo === 'pages'
+          ? `/${reference.value.slug}`
+          : `/blog/${reference.value.slug}`
+
+      if (parentItems?.length && parentItems.length > 0) {
+        url = normalizePath(`/${parentItems.join('/')}${url}`, { ensureLeadingSlash: true })
+      }
+
+      return {
+        type: 'internal',
+        label: linkLabel,
+        url,
+      }
     }
 
-    // Only apply parent items prefix for pages and posts, not builtInPages
-    if (
-      link.reference.relationTo !== 'builtInPages' &&
-      parentItems?.length &&
-      parentItems.length > 0
-    ) {
-      url = normalizePath(`/${parentItems.join('/')}${url}`, { ensureLeadingSlash: true })
-    }
+    if (reference.relationTo === 'builtInPages') {
+      const url = normalizePath(reference.value.url, { ensureLeadingSlash: true })
 
-    return {
-      type: 'internal',
-      label: linkLabel,
-      url,
+      return {
+        type: 'internal',
+        label: linkLabel,
+        url,
+      }
     }
   }
 
-  if (link.url) {
+  // internal hardcoded links
+  if (link.type === 'internal' && link.url) {
     invariant(linkLabel, `Label not set for internal relative link with url ${link.url}`)
 
     let url = normalizePath(link.url, { ensureLeadingSlash: true })

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -946,12 +946,12 @@ export const seed = async ({
       ),
     )
 
-    await upsert(
+    const builtInPages = await upsert(
       'builtInPages',
       payload,
       incremental,
       tenantsById,
-      () => 'builtInPages',
+      (obj) => obj.url,
       Object.values(tenants)
         .map((tenant): RequiredDataFromCollectionSlug<'builtInPages'>[] => [
           builtInPage(tenant, 'All Forecasts', '/forecasts/avalanche'),
@@ -1204,7 +1204,7 @@ export const seed = async ({
       (_obj) => 'nav',
       Object.values(tenants).map(
         (tenant): RequiredDataFromCollectionSlug<'navigations'> =>
-          navigationSeed(payload, pages, tenant),
+          navigationSeed(payload, pages, builtInPages, tenant),
       ),
     )
 

--- a/src/endpoints/seed/navigation.ts
+++ b/src/endpoints/seed/navigation.ts
@@ -52,7 +52,7 @@ export const navigationSeed = (
   }: {
     url: string
     label?: string
-  }): NonNullable<NonNullable<Navigation['donate']>['link']> => {
+  }): NonNullable<Navigation['donate']>['link'] => {
     if (!builtInPages[tenant.slug] || !builtInPages[tenant.slug][url]) {
       payload.logger.warn(`BuiltInPage ${url} not found for tenant ${tenant.name}`)
       return {

--- a/src/endpoints/seed/navigation.ts
+++ b/src/endpoints/seed/navigation.ts
@@ -1,9 +1,10 @@
-import { Navigation, Page, Tenant } from '@/payload-types'
+import { BuiltInPage, Navigation, Page, Tenant } from '@/payload-types'
 import { Payload, RequiredDataFromCollectionSlug } from 'payload'
 
 export const navigationSeed = (
   payload: Payload,
   pages: Record<string, Record<string, Page>>,
+  builtInPages: Record<string, Record<string, BuiltInPage>>,
   tenant: Tenant,
 ): RequiredDataFromCollectionSlug<'navigations'> => {
   const pageLink = ({
@@ -45,6 +46,34 @@ export const navigationSeed = (
     }
   }
 
+  const builtInPageLink = ({
+    url,
+    label,
+  }: {
+    url: string
+    label?: string
+  }): NonNullable<NonNullable<Navigation['donate']>['link']> => {
+    if (!builtInPages[tenant.slug] || !builtInPages[tenant.slug][url]) {
+      payload.logger.warn(`BuiltInPage ${url} not found for tenant ${tenant.name}`)
+      return {
+        type: 'internal',
+        label: label || 'Missing Page',
+        url: '/',
+      }
+    }
+
+    const builtInPage = builtInPages[tenant.slug][url]
+
+    return {
+      type: 'internal',
+      reference: {
+        value: builtInPage.id,
+        relationTo: 'builtInPages',
+      },
+      label: label || builtInPage.title,
+    }
+  }
+
   return {
     _status: 'published',
     tenant: tenant.id,
@@ -57,11 +86,10 @@ export const navigationSeed = (
     weather: {
       items: [
         {
-          link: {
-            type: 'internal',
+          link: builtInPageLink({
+            url: '/weather/stations/map',
             label: 'Weather Stations',
-            url: '/stations/map',
-          },
+          }),
         },
         {
           link: pageLink({


### PR DESCRIPTION
## Description

`builtInPages` weren't being handled correctly in the navigation. They were being filtered out. This allows them in the nav. 

## Related Issues

Fixes #752

## Key Changes

- Enables the use of built-in pages in the navigation
- Uses a built-in page for the weather stations link in the seed script

## Screenshots / Demo

https://www.loom.com/share/134e95648cae46cf8c2dc75fc04fc5e4

## Changes needed after merge

- [ ] Update all centers' weather stations nav link to use their built-in page
- [ ] Communicate that the local accidents can be a built-in page for Sierra / add to their nav. Won't be a significant difference for them but might as well change it. 
