### PR TITLE
Add external url validation to url fields for courses and events

### DIFF
--- a/src/collections/Courses/index.ts
+++ b/src/collections/Courses/index.ts
@@ -9,6 +9,7 @@ import { populatePublishedAt } from '@/hooks/populatePublishedAt'
 import { validateEventDates } from '@/hooks/validateEventDates'
 import { Course } from '@/payload-types'
 import { TIMEZONE_OPTIONS } from '@/utilities/timezones'
+import { validateExternalUrl } from '@/utilities/validateUrl'
 import { validateZipCode } from '@/utilities/validateZipCode'
 import { CollectionConfig } from 'payload'
 import { accessByProviderOrProviderManager } from './access/byProviderOrProviderManager'
@@ -98,6 +99,7 @@ export const Courses: CollectionConfig = {
       admin: {
         description: 'External registration link or landing page link',
       },
+      validate: validateExternalUrl,
     },
     {
       name: 'registrationDeadline',

--- a/src/collections/Events/index.ts
+++ b/src/collections/Events/index.ts
@@ -24,6 +24,7 @@ import { validateEventDates } from '@/hooks/validateEventDates'
 import { Event } from '@/payload-types'
 import { getImageTypeFilter, getTenantFilter } from '@/utilities/collectionFilters'
 import { TIMEZONE_OPTIONS } from '@/utilities/timezones'
+import { validateExternalUrl } from '@/utilities/validateUrl'
 import { MetaImageField } from '@payloadcms/plugin-seo/fields'
 import {
   BlocksFeature,
@@ -89,6 +90,7 @@ export const Events: CollectionConfig = {
       admin: {
         description: 'External registration link',
       },
+      validate: validateExternalUrl,
     },
     {
       name: 'externalEventUrl',
@@ -96,6 +98,7 @@ export const Events: CollectionConfig = {
       admin: {
         description: 'Optional external landing page (takes precedence over event page)',
       },
+      validate: validateExternalUrl,
     },
     {
       type: 'row',


### PR DESCRIPTION
## Description

Add external url validation to url fields for courses and events

## Related Issues

Fixes #792 

## Key Changes

Adds external url validation (i.e. requires a full, valid url) to:
- registration url for events
- external event url for events
- course url for courses

## Screenshots / Demo

Example:
<img width="2056" height="236" alt="CleanShot 2025-12-16 at 17 04 00@2x" src="https://github.com/user-attachments/assets/41c8a27b-8783-49d3-8943-230bcc77cde9" />

