### PR TITLE
Add payload workaround issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/payload-workaround.md
+++ b/.github/ISSUE_TEMPLATE/payload-workaround.md
@@ -2,8 +2,7 @@
 name: Payload workaround
 about: Keep track of Payload workaround bugs
 title: ''
-labels: payload
-milestone: 'Payload workarounds'
+labels: payload-workaround
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/payload-workaround.md
+++ b/.github/ISSUE_TEMPLATE/payload-workaround.md
@@ -3,7 +3,7 @@ name: Payload workaround
 about: Keep track of Payload workaround bugs
 title: ''
 labels: payload
-assignees: ''
+milestone: 'Payload workarounds'
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/payload-workaround.md
+++ b/.github/ISSUE_TEMPLATE/payload-workaround.md
@@ -1,0 +1,16 @@
+---
+name: Payload workaround
+about: Keep track of Payload workaround bugs
+title: ''
+labels: payload
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is and the fix you implemented.
+
+**Link to Payload**
+Link any Payload issues / PRs / discussions
+
+**Payload version**
+What is the current Payload version?


### PR DESCRIPTION
## Description
I wanted to make a space for us to keep track of the payload workaround we implement. Hopefully we wont use this issue that much, but I am just trying to make our lift easier to keep track of issues as payload fixes bugs.

~Add [Payload workarounds](https://github.com/NWACus/web/milestone/18) milestone to keep these in~


Thoughts on this? and the milestone?