### PR TITLE
Fix single observation widget linking

### DIFF
--- a/src/app/(frontend)/[center]/observations/ObservationLinkHijacker.client.tsx
+++ b/src/app/(frontend)/[center]/observations/ObservationLinkHijacker.client.tsx
@@ -67,7 +67,6 @@ export function ObservationLinkHijacker() {
             document.querySelector('#nac-obs-modal-controls a')
           ) {
             modifyLinks()
-            observer.disconnect()
           }
         }
       })


### PR DESCRIPTION
## Description
Fixes back button bug noticed for single observations in observation link hijacker component. The mutation observer was disconnecting after the first modal open, preventing link hijacking on subsequent modal interactions after navigating back to it without refreshing.

## Related Issues
Fixes #730 

## Key Changes
- Removed `observer.disconnect()` call from inside the MutationObserver callback
- Observer now continuously monitors the widget container for new link mutations instead of disconnecting after the first detection
- This allows the hijacker to re-apply custom navigation handlers whenever the modal DOM is recreated (ie: after returning via browser back button)

## Screenshots / Demo
https://www.loom.com/share/eef5c7092e2746af86efda3b151d5fd5