### PR TITLE
Add international as a state for courses and providers

### DIFF
--- a/src/collections/Courses/index.ts
+++ b/src/collections/Courses/index.ts
@@ -1,7 +1,7 @@
 import { courseTypesData } from '@/constants/courseTypes'
 import { affinityGroupField } from '@/fields/affinityGroupField'
 import { contentHashField } from '@/fields/contentHashField'
-import { stateOptions } from '@/fields/location/states'
+import { stateOptionsWIntl } from '@/fields/location/states'
 import { modeOfTravelField } from '@/fields/modeOfTravelField'
 import { slugField } from '@/fields/slug'
 import { startAndEndDateField } from '@/fields/startAndEndDateField'
@@ -70,7 +70,7 @@ export const Courses: CollectionConfig = {
               name: 'state',
               type: 'select',
               label: 'State',
-              options: stateOptions,
+              options: stateOptionsWIntl,
               required: true,
             },
             {

--- a/src/collections/Providers/index.ts
+++ b/src/collections/Providers/index.ts
@@ -1,7 +1,7 @@
 import { accessByProviderRelationship } from '@/access/byProviderRelationship'
 import { courseTypesData } from '@/constants/courseTypes'
 import { contentHashField } from '@/fields/contentHashField'
-import { stateOptions } from '@/fields/location/states'
+import { stateOptionsWIntl } from '@/fields/location/states'
 import { slugField } from '@/fields/slug'
 import { validatePhone } from '@/utilities/validatePhone'
 import { validateExternalUrl } from '@/utilities/validateUrl'
@@ -77,7 +77,7 @@ export const Providers: CollectionConfig = {
               name: 'state',
               type: 'select',
               label: 'State',
-              options: stateOptions,
+              options: stateOptionsWIntl,
             },
             {
               name: 'zip',
@@ -111,7 +111,7 @@ export const Providers: CollectionConfig = {
           name: 'statesServiced',
           label: false,
           type: 'select',
-          options: stateOptions,
+          options: stateOptionsWIntl,
           required: true,
           hasMany: true,
         },

--- a/src/components/ProviderPreview.tsx
+++ b/src/components/ProviderPreview.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import type { Provider } from '@/payload-types'
 
 import { courseTypesData } from '@/constants/courseTypes'
+import { getStateLabel } from '@/fields/location/states'
 import { cn } from '@/utilities/ui'
 import { isValidFullUrl } from '@/utilities/validateUrl'
 import { ExternalLink, Mail, MapPin, Phone } from 'lucide-react'
@@ -19,6 +20,7 @@ export const ProviderPreview = (props: { doc?: Provider }) => {
 
   const getLocationText = () => {
     if (!location) return null
+    if (location.state === 'INTL') return getStateLabel(location.state)
     if (location.city && location.state) return `${location.city}, ${location.state}`
     if (location.city) return location.city
     if (location.state) return location.state

--- a/src/components/filters/StatesFilter.tsx
+++ b/src/components/filters/StatesFilter.tsx
@@ -1,5 +1,5 @@
 import { CheckboxFilter, CheckboxFilterProps } from '@/components/filters/CheckboxFilter'
-import { stateOptions } from '@/fields/location/states'
+import { stateOptionsWIntl } from '@/fields/location/states'
 
 type State = {
   label: string
@@ -11,7 +11,7 @@ type StatesFilterProps = {
 } & Partial<CheckboxFilterProps>
 
 export const StatesFilter = ({ states, ...props }: StatesFilterProps = {}) => {
-  const options = states || stateOptions
+  const options = states || stateOptionsWIntl
 
   return (
     <CheckboxFilter

--- a/src/fields/location/states.ts
+++ b/src/fields/location/states.ts
@@ -50,11 +50,11 @@ export const stateOptions = [
   { label: 'Wisconsin', value: 'WI' },
   { label: 'Wyoming', value: 'WY' },
   { label: 'District of Columbia', value: 'DC' },
-  { label: 'International', value: 'INTL' },
 ]
+export const stateOptionsWIntl = [...stateOptions, { label: 'International', value: 'INTL' }]
 
 // Get full state label from value
 export const getStateLabel = (stateValue: string): string => {
-  const state = stateOptions.find((option) => option.value === stateValue)
+  const state = stateOptionsWIntl.find((option) => option.value === stateValue)
   return state?.label || stateValue
 }

--- a/src/fields/location/states.ts
+++ b/src/fields/location/states.ts
@@ -50,6 +50,7 @@ export const stateOptions = [
   { label: 'Wisconsin', value: 'WI' },
   { label: 'Wyoming', value: 'WY' },
   { label: 'District of Columbia', value: 'DC' },
+  { label: 'International', value: 'INTL' },
 ]
 
 // Get full state label from value

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -834,7 +834,6 @@ export interface Event {
           | 'WI'
           | 'WY'
           | 'DC'
-          | 'INTL'
         )
       | null;
     zip?: string | null;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -834,6 +834,7 @@ export interface Event {
           | 'WI'
           | 'WY'
           | 'DC'
+          | 'INTL'
         )
       | null;
     zip?: string | null;
@@ -1629,6 +1630,7 @@ export interface Provider {
           | 'WI'
           | 'WY'
           | 'DC'
+          | 'INTL'
         )
       | null;
     zip?: string | null;
@@ -1686,6 +1688,7 @@ export interface Provider {
     | 'WI'
     | 'WY'
     | 'DC'
+    | 'INTL'
   )[];
   courses?: {
     docs?: (number | Course)[];
@@ -1783,7 +1786,8 @@ export interface Course {
       | 'WV'
       | 'WI'
       | 'WY'
-      | 'DC';
+      | 'DC'
+      | 'INTL';
     zip?: string | null;
     country?: 'US' | null;
   };

--- a/src/utilities/queries/getCoursesStates.ts
+++ b/src/utilities/queries/getCoursesStates.ts
@@ -31,6 +31,13 @@ export async function getCoursesStates(): Promise<GetCoursesStatesResults> {
       }
     })
 
+    // Move international to the bottom of the list
+    const intlIndex = states.findIndex((s) => s.value === 'INTL')
+    if (intlIndex !== -1) {
+      const [intlItem] = states.splice(intlIndex, 1)
+      states.push(intlItem)
+    }
+
     return { states }
   } catch (error) {
     Sentry.captureException(error)

--- a/src/views/EmbedGenerator/EmbedGeneratorForm.tsx
+++ b/src/views/EmbedGenerator/EmbedGeneratorForm.tsx
@@ -17,7 +17,7 @@ import { type ChangeEvent, useMemo, useState } from 'react'
 
 import { courseTypesData } from '@/constants/courseTypes'
 import { affinityGroupOptions } from '@/fields/affinityGroupField'
-import { stateOptions } from '@/fields/location/states'
+import { stateOptionsWIntl } from '@/fields/location/states'
 import { modeOfTravelOptions } from '@/fields/modeOfTravelField'
 import type { Provider } from '@/payload-types'
 import { format } from 'date-fns'
@@ -276,7 +276,7 @@ export function EmbedGeneratorForm({ baseUrl }: { baseUrl: string }) {
             label="States"
             name="states"
             path="states"
-            options={stateOptions.map((state) => ({ label: state.label, value: state.value }))}
+            options={stateOptionsWIntl.map((state) => ({ label: state.label, value: state.value }))}
             value={options.states}
             onChange={(selected) => {
               updateOption('states', extractStringValues(selected))


### PR DESCRIPTION
## Description
A3 recently brought to our attention they have a few international providers. These providers are either strictly international or have courses in both the US and internationally. The easiest way for us to deal with this is to add international as a state option to both courses and providers. 

## Related Issues
Fixes #815 

## Key Changes
- Add international as state option
- Update provider preview to show international label
- Update course filters to put international option on the bottom of the state list

## Screenshots / Demo
Recorded locally since embeds were not working in preview
https://www.loom.com/share/1687db9d24034cdda6ac86260c252e38

## Future enhancements / Questions
- We will want to decide if we are supporting international addresses or not.
- When discussing this, there was mention of updating permission. Do we need to limit the international option to select user or alter the provider invite flow? Nothing was documented around this.
- The admin UI is not great. I am leaving it since we are treating this PR as a workaround but could use improvement