### PR TITLE
Bugfix: nac media block filter options

### DIFF
--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -105,13 +105,16 @@ export const Pages: CollectionConfig<'pages'> = {
               },
               filterOptions: ({ data }) => {
                 const layoutBlocks = data?.layout
+
+                if (!layoutBlocks) return true
+
                 const nacMediaBlockCount = layoutBlocks.filter(
                   (block: { blockType: string }) => block.blockType === 'nacMediaBlock',
                 ).length
-                return nacMediaBlockCount > 1 ? DEFAULT_BLOCKS.map((block) => block.slug) : true
+                return nacMediaBlockCount >= 1 ? DEFAULT_BLOCKS.map((block) => block.slug) : true
               },
               validate: (value) => {
-                if (!Array.isArray(value)) return true
+                if (!value || !Array.isArray(value)) return true
 
                 const nacMediaBlockCount = value.filter(
                   (block) => block.blockType === 'nacMediaBlock',


### PR DESCRIPTION
## Description

layoutBlocks could be undefined (TS didn't catch this)
Out check for number of nac media blocks was checking for 2+ when it should have been checking for 1+
