### PR TITLE
Fix carousel loop

### DIFF
--- a/src/blocks/SponsorsBlock/components/Carousel.tsx
+++ b/src/blocks/SponsorsBlock/components/Carousel.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/components/ui/carousel'
 import { Sponsor } from '@/payload-types'
 import getTextColorFromBgColor from '@/utilities/getTextColorFromBgColor'
-import { cn } from '@/utilities/ui'
 import Autoplay from 'embla-carousel-autoplay'
 
 export const SponsorsBlockCarousel = ({
@@ -22,22 +21,18 @@ export const SponsorsBlockCarousel = ({
   const carouselItemClasses: { [key: string]: string[] } = {
     1: [''],
     2: [''],
-    3: ['sm:basis-1/2'],
-    4: ['md:basis-1/3'],
-    5: ['md:basis-1/3 lg:basis-1/4'],
-    6: ['md:basis-1/3 lg:basis-1/4 lg:basis-1/5'],
+    3: [''],
+    4: ['sm:basis-1/2'],
+    5: ['sm:basis-1/2 md:basis-1/3'],
+    6: ['sm:basis-1/2 md:basis-1/3 lg:basis-1/4'],
+    7: ['sm:basis-1/2 md:basis-1/3 lg:basis-1/5'],
     default: ['basis-1/2 md:basis-1/3 lg:basis-1/6'],
   }
 
   const carouselItemClass = carouselItemClasses[sponsors.length] || carouselItemClasses['default']
   const borderColor = getTextColorFromBgColor(bgColorClass).replace('text-bg', 'border')
   return (
-    <div
-      className={cn({
-        'max-w-5/6 md:max-w-11/12': sponsors.length < 6,
-        'w-5/6 md:w-11/12': sponsors.length >= 6,
-      })}
-    >
+    <div className="w-full">
       <Carousel
         opts={{
           align: 'start',


### PR DESCRIPTION
## Description
Fix carousel looping back to the biginning instead of continuously looping  on large screen

## Related Issues
Fixes #695 

## Key Changes
I am not fully sure why this was looping back to the beginning, but it had to do with how many icons were not being shown. I combed through the docs and issues and couldn't find anything. There needs to be at least 2 items not shown in order to loop correctly 🤷🏼‍♀️ 

## Screenshots / Demo
Tested carousel view using 1-8+ icons