### PR TITLE
Tenant not defined on post tag

### DIFF
--- a/src/fields/slug/ensureUniqueSlug.ts
+++ b/src/fields/slug/ensureUniqueSlug.ts
@@ -1,3 +1,4 @@
+import { getTenantFromCookie } from '@/utilities/tenancy/getTenantFromCookie'
 import type { FieldHook, Where } from 'payload'
 
 import { ValidationError } from 'payload'
@@ -5,6 +6,7 @@ import invariant from 'tiny-invariant'
 
 export const ensureUniqueSlug: FieldHook = async (props) => {
   const { data, originalDoc, req, value, collection } = props
+  const tenantIDFromCookie = getTenantFromCookie(req.headers, 'number')
 
   invariant(
     !!collection,
@@ -15,10 +17,6 @@ export const ensureUniqueSlug: FieldHook = async (props) => {
   const collectionHasTenantField = !!tenantField
   const tenantFieldRequired =
     tenantField && 'required' in tenantField && tenantField.required === true
-
-  const incomingTenantID = data?.tenant?.id ? data?.tenant.id : data?.tenant
-  const currentTenantID = originalDoc?.tenant?.id ? originalDoc.tenant.id : originalDoc?.tenant
-  const tenantIDToMatch = incomingTenantID || currentTenantID
 
   // Don't validate if slug hasn't been generated yet
   if (!value) {
@@ -41,10 +39,10 @@ export const ensureUniqueSlug: FieldHook = async (props) => {
     })
   }
 
-  if (collectionHasTenantField && tenantFieldRequired && tenantIDToMatch) {
+  if (collectionHasTenantField && tenantFieldRequired && tenantIDFromCookie) {
     conditions.push({
       tenant: {
-        equals: tenantIDToMatch,
+        equals: tenantIDFromCookie,
       },
     })
   }


### PR DESCRIPTION
## Description
The problem is, upon tag creation, tenant is not passed to `ensureUniqueSlug` in the `data` or `originalDoc` props.
`data : { slug: 'category', title: 'Category' }`
`originalDoc: {}`

I checked other collections that are using `ensureUniqueSlug` and `tenant` is being passed in both `data` or `originalDoc` props so I am not sure why `tags` is any different.

## Related Issues
Fixes #820 


## Key Changes
Changed to use `getTentantFromCookie` instead of using `data` or `originalDoc`. I don't feel great about this change, since I think tenant should be defined on `data` or `originalDoc` but I figured it was a better fix than debugging payload create method. `getTentantFromCookie` should always be defined.

## Future enhancements / Questions
- Upgrade payload to include their fix
- truly debug why `tenant` is not passed on `tags` initial create request