### PR TITLE
Allowing a manual run of the production release workflow

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -6,6 +6,12 @@ on:
   push:
     branches:
       - 'release'
+  # Allow manual triggering
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual deployment'
+        required: true
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

We have needed to re-release the latest commit for various reasons since going to production. Previously we've either pushed an empty commit to `release` or re-run the last GHA using re-run all jobs. This allows running the production GHA manually with a required "reason" input. This is a cleaner solution and provides some audit trail. 
