### PR TITLE
Improve column selector for content blocks

### DIFF
--- a/src/components/ColumnLayoutPicker/index.tsx
+++ b/src/components/ColumnLayoutPicker/index.tsx
@@ -29,7 +29,7 @@ const ColumnLayoutPicker = (props: ColumnLayoutPickerProps) => {
 
   const { path, field } = props
   const { value, setValue } = useField<string>({ path })
-  const [currentValue, setCurrentValue] = useState(value || '1_1')
+  const [layoutSelection, setLayoutSelection] = useState(value || '1_1')
 
   const parentPath = path.split(`.${field.name}`)[0]
   const columnsPath = `${parentPath}.columns`
@@ -38,14 +38,14 @@ const ColumnLayoutPicker = (props: ColumnLayoutPickerProps) => {
 
   useEffect(() => {
     if (value) {
-      setCurrentValue(value)
+      setLayoutSelection(value)
     }
   }, [value])
 
   // Auto-select valid layout when columns change
   useEffect(() => {
     if (numColumns && numColumns > 0) {
-      const currentColCount = parseInt(currentValue.split('_')[0])
+      const currentColCount = parseInt(layoutSelection.split('_')[0])
       // If current selection doesn't match column count, find the first valid option
       if (currentColCount !== numColumns) {
         const validOption = layoutOptions.find(
@@ -53,11 +53,11 @@ const ColumnLayoutPicker = (props: ColumnLayoutPickerProps) => {
         )
         if (validOption) {
           setValue(validOption.value)
-          setCurrentValue(validOption.value)
+          setLayoutSelection(validOption.value)
         }
       }
     }
-  }, [numColumns, currentValue, setValue, layoutOptions])
+  }, [numColumns, layoutSelection, setValue, layoutOptions])
 
   if (numColumns === 0) return null
 
@@ -66,10 +66,10 @@ const ColumnLayoutPicker = (props: ColumnLayoutPickerProps) => {
       <FieldLabel htmlFor={path} label={field.label} required={field.required} />
       <ToggleGroup
         type="single"
-        value={currentValue}
+        value={layoutSelection}
         onValueChange={(newValue: string) => {
           if (newValue) {
-            setCurrentValue(newValue)
+            setLayoutSelection(newValue)
             setValue(newValue)
           }
         }}

--- a/src/components/ColumnLayoutPicker/index.tsx
+++ b/src/components/ColumnLayoutPicker/index.tsx
@@ -4,32 +4,60 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { FieldLabel, useField } from '@payloadcms/ui'
 import { Columns2, Columns3, Columns4, Square } from 'lucide-react'
 import { Field, SelectFieldClientProps } from 'payload'
+import { useEffect, useMemo, useState } from 'react'
 import { Columns112, Columns12, Columns121, Columns21, Columns211 } from './icons'
+
 type ColumnLayoutPickerProps = {
   sb: Field
 } & SelectFieldClientProps
+
 const ColumnLayoutPicker = (props: ColumnLayoutPickerProps) => {
-  const layoutOptions = [
-    { label: 'full', value: '1_1', icon: Square },
-    { label: '1:1', value: '2_11', icon: Columns2 },
-    { label: '1:2', value: '2_12', icon: Columns12 },
-    { label: '2:1', value: '2_21', icon: Columns21 },
-    { label: '1:1:1', value: '3_111', icon: Columns3 },
-    { label: '1:1:2', value: '3_112', icon: Columns112 },
-    { label: '1:2:1', value: '3_121', icon: Columns121 },
-    { label: '2:1:1', value: '3_211', icon: Columns211 },
-    { label: '1:1:1:1', value: '4_1111', icon: Columns4 },
-  ]
+  const layoutOptions = useMemo(
+    () => [
+      { label: 'full', value: '1_1', icon: Square },
+      { label: '1:1', value: '2_11', icon: Columns2 },
+      { label: '1:2', value: '2_12', icon: Columns12 },
+      { label: '2:1', value: '2_21', icon: Columns21 },
+      { label: '1:1:1', value: '3_111', icon: Columns3 },
+      { label: '1:1:2', value: '3_112', icon: Columns112 },
+      { label: '1:2:1', value: '3_121', icon: Columns121 },
+      { label: '2:1:1', value: '3_211', icon: Columns211 },
+      { label: '1:1:1:1', value: '4_1111', icon: Columns4 },
+    ],
+    [],
+  )
+
   const { path, field } = props
-
   const { value, setValue } = useField<string>({ path })
-
-  const currentValue = value || '1_1'
+  const [currentValue, setCurrentValue] = useState(value || '1_1')
 
   const parentPath = path.split(`.${field.name}`)[0]
   const columnsPath = `${parentPath}.columns`
 
   const { value: numColumns } = useField<number>({ path: columnsPath })
+
+  useEffect(() => {
+    if (value) {
+      setCurrentValue(value)
+    }
+  }, [value])
+
+  // Auto-select valid layout when columns change
+  useEffect(() => {
+    if (numColumns && numColumns > 0) {
+      const currentColCount = parseInt(currentValue.split('_')[0])
+      // If current selection doesn't match column count, find the first valid option
+      if (currentColCount !== numColumns) {
+        const validOption = layoutOptions.find(
+          (opt) => parseInt(opt.value.split('_')[0]) === numColumns,
+        )
+        if (validOption) {
+          setValue(validOption.value)
+          setCurrentValue(validOption.value)
+        }
+      }
+    }
+  }, [numColumns, currentValue, setValue, layoutOptions])
 
   if (numColumns === 0) return null
 
@@ -39,22 +67,26 @@ const ColumnLayoutPicker = (props: ColumnLayoutPickerProps) => {
       <ToggleGroup
         type="single"
         value={currentValue}
-        onValueChange={(newValue: string) => newValue && setValue(newValue)}
+        onValueChange={(newValue: string) => {
+          if (newValue) {
+            setCurrentValue(newValue)
+            setValue(newValue)
+          }
+        }}
         variant="outline"
         className="justify-start"
       >
         {layoutOptions.map((option) => {
           const Icon = option.icon
           const colCount = parseInt(option.value.split('_')[0])
-          const isDisabled = colCount !== numColumns
+          if (colCount !== numColumns) return null
 
           return (
             <ToggleGroupItem
               key={option.value}
               value={option.value}
               aria-label={option.label}
-              className={`${isDisabled ? 'pointer-events-auto cursor-not-allowed opacity-80' : 'cursor-pointer'}`}
-              disabled={isDisabled}
+              className="cursor-pointer"
             >
               <Icon style={{ width: '20px', height: '20px' }} />
             </ToggleGroupItem>


### PR DESCRIPTION
## Description
The column selector experience for content blocks is a bad UI & UX. This PR updates the column selector to automatically pick valid layout based on number of columns added. It will also hide any irrelevant column selections.

## Related Issues
Fixes #701 

## Key Changes
- Adds `useEffect` to listen for change in number of columns to automatically selects the first valid column layout when a column is added
- Hides any irrelevant/not valid column layouts that were previously displayed

## How to test
- Add a content block to a page
- Add/ remove columns and watch the column picker update

## Screenshots / Demo video
https://www.loom.com/share/9576fb618d7045ada752affafe0f00e9