### PR TITLE
Sort International (INTL) state option to bottom of providers embed list

### DIFF
--- a/src/app/(embeds)/embeds/providers/page.tsx
+++ b/src/app/(embeds)/embeds/providers/page.tsx
@@ -57,7 +57,12 @@ export default async function ProvidersEmbedPage({
     }
   })
 
-  const states = Object.keys(providersByState).sort()
+  // Sort states alphabetically, but always put International (INTL) last
+  const states = Object.keys(providersByState).sort((a, b) => {
+    if (a === 'INTL') return 1
+    if (b === 'INTL') return -1
+    return a.localeCompare(b)
+  })
 
   // Split states into two columns for vertical flow
   const midpoint = Math.ceil(states.length / 2)

--- a/src/utilities/queries/getCoursesStates.ts
+++ b/src/utilities/queries/getCoursesStates.ts
@@ -31,12 +31,12 @@ export async function getCoursesStates(): Promise<GetCoursesStatesResults> {
       }
     })
 
-    // Move international to the bottom of the list
-    const intlIndex = states.findIndex((s) => s.value === 'INTL')
-    if (intlIndex !== -1) {
-      const [intlItem] = states.splice(intlIndex, 1)
-      states.push(intlItem)
-    }
+    // Sort states alphabetically, but always put International (INTL) last
+    states.sort((a, b) => {
+      if (a.value === 'INTL') return 1
+      if (b.value === 'INTL') return -1
+      return 0 // preserve existing alphabetical order from DB
+    })
 
     return { states }
   } catch (error) {


### PR DESCRIPTION
## Description

Previously, states were sorted alphabetically which placed INTL between IL (Illinois) and IN (Indiana). This change uses a custom sort comparator to ensure INTL always appears last while maintaining alphabetical order for all other states.

## Screenshots / Demo video

Check out: https://international-to-bottom.preview.avy-fx.org/embeds/providers

