### PR TITLE
Bugfix: Fixing event date hydration error

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "**/*": "pnpm run prettify"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.4.1",
     "@libsql/client": "^0.15.4",
     "@open-iframe-resizer/core": "^2.1.0",
     "@open-iframe-resizer/react": "^2.1.0",
@@ -87,7 +88,6 @@
     "clsx": "^2.1.1",
     "cross-env": "^7.0.3",
     "date-fns": "^4.1.0",
-    "date-fns-tz": "^3.2.0",
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
     "fuse.js": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      '@date-fns/tz':
+        specifier: ^1.4.1
+        version: 1.4.1
       '@libsql/client':
         specifier: ^0.15.4
         version: 0.15.4
@@ -130,9 +133,6 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
-      date-fns-tz:
-        specifier: ^3.2.0
-        version: 3.2.0(date-fns@4.1.0)
       embla-carousel-autoplay:
         specifier: ^8.6.0
         version: 8.6.0(embla-carousel@8.6.0)
@@ -8020,14 +8020,6 @@ packages:
         integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==,
       }
 
-  date-fns-tz@3.2.0:
-    resolution:
-      {
-        integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==,
-      }
-    peerDependencies:
-      date-fns: ^3.0.0 || ^4.0.0
-
   date-fns@3.6.0:
     resolution:
       {
@@ -10564,7 +10556,6 @@ packages:
       {
         integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==,
       }
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.5.6:
@@ -19498,10 +19489,6 @@ snapshots:
   dataloader@2.2.3: {}
 
   date-fns-jalali@4.1.0-0: {}
-
-  date-fns-tz@3.2.0(date-fns@4.1.0):
-    dependencies:
-      date-fns: 4.1.0
 
   date-fns@3.6.0: {}
 

--- a/src/components/EventPreview/index.tsx
+++ b/src/components/EventPreview/index.tsx
@@ -1,3 +1,4 @@
+import { formatDateTime } from '@/utilities/formatDateTime'
 import { cn } from '@/utilities/ui'
 
 import type { Event } from '@/payload-types'
@@ -45,10 +46,9 @@ export const EventPreview = (props: {
 
   const eventTypeDisplay = type ? eventTypesData.find((et) => et.value === type)?.label : null
 
-  const parsedStartDate = new Date(startDate)
-  const month = parsedStartDate.toLocaleDateString('en-US', { month: 'short' })
-  const day = parsedStartDate.getDate()
-  const year = parsedStartDate.getFullYear()
+  const month = formatDateTime(startDate, startDate_tz, 'MMM')
+  const day = formatDateTime(startDate, startDate_tz, 'd')
+  const year = formatDateTime(startDate, startDate_tz, 'yyyy')
 
   return (
     <article

--- a/src/components/StartAndEndDateDisplay.tsx
+++ b/src/components/StartAndEndDateDisplay.tsx
@@ -1,6 +1,18 @@
 import type { Event } from '@/payload-types'
 import { formatDateTime } from '@/utilities/formatDateTime'
-import { isSameDay } from 'date-fns'
+
+// Timezone-aware same-day comparison to avoid hydration mismatches
+// Compares the formatted date strings in the event's timezone rather than local timezone
+const isSameDayInTimezone = (
+  date1: string,
+  tz1: string | null | undefined,
+  date2: string,
+  tz2: string | null | undefined,
+): boolean => {
+  const day1 = formatDateTime(date1, tz1, 'yyyy-MM-dd')
+  const day2 = formatDateTime(date2, tz2, 'yyyy-MM-dd')
+  return day1 === day2
+}
 
 export function StartAndEndDateDisplay({
   startDate,
@@ -10,7 +22,7 @@ export function StartAndEndDateDisplay({
 }: Pick<Event, 'startDate' | 'startDate_tz' | 'endDate' | 'endDate_tz'>) {
   return (
     <>
-      {endDate && isSameDay(startDate, endDate) ? (
+      {endDate && isSameDayInTimezone(startDate, startDate_tz, endDate, endDate_tz) ? (
         <>
           <span>
             {formatDateTime(startDate, startDate_tz, 'MMM d, yyyy, p')}

--- a/src/components/StartAndEndDateDisplay.tsx
+++ b/src/components/StartAndEndDateDisplay.tsx
@@ -1,18 +1,7 @@
 import type { Event } from '@/payload-types'
 import { formatDateTime } from '@/utilities/formatDateTime'
-
-// Timezone-aware same-day comparison to avoid hydration mismatches
-// Compares the formatted date strings in the event's timezone rather than local timezone
-const isSameDayInTimezone = (
-  date1: string,
-  tz1: string | null | undefined,
-  date2: string,
-  tz2: string | null | undefined,
-): boolean => {
-  const day1 = formatDateTime(date1, tz1, 'yyyy-MM-dd')
-  const day2 = formatDateTime(date2, tz2, 'yyyy-MM-dd')
-  return day1 === day2
-}
+import { tz } from '@date-fns/tz'
+import { isSameDay } from 'date-fns'
 
 export function StartAndEndDateDisplay({
   startDate,
@@ -22,7 +11,7 @@ export function StartAndEndDateDisplay({
 }: Pick<Event, 'startDate' | 'startDate_tz' | 'endDate' | 'endDate_tz'>) {
   return (
     <>
-      {endDate && isSameDayInTimezone(startDate, startDate_tz, endDate, endDate_tz) ? (
+      {endDate && isSameDay(startDate, endDate, { in: tz(startDate_tz ?? undefined) }) ? (
         <>
           <span>
             {formatDateTime(startDate, startDate_tz, 'MMM d, yyyy, p')}

--- a/src/components/StartAndEndDateDisplay.tsx
+++ b/src/components/StartAndEndDateDisplay.tsx
@@ -11,7 +11,7 @@ export function StartAndEndDateDisplay({
 }: Pick<Event, 'startDate' | 'startDate_tz' | 'endDate' | 'endDate_tz'>) {
   return (
     <>
-      {endDate && isSameDay(startDate, endDate, { in: tz(startDate_tz ?? undefined) }) ? (
+      {endDate && isSameDay(startDate, endDate, { in: tz(startDate_tz) }) ? (
         <>
           <span>
             {formatDateTime(startDate, startDate_tz, 'MMM d, yyyy, p')}

--- a/src/utilities/formatDateTime.ts
+++ b/src/utilities/formatDateTime.ts
@@ -1,10 +1,10 @@
-import { formatInTimeZone } from 'date-fns-tz'
+import { TZDate } from '@date-fns/tz'
 import { format } from 'date-fns/format'
 
 export const formatDateTime = (
   dateString: string,
   tz: string | null | undefined,
-  options: string,
+  formatStr: string,
 ) => {
-  return tz ? formatInTimeZone(dateString, tz, options) : format(dateString, options)
+  return tz ? format(new TZDate(dateString, tz), formatStr) : format(dateString, formatStr)
 }


### PR DESCRIPTION
## Description

Fix date hydration errors on event cards by using timezone-aware date formatting.

## Related Issues

Fixes #751

## Key Changes

- Replace raw `new Date()` methods with `formatDateTime()` in EventPreview for the large date sidebar display
- Replace `isSameDay()` from date-fns with timezone-aware comparison in StartAndEndDateDisplay
- Add test event seed data with midnight UTC start time to reproduce the issue

## Screenshots / Demo

No hydration error :)

<img width="4578" height="2750" alt="CleanShot 2026-01-11 at 21 17 47@2x" src="https://github.com/user-attachments/assets/2b424a40-68d0-4ba4-a8b8-35b680b087e2" />


## Rule of thumb for hydration mismatches for dates

**Triggering date hydration errors:** Hydration mismatches occur when a date falls on different calendar days in UTC vs the user's timezone:

| User Timezone | Problematic UTC Times |
|--------------|----------------------|
| US (behind UTC) | Early morning UTC (00:00-08:00) |
| Ahead of UTC | Late evening UTC (16:00-23:59) |

To test locally: `TZ=UTC pnpm dev`

