### PR TITLE
collections/Documents: allow other MIME types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 
 # Payload default media upload directory
 public/media/
+public/documents
 
 public/robots.txt
 public/sitemap*.xml

--- a/src/collections/Documents/hooks/revalidateDocuments.ts
+++ b/src/collections/Documents/hooks/revalidateDocuments.ts
@@ -1,0 +1,34 @@
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
+
+import type { Document } from '@/payload-types'
+import { revalidateBlockReferences } from '@/utilities/revalidateBlockReferences'
+import { revalidateRelationshipReferences } from '@/utilities/revalidateRelationshipReferences'
+
+async function revalidate(docId: number) {
+  await revalidateBlockReferences({
+    collection: 'documents',
+    id: docId,
+  })
+  await revalidateRelationshipReferences({
+    collection: 'documents',
+    id: docId,
+  })
+}
+
+export const revalidateDocuments: CollectionAfterChangeHook<Document> = async ({
+  doc,
+  req: { context },
+}) => {
+  if (context.disableRevalidate) return
+
+  await revalidate(doc.id)
+}
+
+export const revalidateDocumentsDelete: CollectionAfterDeleteHook<Document> = async ({
+  doc,
+  req: { context },
+}) => {
+  if (context.disableRevalidate) return
+
+  await revalidate(doc.id)
+}

--- a/src/collections/Documents/index.ts
+++ b/src/collections/Documents/index.ts
@@ -38,7 +38,15 @@ export const Documents: CollectionConfig = {
   ],
   upload: {
     staticDir: path.resolve(dirname, '../../../public/documents'),
-    mimeTypes: ['application/pdf', 'text/x-php', 'text/xml'],
+    mimeTypes: [
+      'application/pdf',
+      'text/x-php',
+      'text/php',
+      'application/xml',
+      'application/octet-stream',
+      'application/vnd.google-earth.kml+xml',
+      '.kml',
+    ],
   },
   hooks: {
     beforeOperation: [prefixFilenameWithTenant],

--- a/src/collections/Documents/index.ts
+++ b/src/collections/Documents/index.ts
@@ -38,7 +38,7 @@ export const Documents: CollectionConfig = {
   ],
   upload: {
     staticDir: path.resolve(dirname, '../../../public/documents'),
-    mimeTypes: ['application/pdf'],
+    mimeTypes: ['application/pdf', 'text/x-php', 'text/xml'],
   },
   hooks: {
     beforeOperation: [prefixFilenameWithTenant],

--- a/src/collections/Documents/index.ts
+++ b/src/collections/Documents/index.ts
@@ -9,7 +9,7 @@ import { hasGlobalOrTenantRolePermission } from '@/utilities/rbac/hasGlobalOrTen
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { prefixFilenameWithTenant } from '../Media/hooks/prefixFilenameWithTenant'
-import { revalidateMedia, revalidateMediaDelete } from '../Media/hooks/revalidateMedia'
+import { revalidateDocuments, revalidateDocumentsDelete } from './hooks/revalidateDocuments'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -50,7 +50,7 @@ export const Documents: CollectionConfig = {
   },
   hooks: {
     beforeOperation: [prefixFilenameWithTenant],
-    afterChange: [revalidateMedia],
-    afterDelete: [revalidateMediaDelete],
+    afterChange: [revalidateDocuments],
+    afterDelete: [revalidateDocumentsDelete],
   },
 }

--- a/src/utilities/revalidateDocument.ts
+++ b/src/utilities/revalidateDocument.ts
@@ -6,6 +6,7 @@ import { getPayload } from 'payload'
 export interface RevalidationReference {
   collection:
     | 'biographies'
+    | 'documents'
     | 'teams'
     | 'media'
     | 'forms'


### PR DESCRIPTION
One of our users has an urgent use-case for uploading XML and PHP files.
