### PR TITLE
Add vercel cleanup to GHA

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -21,9 +21,6 @@ jobs:
           branch="${ref##refs/heads/}"
           clean_branch="${branch//[^a-z0-9\-]/x}"
 
-          # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
-          # and ensuring total database name stays within 58 character limit
-          # "payloadcms-preview-" is 19 characters, leaving 39 for the branch
           if [ ${#clean_branch} -gt 39 ]; then
             prefix="${clean_branch:0:31}"
             hash=$(echo -n "${clean_branch}" | sha256sum | cut -c1-7)
@@ -33,10 +30,8 @@ jobs:
           name="payloadcms-preview-${clean_branch}"
           echo "[INFO] Attempting to delete database ${name}"
 
-          # Switch to the correct organization
           /home/runner/.turso/turso org switch nwac
 
-          # Check if database exists before attempting to delete
           if /home/runner/.turso/turso db show "${name}" >/dev/null 2>&1; then
             echo "[INFO] Database ${name} exists, deleting..."
             /home/runner/.turso/turso db destroy --yes "${name}"
@@ -60,7 +55,6 @@ jobs:
           ref="${{ github.event.ref }}"
           branch="${ref##refs/heads/}"
 
-          # Safety check: never delete from production
           if [ "$branch" = "main" ] || [ "$branch" = "release" ]; then
             echo "[ERROR] Refusing to delete environment variables from production branch: ${branch}"
             exit 1
@@ -82,6 +76,7 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
       - name: Remove Vercel deployments and aliases
         run: |
@@ -92,35 +87,17 @@ jobs:
           BRANCH_NAME="${{ github.head_ref }}"
           echo "Cleaning up deployments and aliases for branch: $BRANCH_NAME"
 
-          # Get all deployments for the project
-          DEPLOYMENTS=$(curl -s -H "Authorization: Bearer $VERCEL_TOKEN" \
-            "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT_ID&teamId=$VERCEL_ORG_ID" | jq '.deployments')
-
-          # Filter deployments by branch name
-          echo "$DEPLOYMENTS" | jq -r '.[] | select(.meta.githubCommitRef == "'"$BRANCH_NAME"'") | .uid' | while read -r DEPLOYMENT_ID; do
-            if [ ! -z "$DEPLOYMENT_ID" ]; then
-              echo "Found deployment: $DEPLOYMENT_ID"
+          # Get all deployments for the project filtered by branch
+          vercel list --meta githubCommitRef=$BRANCH_NAME --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null | while read -r DEPLOYMENT_URL; do
+            if [ ! -z "$DEPLOYMENT_URL" ]; then
+              echo "Found deployment: $DEPLOYMENT_URL"
               
-              # Get aliases for this deployment
-              ALIASES=$(curl -s -H "Authorization: Bearer $VERCEL_TOKEN" \
-                "https://api.vercel.com/v4/aliases?projectId=$VERCEL_PROJECT_ID&teamId=$VERCEL_ORG_ID&limit=100" | jq -r '.aliases[] | select(.deploymentId == "'"$DEPLOYMENT_ID"'") | .alias')
-              
-              # Remove each alias
-              echo "$ALIASES" | while read -r ALIAS; do
-                if [ ! -z "$ALIAS" ]; then
-                  echo "Removing alias: $ALIAS"
-                  curl -s -X DELETE -H "Authorization: Bearer $VERCEL_TOKEN" \
-                    "https://api.vercel.com/v3/aliases/$ALIAS?teamId=$VERCEL_ORG_ID" || echo "Failed to remove alias: $ALIAS"
-                fi
-              done
-              
-              # Remove the deployment
-              echo "Removing deployment: $DEPLOYMENT_ID"
-              curl -s -X DELETE -H "Authorization: Bearer $VERCEL_TOKEN" \
-                "https://api.vercel.com/v13/deployments/$DEPLOYMENT_ID?teamId=$VERCEL_ORG_ID" || echo "Failed to remove deployment: $DEPLOYMENT_ID"
+              # Remove the deployment and its aliases
+              echo "Removing deployment: $DEPLOYMENT_URL"
+              vercel remove "$DEPLOYMENT_URL" --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_URL"
             fi
           done
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,5 +1,8 @@
 name: cleanup
 on:
+  push:
+    branches:
+      - 'gha-cleanup'
   delete:
 jobs:
   cleanup:
@@ -10,6 +13,7 @@ jobs:
         run: curl -sSfL https://get.tur.so/install.sh | bash
         env:
           TURSO_INSTALL_SKIP_SIGNUP: 'true'
+
       - name: Delete preview database
         run: |
           set -o errexit
@@ -57,7 +61,18 @@ jobs:
           set -o pipefail
 
           ref="${{ github.event.ref }}"
+          echo "[DEBUG] Raw ref: ${ref}"
+
           branch="${ref##refs/heads/}"
+          echo "[DEBUG] Extracted branch: ${branch}"
+
+          # Safety check: never delete from production
+          echo "[DEBUG] Checking if branch is protected (main or release)"
+          if [ "$branch" = "main" ] || [ "$branch" = "release" ]; then
+            echo "[ERROR] Refusing to delete environment variables from production branch: ${branch}"
+            exit 1
+          fi
+          echo "[DEBUG] Branch check passed, proceeding with cleanup"
 
           ENV_VARS=(
             "DATABASE_URI"
@@ -67,8 +82,11 @@ jobs:
           )
 
           echo "[INFO] Removing environment variables for branch: ${branch}"
+          echo "[DEBUG] VERCEL_ORG_ID: $VERCEL_ORG_ID"
+          echo "[DEBUG] VERCEL_PROJECT_ID: $VERCEL_PROJECT_ID"
 
           for VAR in "${ENV_VARS[@]}"; do
+            echo "[DEBUG] Running: vercel env rm \"$VAR\" preview \"$branch\""
             echo "[INFO] Removing environment variable: $VAR"
             vercel env rm "$VAR" preview "$branch" --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Variable $VAR not found or already removed"
           done
@@ -83,12 +101,29 @@ jobs:
           set -o pipefail
 
           ref="${{ github.event.ref }}"
+          echo "[DEBUG] Raw ref: ${ref}"
+
           branch="${ref##refs/heads/}"
+          echo "[DEBUG] Extracted branch: ${branch}"
+
+          # Safety check: never delete from production
+          echo "[DEBUG] Checking if branch is protected (main or release)"
+          if [ "$branch" = "main" ] || [ "$branch" = "release" ]; then
+            echo "[ERROR] Refusing to delete deployments from production branch: ${branch}"
+            exit 1
+          fi
+          echo "[DEBUG] Branch check passed, proceeding with cleanup"
 
           echo "[INFO] Finding deployments for branch: ${branch}"
+          echo "[DEBUG] VERCEL_ORG_ID: $VERCEL_ORG_ID"
+          echo "[DEBUG] VERCEL_PROJECT_ID: $VERCEL_PROJECT_ID"
+          echo "[DEBUG] Running: vercel deployments --json"
 
           # Get all deployments and filter by branch
           DEPLOYMENTS=$(vercel deployments --json --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null | jq -r ".deployments[] | select(.meta.githubCommitRef==\"$branch\") | .uid" || echo "")
+
+          echo "[DEBUG] Deployments found: ${DEPLOYMENTS}"
+          echo "[DEBUG] Deployment count: $(echo "$DEPLOYMENTS" | wc -w)"
 
           if [ -z "$DEPLOYMENTS" ]; then
             echo "[WARN] No deployments found for branch: ${branch}"
@@ -97,13 +132,17 @@ jobs:
 
             # Remove aliases first (they're tied to deployment IDs)
             for DEPLOYMENT_ID in $DEPLOYMENTS; do
+              echo "[DEBUG] Processing deployment: $DEPLOYMENT_ID"
               echo "[INFO] Removing aliases for deployment: $DEPLOYMENT_ID"
               ALIASES=$(vercel alias ls --json --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null | jq -r ".aliases[] | select(.deploymentId==\"$DEPLOYMENT_ID\") | .alias" || echo "")
+
+              echo "[DEBUG] Aliases found for $DEPLOYMENT_ID: ${ALIASES}"
 
               if [ -z "$ALIASES" ]; then
                 echo "[WARN] No aliases found for deployment: $DEPLOYMENT_ID"
               else
                 for ALIAS in $ALIASES; do
+                  echo "[DEBUG] Running: vercel alias remove \"$ALIAS\""
                   echo "[INFO] Removing alias: $ALIAS"
                   vercel alias remove "$ALIAS" --token=${{ secrets.VERCEL_TOKEN }} --yes || echo "[WARN] Failed to remove alias: $ALIAS"
                 done
@@ -112,6 +151,7 @@ jobs:
 
             # Then remove deployments
             for DEPLOYMENT_ID in $DEPLOYMENTS; do
+              echo "[DEBUG] Running: vercel remove \"$DEPLOYMENT_ID\""
               echo "[INFO] Removing deployment: $DEPLOYMENT_ID"
               vercel remove "$DEPLOYMENT_ID" --token=${{ secrets.VERCEL_TOKEN }} --yes || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_ID"
             done

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -21,6 +21,9 @@ jobs:
           branch="${ref##refs/heads/}"
           clean_branch="${branch//[^a-z0-9\-]/x}"
 
+          # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
+          # and ensuring total database name stays within 58 character limit
+          # "payloadcms-preview-" is 19 characters, leaving 39 for the branch
           if [ ${#clean_branch} -gt 39 ]; then
             prefix="${clean_branch:0:31}"
             hash=$(echo -n "${clean_branch}" | sha256sum | cut -c1-7)
@@ -30,8 +33,10 @@ jobs:
           name="payloadcms-preview-${clean_branch}"
           echo "[INFO] Attempting to delete database ${name}"
 
+          # Switch to the correct organization
           /home/runner/.turso/turso org switch nwac
 
+          # Check if database exists before attempting to delete
           if /home/runner/.turso/turso db show "${name}" >/dev/null 2>&1; then
             echo "[INFO] Database ${name} exists, deleting..."
             /home/runner/.turso/turso db destroy --yes "${name}"

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,8 +1,8 @@
 name: cleanup
 on:
-  push:
-    branches:
-      - 'gha-cleanup'
+  workflow_run:
+    workflows: ['CI', 'preview']
+    types: [completed]
   delete:
 jobs:
   cleanup:
@@ -14,42 +14,42 @@ jobs:
         env:
           TURSO_INSTALL_SKIP_SIGNUP: 'true'
 
-      - name: Delete preview database
-        run: |
-          set -o errexit
-          set -o nounset
-          set -o pipefail
+      # - name: Delete preview database
+      #   run: |
+      #     set -o errexit
+      #     set -o nounset
+      #     set -o pipefail
 
-          ref="${{ github.event.ref }}"
-          branch="${ref##refs/heads/}"
-          clean_branch="${branch//[^a-z0-9\-]/x}"
+      #     ref="${{ github.event.ref }}"
+      #     branch="${ref##refs/heads/}"
+      #     clean_branch="${branch//[^a-z0-9\-]/x}"
 
-          # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
-          # and ensuring total database name stays within 58 character limit
-          # "payloadcms-preview-" is 19 characters, leaving 39 for the branch
-          if [ ${#clean_branch} -gt 39 ]; then
-            prefix="${clean_branch:0:31}"
-            hash=$(echo -n "${clean_branch}" | sha256sum | cut -c1-7)
-            clean_branch="${prefix}-${hash}"
-          fi
+      #     # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
+      #     # and ensuring total database name stays within 58 character limit
+      #     # "payloadcms-preview-" is 19 characters, leaving 39 for the branch
+      #     if [ ${#clean_branch} -gt 39 ]; then
+      #       prefix="${clean_branch:0:31}"
+      #       hash=$(echo -n "${clean_branch}" | sha256sum | cut -c1-7)
+      #       clean_branch="${prefix}-${hash}"
+      #     fi
 
-          name="payloadcms-preview-${clean_branch}"
-          echo "[INFO] Attempting to delete database ${name}"
+      #     name="payloadcms-preview-${clean_branch}"
+      #     echo "[INFO] Attempting to delete database ${name}"
 
-          # Switch to the correct organization
-          /home/runner/.turso/turso org switch nwac
+      #     # Switch to the correct organization
+      #     /home/runner/.turso/turso org switch nwac
 
-          # Check if database exists before attempting to delete
-          if /home/runner/.turso/turso db show "${name}" >/dev/null 2>&1; then
-            echo "[INFO] Database ${name} exists, deleting..."
-            /home/runner/.turso/turso db destroy --yes "${name}"
-            echo "[INFO] Successfully deleted database ${name}"
-          else
-            echo "[ERROR] Database ${name} does not exist, expected it to be there for cleanup"
-            exit 1
-          fi
-        env:
-          TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
+      #     # Check if database exists before attempting to delete
+      #     if /home/runner/.turso/turso db show "${name}" >/dev/null 2>&1; then
+      #       echo "[INFO] Database ${name} exists, deleting..."
+      #       /home/runner/.turso/turso db destroy --yes "${name}"
+      #       echo "[INFO] Successfully deleted database ${name}"
+      #     else
+      #       echo "[ERROR] Database ${name} does not exist, expected it to be there for cleanup"
+      #       exit 1
+      #     fi
+      #   env:
+      #     TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
 
       - name: Install Vercel CLI
         run: npm install -g vercel
@@ -88,7 +88,7 @@ jobs:
           for VAR in "${ENV_VARS[@]}"; do
             echo "[DEBUG] Running: vercel env rm \"$VAR\" preview \"$branch\""
             echo "[INFO] Removing environment variable: $VAR"
-            vercel env rm "$VAR" preview "$branch" --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Variable $VAR not found or already removed"
+            # vercel env rm "$VAR" preview "$branch" --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Variable $VAR not found or already removed"
           done
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -144,7 +144,7 @@ jobs:
                 for ALIAS in $ALIASES; do
                   echo "[DEBUG] Running: vercel alias remove \"$ALIAS\""
                   echo "[INFO] Removing alias: $ALIAS"
-                  vercel alias remove "$ALIAS" --token=${{ secrets.VERCEL_TOKEN }} --yes || echo "[WARN] Failed to remove alias: $ALIAS"
+                  # vercel alias remove "$ALIAS" --token=${{ secrets.VERCEL_TOKEN }} --yes || echo "[WARN] Failed to remove alias: $ALIAS"
                 done
               fi
             done
@@ -153,7 +153,7 @@ jobs:
             for DEPLOYMENT_ID in $DEPLOYMENTS; do
               echo "[DEBUG] Running: vercel remove \"$DEPLOYMENT_ID\""
               echo "[INFO] Removing deployment: $DEPLOYMENT_ID"
-              vercel remove "$DEPLOYMENT_ID" --token=${{ secrets.VERCEL_TOKEN }} --yes || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_ID"
+              # vercel remove "$DEPLOYMENT_ID" --token=${{ secrets.VERCEL_TOKEN }} --yes || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_ID"
             done
           fi
         env:

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,55 +1,52 @@
 name: cleanup
 on:
-  push:
-    branches:
-      - 'gha-cleanup'
   delete:
 jobs:
   cleanup:
     if: ${{ github.event_name == 'workflow_dispatch' || (!contains(fromJson('["main", "release"]'), github.event.ref)) }}
     runs-on: ubuntu-latest
     steps:
-      # - name: Install Turso CLI
-      #   run: curl -sSfL https://get.tur.so/install.sh | bash
-      #   env:
-      #     TURSO_INSTALL_SKIP_SIGNUP: 'true'
+      - name: Install Turso CLI
+        run: curl -sSfL https://get.tur.so/install.sh | bash
+        env:
+          TURSO_INSTALL_SKIP_SIGNUP: 'true'
 
-      # - name: Delete preview database
-      #   run: |
-      #     set -o errexit
-      #     set -o nounset
-      #     set -o pipefail
+      - name: Delete preview database
+        run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
 
-      #     ref="${{ github.event.ref }}"
-      #     branch="${ref##refs/heads/}"
-      #     clean_branch="${branch//[^a-z0-9\-]/x}"
+          ref="${{ github.event.ref }}"
+          branch="${ref##refs/heads/}"
+          clean_branch="${branch//[^a-z0-9\-]/x}"
 
-      #     # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
-      #     # and ensuring total database name stays within 58 character limit
-      #     # "payloadcms-preview-" is 19 characters, leaving 39 for the branch
-      #     if [ ${#clean_branch} -gt 39 ]; then
-      #       prefix="${clean_branch:0:31}"
-      #       hash=$(echo -n "${clean_branch}" | sha256sum | cut -c1-7)
-      #       clean_branch="${prefix}-${hash}"
-      #     fi
+          # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
+          # and ensuring total database name stays within 58 character limit
+          # "payloadcms-preview-" is 19 characters, leaving 39 for the branch
+          if [ ${#clean_branch} -gt 39 ]; then
+            prefix="${clean_branch:0:31}"
+            hash=$(echo -n "${clean_branch}" | sha256sum | cut -c1-7)
+            clean_branch="${prefix}-${hash}"
+          fi
 
-      #     name="payloadcms-preview-${clean_branch}"
-      #     echo "[INFO] Attempting to delete database ${name}"
+          name="payloadcms-preview-${clean_branch}"
+          echo "[INFO] Attempting to delete database ${name}"
 
-      #     # Switch to the correct organization
-      #     /home/runner/.turso/turso org switch nwac
+          # Switch to the correct organization
+          /home/runner/.turso/turso org switch nwac
 
-      #     # Check if database exists before attempting to delete
-      #     if /home/runner/.turso/turso db show "${name}" >/dev/null 2>&1; then
-      #       echo "[INFO] Database ${name} exists, deleting..."
-      #       /home/runner/.turso/turso db destroy --yes "${name}"
-      #       echo "[INFO] Successfully deleted database ${name}"
-      #     else
-      #       echo "[ERROR] Database ${name} does not exist, expected it to be there for cleanup"
-      #       exit 1
-      #     fi
-      #   env:
-      #     TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
+          # Check if database exists before attempting to delete
+          if /home/runner/.turso/turso db show "${name}" >/dev/null 2>&1; then
+            echo "[INFO] Database ${name} exists, deleting..."
+            /home/runner/.turso/turso db destroy --yes "${name}"
+            echo "[INFO] Successfully deleted database ${name}"
+          else
+            echo "[ERROR] Database ${name} does not exist, expected it to be there for cleanup"
+            exit 1
+          fi
+        env:
+          TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
 
       - name: Install Vercel CLI
         run: npm install -g vercel
@@ -80,7 +77,7 @@ jobs:
 
           for VAR in "${ENV_VARS[@]}"; do
             echo "[INFO] Removing environment variable: $VAR"
-            # vercel env rm "$VAR" preview "$branch" --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Variable $VAR not found or already removed"
+            vercel env rm "$VAR" preview "$branch" --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Variable $VAR not found or already removed"
           done
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -123,6 +120,3 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      - name: Log cleanup completion
-        run: echo "Vercel cleanup completed for branch ${{ github.head_ref }}"

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -85,6 +85,10 @@ jobs:
 
       - name: Remove Vercel deployments and aliases
         run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
           BRANCH_NAME="${{ github.head_ref }}"
           echo "Cleaning up deployments and aliases for branch: $BRANCH_NAME"
 

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -93,7 +93,7 @@ jobs:
           echo "Cleaning up deployments and aliases for branch: $branch"
 
           if [ "$branch" = "main" ] || [ "$branch" = "release" ]; then
-            echo "[ERROR] Refusing to delete environment variables from production branch: ${branch}"
+            echo "[ERROR] Refusing to delete deployments and aliases from production branch: ${branch}"
             exit 1
           fi
 

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -89,11 +89,16 @@ jobs:
           set -o nounset
           set -o pipefail
 
-          BRANCH_NAME="${{ github.head_ref }}"
-          echo "Cleaning up deployments and aliases for branch: $BRANCH_NAME"
+          branch="${{ github.head_ref }}"
+          echo "Cleaning up deployments and aliases for branch: $branch"
+
+          if [ "$branch" = "main" ] || [ "$branch" = "release" ]; then
+            echo "[ERROR] Refusing to delete environment variables from production branch: ${branch}"
+            exit 1
+          fi
 
           # Get all deployments for the project filtered by branch
-          vercel list --meta githubCommitRef=$BRANCH_NAME --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null | while read -r DEPLOYMENT_URL; do
+          vercel list --meta githubCommitRef=$branch --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null | while read -r DEPLOYMENT_URL; do
             if [ ! -z "$DEPLOYMENT_URL" ]; then
               echo "Found deployment: $DEPLOYMENT_URL"
               

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,8 +1,8 @@
 name: cleanup
 on:
-  workflow_run:
-    workflows: ['CI', 'preview']
-    types: [completed]
+  push:
+    branches:
+      - 'gha-cleanup'
   delete:
 jobs:
   cleanup:
@@ -14,42 +14,42 @@ jobs:
         env:
           TURSO_INSTALL_SKIP_SIGNUP: 'true'
 
-      # - name: Delete preview database
-      #   run: |
-      #     set -o errexit
-      #     set -o nounset
-      #     set -o pipefail
+      - name: Delete preview database
+        run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
 
-      #     ref="${{ github.event.ref }}"
-      #     branch="${ref##refs/heads/}"
-      #     clean_branch="${branch//[^a-z0-9\-]/x}"
+          ref="${{ github.event.ref }}"
+          branch="${ref##refs/heads/}"
+          clean_branch="${branch//[^a-z0-9\-]/x}"
 
-      #     # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
-      #     # and ensuring total database name stays within 58 character limit
-      #     # "payloadcms-preview-" is 19 characters, leaving 39 for the branch
-      #     if [ ${#clean_branch} -gt 39 ]; then
-      #       prefix="${clean_branch:0:31}"
-      #       hash=$(echo -n "${clean_branch}" | sha256sum | cut -c1-7)
-      #       clean_branch="${prefix}-${hash}"
-      #     fi
+          # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
+          # and ensuring total database name stays within 58 character limit
+          # "payloadcms-preview-" is 19 characters, leaving 39 for the branch
+          if [ ${#clean_branch} -gt 39 ]; then
+            prefix="${clean_branch:0:31}"
+            hash=$(echo -n "${clean_branch}" | sha256sum | cut -c1-7)
+            clean_branch="${prefix}-${hash}"
+          fi
 
-      #     name="payloadcms-preview-${clean_branch}"
-      #     echo "[INFO] Attempting to delete database ${name}"
+          name="payloadcms-preview-${clean_branch}"
+          echo "[INFO] Attempting to delete database ${name}"
 
-      #     # Switch to the correct organization
-      #     /home/runner/.turso/turso org switch nwac
+          # Switch to the correct organization
+          /home/runner/.turso/turso org switch nwac
 
-      #     # Check if database exists before attempting to delete
-      #     if /home/runner/.turso/turso db show "${name}" >/dev/null 2>&1; then
-      #       echo "[INFO] Database ${name} exists, deleting..."
-      #       /home/runner/.turso/turso db destroy --yes "${name}"
-      #       echo "[INFO] Successfully deleted database ${name}"
-      #     else
-      #       echo "[ERROR] Database ${name} does not exist, expected it to be there for cleanup"
-      #       exit 1
-      #     fi
-      #   env:
-      #     TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
+          # Check if database exists before attempting to delete
+          if /home/runner/.turso/turso db show "${name}" >/dev/null 2>&1; then
+            echo "[INFO] Database ${name} exists, deleting..."
+            /home/runner/.turso/turso db destroy --yes "${name}"
+            echo "[INFO] Successfully deleted database ${name}"
+          else
+            echo "[ERROR] Database ${name} does not exist, expected it to be there for cleanup"
+            exit 1
+          fi
+        env:
+          TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
 
       - name: Install Vercel CLI
         run: npm install -g vercel
@@ -94,68 +94,43 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
-      - name: Remove Vercel Deployments and Aliases
-        run: |
-          set -o errexit
-          set -o nounset
-          set -o pipefail
-
-          ref="${{ github.event.ref }}"
-          echo "[DEBUG] Raw ref: ${ref}"
-
-          branch="${ref##refs/heads/}"
-          echo "[DEBUG] Extracted branch: ${branch}"
-
-          # Safety check: never delete from production
-          echo "[DEBUG] Checking if branch is protected (main or release)"
-          if [ "$branch" = "main" ] || [ "$branch" = "release" ]; then
-            echo "[ERROR] Refusing to delete deployments from production branch: ${branch}"
-            exit 1
-          fi
-          echo "[DEBUG] Branch check passed, proceeding with cleanup"
-
-          echo "[INFO] Finding deployments for branch: ${branch}"
-          echo "[DEBUG] VERCEL_ORG_ID: $VERCEL_ORG_ID"
-          echo "[DEBUG] VERCEL_PROJECT_ID: $VERCEL_PROJECT_ID"
-          echo "[DEBUG] Running: vercel deployments --json"
-
-          # Get all deployments and filter by branch
-          DEPLOYMENTS=$(vercel deployments --json --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null | jq -r ".deployments[] | select(.meta.githubCommitRef==\"$branch\") | .uid" || echo "")
-
-          echo "[DEBUG] Deployments found: ${DEPLOYMENTS}"
-          echo "[DEBUG] Deployment count: $(echo "$DEPLOYMENTS" | wc -w)"
-
-          if [ -z "$DEPLOYMENTS" ]; then
-            echo "[WARN] No deployments found for branch: ${branch}"
-          else
-            echo "[INFO] Found deployments: $DEPLOYMENTS"
-
-            # Remove aliases first (they're tied to deployment IDs)
-            for DEPLOYMENT_ID in $DEPLOYMENTS; do
-              echo "[DEBUG] Processing deployment: $DEPLOYMENT_ID"
-              echo "[INFO] Removing aliases for deployment: $DEPLOYMENT_ID"
-              ALIASES=$(vercel alias ls --json --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null | jq -r ".aliases[] | select(.deploymentId==\"$DEPLOYMENT_ID\") | .alias" || echo "")
-
-              echo "[DEBUG] Aliases found for $DEPLOYMENT_ID: ${ALIASES}"
-
-              if [ -z "$ALIASES" ]; then
-                echo "[WARN] No aliases found for deployment: $DEPLOYMENT_ID"
-              else
-                for ALIAS in $ALIASES; do
-                  echo "[DEBUG] Running: vercel alias remove \"$ALIAS\""
-                  echo "[INFO] Removing alias: $ALIAS"
-                  # vercel alias remove "$ALIAS" --token=${{ secrets.VERCEL_TOKEN }} --yes || echo "[WARN] Failed to remove alias: $ALIAS"
-                done
-              fi
-            done
-
-            # Then remove deployments
-            for DEPLOYMENT_ID in $DEPLOYMENTS; do
-              echo "[DEBUG] Running: vercel remove \"$DEPLOYMENT_ID\""
-              echo "[INFO] Removing deployment: $DEPLOYMENT_ID"
-              # vercel remove "$DEPLOYMENT_ID" --token=${{ secrets.VERCEL_TOKEN }} --yes || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_ID"
-            done
-          fi
+      - name: Remove Vercel deployments and aliases
         env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          BRANCH_NAME="${{ github.head_ref }}"
+          echo "Cleaning up deployments and aliases for branch: $BRANCH_NAME"
+
+          # Get all deployments for the project
+          DEPLOYMENTS=$(curl -s -H "Authorization: Bearer $VERCEL_TOKEN" \
+            "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT_ID&teamId=$VERCEL_ORG_ID" | jq '.deployments')
+
+          # Filter deployments by branch name
+          echo "$DEPLOYMENTS" | jq -r '.[] | select(.meta.githubCommitRef == "'"$BRANCH_NAME"'") | .uid' | while read -r DEPLOYMENT_ID; do
+            if [ ! -z "$DEPLOYMENT_ID" ]; then
+              echo "Found deployment: $DEPLOYMENT_ID"
+              
+              # Get aliases for this deployment
+              ALIASES=$(curl -s -H "Authorization: Bearer $VERCEL_TOKEN" \
+                "https://api.vercel.com/v4/aliases?projectId=$VERCEL_PROJECT_ID&teamId=$VERCEL_ORG_ID&limit=100" | jq -r '.aliases[] | select(.deploymentId == "'"$DEPLOYMENT_ID"'") | .alias')
+              
+              # Remove each alias
+              echo "$ALIASES" | while read -r ALIAS; do
+                if [ ! -z "$ALIAS" ]; then
+                  echo "Removing alias: $ALIAS"
+                  curl -s -X DELETE -H "Authorization: Bearer $VERCEL_TOKEN" \
+                    "https://api.vercel.com/v3/aliases/$ALIAS?teamId=$VERCEL_ORG_ID" || echo "Failed to remove alias: $ALIAS"
+                fi
+              done
+              
+              # Remove the deployment
+              echo "Removing deployment: $DEPLOYMENT_ID"
+              curl -s -X DELETE -H "Authorization: Bearer $VERCEL_TOKEN" \
+                "https://api.vercel.com/v13/deployments/$DEPLOYMENT_ID?teamId=$VERCEL_ORG_ID" || echo "Failed to remove deployment: $DEPLOYMENT_ID"
+            fi
+          done
+
+      - name: Log cleanup completion
+        run: echo "Vercel cleanup completed for branch ${{ github.head_ref }}"

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -9,47 +9,47 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || (!contains(fromJson('["main", "release"]'), github.event.ref)) }}
     runs-on: ubuntu-latest
     steps:
-      - name: Install Turso CLI
-        run: curl -sSfL https://get.tur.so/install.sh | bash
-        env:
-          TURSO_INSTALL_SKIP_SIGNUP: 'true'
+      # - name: Install Turso CLI
+      #   run: curl -sSfL https://get.tur.so/install.sh | bash
+      #   env:
+      #     TURSO_INSTALL_SKIP_SIGNUP: 'true'
 
-      - name: Delete preview database
-        run: |
-          set -o errexit
-          set -o nounset
-          set -o pipefail
+      # - name: Delete preview database
+      #   run: |
+      #     set -o errexit
+      #     set -o nounset
+      #     set -o pipefail
 
-          ref="${{ github.event.ref }}"
-          branch="${ref##refs/heads/}"
-          clean_branch="${branch//[^a-z0-9\-]/x}"
+      #     ref="${{ github.event.ref }}"
+      #     branch="${ref##refs/heads/}"
+      #     clean_branch="${branch//[^a-z0-9\-]/x}"
 
-          # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
-          # and ensuring total database name stays within 58 character limit
-          # "payloadcms-preview-" is 19 characters, leaving 39 for the branch
-          if [ ${#clean_branch} -gt 39 ]; then
-            prefix="${clean_branch:0:31}"
-            hash=$(echo -n "${clean_branch}" | sha256sum | cut -c1-7)
-            clean_branch="${prefix}-${hash}"
-          fi
+      #     # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
+      #     # and ensuring total database name stays within 58 character limit
+      #     # "payloadcms-preview-" is 19 characters, leaving 39 for the branch
+      #     if [ ${#clean_branch} -gt 39 ]; then
+      #       prefix="${clean_branch:0:31}"
+      #       hash=$(echo -n "${clean_branch}" | sha256sum | cut -c1-7)
+      #       clean_branch="${prefix}-${hash}"
+      #     fi
 
-          name="payloadcms-preview-${clean_branch}"
-          echo "[INFO] Attempting to delete database ${name}"
+      #     name="payloadcms-preview-${clean_branch}"
+      #     echo "[INFO] Attempting to delete database ${name}"
 
-          # Switch to the correct organization
-          /home/runner/.turso/turso org switch nwac
+      #     # Switch to the correct organization
+      #     /home/runner/.turso/turso org switch nwac
 
-          # Check if database exists before attempting to delete
-          if /home/runner/.turso/turso db show "${name}" >/dev/null 2>&1; then
-            echo "[INFO] Database ${name} exists, deleting..."
-            /home/runner/.turso/turso db destroy --yes "${name}"
-            echo "[INFO] Successfully deleted database ${name}"
-          else
-            echo "[ERROR] Database ${name} does not exist, expected it to be there for cleanup"
-            exit 1
-          fi
-        env:
-          TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
+      #     # Check if database exists before attempting to delete
+      #     if /home/runner/.turso/turso db show "${name}" >/dev/null 2>&1; then
+      #       echo "[INFO] Database ${name} exists, deleting..."
+      #       /home/runner/.turso/turso db destroy --yes "${name}"
+      #       echo "[INFO] Successfully deleted database ${name}"
+      #     else
+      #       echo "[ERROR] Database ${name} does not exist, expected it to be there for cleanup"
+      #       exit 1
+      #     fi
+      #   env:
+      #     TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
 
       - name: Install Vercel CLI
         run: npm install -g vercel
@@ -61,18 +61,13 @@ jobs:
           set -o pipefail
 
           ref="${{ github.event.ref }}"
-          echo "[DEBUG] Raw ref: ${ref}"
-
           branch="${ref##refs/heads/}"
-          echo "[DEBUG] Extracted branch: ${branch}"
 
           # Safety check: never delete from production
-          echo "[DEBUG] Checking if branch is protected (main or release)"
           if [ "$branch" = "main" ] || [ "$branch" = "release" ]; then
             echo "[ERROR] Refusing to delete environment variables from production branch: ${branch}"
             exit 1
           fi
-          echo "[DEBUG] Branch check passed, proceeding with cleanup"
 
           ENV_VARS=(
             "DATABASE_URI"
@@ -82,11 +77,8 @@ jobs:
           )
 
           echo "[INFO] Removing environment variables for branch: ${branch}"
-          echo "[DEBUG] VERCEL_ORG_ID: $VERCEL_ORG_ID"
-          echo "[DEBUG] VERCEL_PROJECT_ID: $VERCEL_PROJECT_ID"
 
           for VAR in "${ENV_VARS[@]}"; do
-            echo "[DEBUG] Running: vercel env rm \"$VAR\" preview \"$branch\""
             echo "[INFO] Removing environment variable: $VAR"
             # vercel env rm "$VAR" preview "$branch" --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Variable $VAR not found or already removed"
           done
@@ -95,10 +87,6 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Remove Vercel deployments and aliases
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           BRANCH_NAME="${{ github.head_ref }}"
           echo "Cleaning up deployments and aliases for branch: $BRANCH_NAME"
@@ -131,6 +119,10 @@ jobs:
                 "https://api.vercel.com/v13/deployments/$DEPLOYMENT_ID?teamId=$VERCEL_ORG_ID" || echo "Failed to remove deployment: $DEPLOYMENT_ID"
             fi
           done
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Log cleanup completion
         run: echo "Vercel cleanup completed for branch ${{ github.head_ref }}"

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types:
       - opened
-      # - synchronize
+      - synchronize
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -20,46 +20,46 @@ jobs:
         run: curl -sSfL https://get.tur.so/install.sh | bash
         env:
           TURSO_INSTALL_SKIP_SIGNUP: 'true'
-      - name: Create a new database for the preview
-        id: database
-        run: |
-          set -o errexit
-          set -o nounset
-          set -o pipefail
+      # - name: Create a new database for the preview
+      #   id: database
+      #   run: |
+      #     set -o errexit
+      #     set -o nounset
+      #     set -o pipefail
 
-          head_ref="${{ github.head_ref }}"
-          ref="${head_ref//[^a-z0-9\-]/x}"
-          # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
-          # and ensuring total database name stays within 58 character limit
-          # "payloadcms-preview-" is 19 characters, leaving 39 for the ref
-          if [ ${#ref} -gt 39 ]; then
-            prefix="${ref:0:31}"
-            hash=$(echo -n "${ref}" | sha256sum | cut -c1-7)
-            ref="${prefix}-${hash}"
-          fi
-          echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
+      #     head_ref="${{ github.head_ref }}"
+      #     ref="${head_ref//[^a-z0-9\-]/x}"
+      #     # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
+      #     # and ensuring total database name stays within 58 character limit
+      #     # "payloadcms-preview-" is 19 characters, leaving 39 for the ref
+      #     if [ ${#ref} -gt 39 ]; then
+      #       prefix="${ref:0:31}"
+      #       hash=$(echo -n "${ref}" | sha256sum | cut -c1-7)
+      #       ref="${prefix}-${hash}"
+      #     fi
+      #     echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
 
-          name="payloadcms-preview-${ref}"
-          /home/runner/.turso/turso org switch nwac
-          if /home/runner/.turso/turso db show "${name}"; then
-            /home/runner/.turso/turso db destroy "${name}" --yes
-          fi
-          /home/runner/.turso/turso db create "${name}" --wait
-          /home/runner/.turso/turso db shell "${name}" .tables
-          echo "name=${name}" >> "${GITHUB_OUTPUT}"
-        env:
-          TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
-      - name: Record database connection URI and token
-        id: connection
-        run: |
-          set -o errexit
-          set -o nounset
-          set -o pipefail
+      #     name="payloadcms-preview-${ref}"
+      #     /home/runner/.turso/turso org switch nwac
+      #     if /home/runner/.turso/turso db show "${name}"; then
+      #       /home/runner/.turso/turso db destroy "${name}" --yes
+      #     fi
+      #     /home/runner/.turso/turso db create "${name}" --wait
+      #     /home/runner/.turso/turso db shell "${name}" .tables
+      #     echo "name=${name}" >> "${GITHUB_OUTPUT}"
+      #   env:
+      #     TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
+      # - name: Record database connection URI and token
+      #   id: connection
+      #   run: |
+      #     set -o errexit
+      #     set -o nounset
+      #     set -o pipefail
 
-          echo "uri=$(/home/runner/.turso/turso db show "${{ steps.database.outputs.name }}" --url)" >> "${GITHUB_OUTPUT}"
-          echo "token=$(/home/runner/.turso/turso db tokens create "${{ steps.database.outputs.name }}")" >> "${GITHUB_OUTPUT}"
-        env:
-          TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
+      #     echo "uri=$(/home/runner/.turso/turso db show "${{ steps.database.outputs.name }}" --url)" >> "${GITHUB_OUTPUT}"
+      #     echo "token=$(/home/runner/.turso/turso db tokens create "${{ steps.database.outputs.name }}")" >> "${GITHUB_OUTPUT}"
+      #   env:
+      #     TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
       - name: 🏗 Setup pnpm
@@ -99,13 +99,13 @@ jobs:
         run: echo -n "${{ steps.domains.outputs.preview_alias }}" | vercel env add NEXT_PUBLIC_ROOT_DOMAIN preview ${{ github.head_ref }} --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Pull Vercel Environment Variables into .env file
         run: vercel env pull --yes --environment=preview --git-branch="${{ github.head_ref }}" --token=${{ secrets.VERCEL_TOKEN }} .env
-      - name: Seed the database
-        run: pnpm seed:standalone
-        env:
-          DATABASE_URI: '${{ steps.connection.outputs.uri }}'
-          DATABASE_AUTH_TOKEN: '${{ steps.connection.outputs.token }}'
-          PAYLOAD_SEED_PASSWORD: '${{ secrets.PAYLOAD_SEED_PASSWORD }}'
-          PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
+      # - name: Seed the database
+      #   run: pnpm seed:standalone
+      #   env:
+      #     DATABASE_URI: '${{ steps.connection.outputs.uri }}'
+      #     DATABASE_AUTH_TOKEN: '${{ steps.connection.outputs.token }}'
+      #     PAYLOAD_SEED_PASSWORD: '${{ secrets.PAYLOAD_SEED_PASSWORD }}'
+      #     PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --git-branch="${{ github.head_ref }}" --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types:
       - opened
-      - synchronize
+      # - synchronize
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -20,46 +20,46 @@ jobs:
         run: curl -sSfL https://get.tur.so/install.sh | bash
         env:
           TURSO_INSTALL_SKIP_SIGNUP: 'true'
-      # - name: Create a new database for the preview
-      #   id: database
-      #   run: |
-      #     set -o errexit
-      #     set -o nounset
-      #     set -o pipefail
+      - name: Create a new database for the preview
+        id: database
+        run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
 
-      #     head_ref="${{ github.head_ref }}"
-      #     ref="${head_ref//[^a-z0-9\-]/x}"
-      #     # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
-      #     # and ensuring total database name stays within 58 character limit
-      #     # "payloadcms-preview-" is 19 characters, leaving 39 for the ref
-      #     if [ ${#ref} -gt 39 ]; then
-      #       prefix="${ref:0:31}"
-      #       hash=$(echo -n "${ref}" | sha256sum | cut -c1-7)
-      #       ref="${prefix}-${hash}"
-      #     fi
-      #     echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
+          head_ref="${{ github.head_ref }}"
+          ref="${head_ref//[^a-z0-9\-]/x}"
+          # Truncate ref to a prefix + hash suffix to avoid collisions while maintaining readability
+          # and ensuring total database name stays within 58 character limit
+          # "payloadcms-preview-" is 19 characters, leaving 39 for the ref
+          if [ ${#ref} -gt 39 ]; then
+            prefix="${ref:0:31}"
+            hash=$(echo -n "${ref}" | sha256sum | cut -c1-7)
+            ref="${prefix}-${hash}"
+          fi
+          echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
 
-      #     name="payloadcms-preview-${ref}"
-      #     /home/runner/.turso/turso org switch nwac
-      #     if /home/runner/.turso/turso db show "${name}"; then
-      #       /home/runner/.turso/turso db destroy "${name}" --yes
-      #     fi
-      #     /home/runner/.turso/turso db create "${name}" --wait
-      #     /home/runner/.turso/turso db shell "${name}" .tables
-      #     echo "name=${name}" >> "${GITHUB_OUTPUT}"
-      #   env:
-      #     TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
-      # - name: Record database connection URI and token
-      #   id: connection
-      #   run: |
-      #     set -o errexit
-      #     set -o nounset
-      #     set -o pipefail
+          name="payloadcms-preview-${ref}"
+          /home/runner/.turso/turso org switch nwac
+          if /home/runner/.turso/turso db show "${name}"; then
+            /home/runner/.turso/turso db destroy "${name}" --yes
+          fi
+          /home/runner/.turso/turso db create "${name}" --wait
+          /home/runner/.turso/turso db shell "${name}" .tables
+          echo "name=${name}" >> "${GITHUB_OUTPUT}"
+        env:
+          TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
+      - name: Record database connection URI and token
+        id: connection
+        run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
 
-      #     echo "uri=$(/home/runner/.turso/turso db show "${{ steps.database.outputs.name }}" --url)" >> "${GITHUB_OUTPUT}"
-      #     echo "token=$(/home/runner/.turso/turso db tokens create "${{ steps.database.outputs.name }}")" >> "${GITHUB_OUTPUT}"
-      #   env:
-      #     TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
+          echo "uri=$(/home/runner/.turso/turso db show "${{ steps.database.outputs.name }}" --url)" >> "${GITHUB_OUTPUT}"
+          echo "token=$(/home/runner/.turso/turso db tokens create "${{ steps.database.outputs.name }}")" >> "${GITHUB_OUTPUT}"
+        env:
+          TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
       - name: 🏗 Setup pnpm
@@ -99,13 +99,13 @@ jobs:
         run: echo -n "${{ steps.domains.outputs.preview_alias }}" | vercel env add NEXT_PUBLIC_ROOT_DOMAIN preview ${{ github.head_ref }} --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Pull Vercel Environment Variables into .env file
         run: vercel env pull --yes --environment=preview --git-branch="${{ github.head_ref }}" --token=${{ secrets.VERCEL_TOKEN }} .env
-      # - name: Seed the database
-      #   run: pnpm seed:standalone
-      #   env:
-      #     DATABASE_URI: '${{ steps.connection.outputs.uri }}'
-      #     DATABASE_AUTH_TOKEN: '${{ steps.connection.outputs.token }}'
-      #     PAYLOAD_SEED_PASSWORD: '${{ secrets.PAYLOAD_SEED_PASSWORD }}'
-      #     PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
+      - name: Seed the database
+        run: pnpm seed:standalone
+        env:
+          DATABASE_URI: '${{ steps.connection.outputs.uri }}'
+          DATABASE_AUTH_TOKEN: '${{ steps.connection.outputs.token }}'
+          PAYLOAD_SEED_PASSWORD: '${{ secrets.PAYLOAD_SEED_PASSWORD }}'
+          PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --git-branch="${{ github.head_ref }}" --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts


### PR DESCRIPTION
### Description
Since we ran out of space, we need to properly clean up Vercel preview items. This includes two main aread:
* Environment variables
  * This script works great! Added a branch catch all just in case (will need to remove for `main`)
  * We need to remove 4 variables associated with each branch:
      - `DATABASE_URI`
      - `DATABASE_AUTH_TOKEN`
      - `PAYLOAD_SEED_PASSWORD`
      - `NEXT_PUBLIC_ROOT_DOMAIN`

* Deployments and aliases
  * We need to remove the alias first since it is associated with a deployment id
  * Each branch/PR has 2 aliases that switch to the most recently deployed deployment
    * Wild card alias: `BRANCH_NAME.preview.avy-fx.org`
    * ID alias: `avy-HASH-nwac.vercel.app`
    
 TODO: 
 - Clean up deployments for `main` from `github-merge-queue[bot]`
 - Clean up deployments for `release`