### PR TITLE
Do not cache non-tenant-scoped 404s

### DIFF
--- a/src/app/[...segmentsNotFound]/page.tsx
+++ b/src/app/[...segmentsNotFound]/page.tsx
@@ -2,6 +2,9 @@ import Link from 'next/link'
 
 import { Button } from '@/components/ui/button'
 
+// Prevent caching 404 responses so new routes can take over when content is created
+export const dynamic = 'force-dynamic'
+
 export default function NotFound() {
   return (
     <div className="container py-28">


### PR DESCRIPTION
## Description

This is an attempt at restricting the non-tenant-scoped catch-all route which serves as the 404 page from being cached. I have a suspicion that this is what was causing #841 but I wasn't able to reproduce locally. 

## Related Issues

Related to #841 but couldn't identify root cause so I'm not sure this will resolve it

## Key Changes

Sets the `dynamic` export to `force-dynamic` in an effort to avoid the caching of 404s

## Future enhancements / Questions

I hate to make a change that I just think _might_ be the solution. I spent a while trying to recreate this locally with no luck so this is me doing _something_ about it. This is a low consequence change - it seems fine (and potentially ideal) to not cache 404s anyways. 
