### PR TITLE
Allow script tags in generic embeds

### DIFF
--- a/src/blocks/GenericEmbed/Component.tsx
+++ b/src/blocks/GenericEmbed/Component.tsx
@@ -49,6 +49,7 @@ export const GenericEmbedBlock = ({
         'width',
         'allowpaymentrequest',
       ],
+      FORCE_BODY: true,
     })
 
     const styleOverrides = `


### PR DESCRIPTION
## Description

This sets `FORCE_BODY` to true in DOMPurify settings to allow script tags. Apparently, even if you include `scripts` in the `ADD_TAGS` option, scripts will be stripped. This was causing the script that the donorbox embed needed to be stripped from the resulting sanitized html. 

We're still sandboxing all embeds in an iframe so the crypto modal will only open in the iframe document which doesn't look amazing. Since we resize to the height of the iframe content using `@open-iframe-resizer`, there isn't much vertical space for it to occupy:
![CleanShot 2026-01-06 at 17 10 30](https://github.com/user-attachments/assets/d81f2a4d-78c0-4e64-867b-de494311d4a4)

I still believe that these types of things should be resolved by setting styles on the iframe / embed html rather than trying to account for these things on our end. So I suggest we accept this. 

## Related Issues

Fixes #816

## Key Changes

Adds `FORCE_BODY=true` to DOMPurify settings, allowing script tags in sanitized html.

## Future enhancements / Questions

It might be helpful to write some best practices for styling embeds in our Notion docs. 
