### PR TITLE
Add Claude GitHub integration for issue-driven development

### DIFF
--- a/.github/ISSUE_TEMPLATE/claude-task.md
+++ b/.github/ISSUE_TEMPLATE/claude-task.md
@@ -1,0 +1,50 @@
+---
+name: Claude Task
+about: Request a code change that Claude can implement
+title: ''
+labels: claude
+assignees: ''
+---
+
+@claude
+
+## What needs to be done
+
+<!-- Describe the change you want in plain language. Be specific about what should happen. -->
+
+## Context
+
+<!-- Optional: Add any helpful background information -->
+
+- Related page/feature:
+- Design link (if applicable):
+- Related issues:
+
+## Requirements
+
+<!-- List specific requirements as checkboxes. Claude will use these to verify the work is complete. -->
+
+- [ ] Requirement 1
+- [ ] Requirement 2
+- [ ] Tests pass
+
+## Examples (optional)
+
+<!-- If helpful, show before/after examples or reference similar existing features -->
+
+---
+
+<details>
+<summary>Tips for writing good Claude tasks</summary>
+
+**Be specific**: "Add a back-to-top button that appears after scrolling 500px" is better than "Add a button"
+
+**Include acceptance criteria**: Use checkboxes to define what "done" looks like
+
+**One task per issue**: Don't combine unrelated changes
+
+**Provide context**: Link to designs, reference existing similar features
+
+See the full guide: [docs/claude-github-issues.md](/docs/claude-github-issues.md)
+
+</details>

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -80,4 +80,4 @@ jobs:
 
           # Limit tools to safe operations for this codebase
           claude_args: |
-            --allowedTools "Read,Glob,Grep,Edit,Write,Bash(pnpm tsc),Bash(pnpm lint),Bash(pnpm test),Bash(pnpm test:*),Bash(git status),Bash(git diff),Bash(git add),Bash(git commit),Bash(git checkout -b *),Bash(git push),Bash(gh pr create *),Bash(gh issue comment *),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Read,Glob,Grep,Edit,Write,Bash(pnpm prettify),Bash(pnpm tsc),Bash(pnpm lint),Bash(pnpm test),Bash(pnpm test:*),Bash(git status),Bash(git diff),Bash(git add),Bash(git commit),Bash(git checkout -b *),Bash(git push),Bash(gh pr create *),Bash(gh issue comment *),mcp__github_inline_comment__create_inline_comment"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,19 +3,13 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
   issues:
     types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
@@ -33,7 +27,7 @@ jobs:
           result-encoding: string
           script: |
             const org = context.repo.owner;
-            const team = 'claude-users'; // Change this to your team slug
+            const team = 'claude-users';
             const username = context.actor;
 
             try {

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,89 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Check team membership
+        id: team-check
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            const org = context.repo.owner;
+            const team = 'claude-users'; // Change this to your team slug
+            const username = context.actor;
+
+            try {
+              await github.rest.teams.getMembershipForUserInOrg({
+                org,
+                team_slug: team,
+                username,
+              });
+              console.log(`✅ ${username} is a member of ${team}`);
+              return 'authorized';
+            } catch (error) {
+              if (error.status === 404) {
+                console.log(`❌ ${username} is not a member of ${team}`);
+                return 'unauthorized';
+              }
+              throw error;
+            }
+
+      - name: Post unauthorized comment
+        if: steps.team-check.outputs.result == 'unauthorized'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const username = context.actor;
+            const team = 'claude-users';
+            const issueNumber = context.issue?.number || context.payload.issue?.number || context.payload.pull_request?.number;
+
+            if (issueNumber) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `👋 @${username}, you're not currently authorized to use Claude on this repository.\n\nTo use Claude, you need to be a member of the \`${team}\` team. Please contact a repository administrator if you believe you should have access.`
+              });
+            }
+
+            core.setFailed(`User ${username} is not authorized to use Claude.`)
+
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+
+          # Limit tools to safe operations for this codebase
+          claude_args: |
+            --allowedTools "Read,Glob,Grep,Edit,Write,Bash(pnpm tsc),Bash(pnpm lint),Bash(pnpm test),Bash(pnpm test:*),Bash(git status),Bash(git diff),Bash(git add),Bash(git commit),Bash(git checkout -b *),Bash(git push),Bash(gh pr create *),Bash(gh issue comment *),mcp__github_inline_comment__create_inline_comment"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,7 +388,7 @@ When triggered via GitHub Issues (with `@claude` mention):
 1. Create a new branch from `main` with a descriptive name
 2. Make focused changes that address the issue requirements
 3. Follow existing code patterns and styles in the codebase
-4. Run `pnpm tsc` and `pnpm lint` before committing
+4. Run `pnpm prettify`, `pnpm tsc`, and `pnpm lint` before committing
 
 ### Creating the PR
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,9 +393,10 @@ When triggered via GitHub Issues (with `@claude` mention):
 ### Creating the PR
 
 1. Write a clear PR title summarizing the change
-2. Reference the issue number (e.g., "Fixes #123")
-3. Describe what was changed and why
-4. Note any decisions made or alternatives considered
+2. Follow the PR description template in .github/PULL_REQUEST_TEMPLATE.md
+3. Reference the issue number (e.g., "Fixes #123")
+4. Describe what was changed and why
+5. Note any decisions made or alternatives considered
 
 ### Quality Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,3 +370,40 @@ if (!document || !isValidRelationship(document)) {
 - Include tests with PRs when possible
 - Client tests go in `__tests__/client/` (jsdom environment)
 - Server tests go in `__tests__/server/` (node environment)
+
+---
+
+## Working on GitHub Issues
+
+When triggered via GitHub Issues (with `@claude` mention):
+
+### Before Making Changes
+
+1. Read the full issue description and any linked context
+2. Identify which files need to be modified
+3. Understand existing patterns in nearby code
+
+### Making Changes
+
+1. Create a new branch from `main` with a descriptive name
+2. Make focused changes that address the issue requirements
+3. Follow existing code patterns and styles in the codebase
+4. Run `pnpm tsc` and `pnpm lint` before committing
+
+### Creating the PR
+
+1. Write a clear PR title summarizing the change
+2. Reference the issue number (e.g., "Fixes #123")
+3. Describe what was changed and why
+4. Note any decisions made or alternatives considered
+
+### Quality Checklist
+
+Before marking work complete, verify:
+
+- [ ] Changes address all requirements in the issue
+- [ ] Code follows existing patterns in the codebase
+- [ ] No TypeScript errors (`pnpm tsc`)
+- [ ] No lint errors (`pnpm lint`)
+- [ ] Tests pass if applicable (`pnpm test`)
+- [ ] No unrelated changes included

--- a/README.md
+++ b/README.md
@@ -151,4 +151,4 @@ See our [revalidation docs](/docs/revalidation.md).
 
 ## Using Claude via GitHub Issues
 
-Non-developers can request code changes by creating GitHub issues that mention `@claude`. See our [Claude GitHub Issues guide](/docs/claude-github-issues.md) for instructions and best practices.
+Approved team members (part of the claude-users team) can request code changes by creating GitHub issues that mention `@claude`. See our [Claude GitHub Issues guide](/docs/claude-github-issues.md) for instructions and best practices.

--- a/README.md
+++ b/README.md
@@ -148,3 +148,7 @@ You likely won't use `pnpm email:build` or `pnpm email:export`. The primary meth
 ## Incremental Static Regeneration (ISR)
 
 See our [revalidation docs](/docs/revalidation.md).
+
+## Using Claude via GitHub Issues
+
+Non-developers can request code changes by creating GitHub issues that mention `@claude`. See our [Claude GitHub Issues guide](/docs/claude-github-issues.md) for instructions and best practices.

--- a/docs/claude-github-issues.md
+++ b/docs/claude-github-issues.md
@@ -1,0 +1,155 @@
+# Using Claude via GitHub Issues
+
+This guide explains how to use Claude Code to work on issues and create pull requests directly from GitHub.
+
+## How It Works
+
+When you mention `@claude` in a GitHub issue or comment, Claude will:
+
+1. Read the issue description and context
+2. Analyze the codebase to understand what needs to change
+3. Implement the requested changes
+4. Create a pull request with the solution
+
+A human developer should always review Claude's PR before merging.
+
+## Triggering Claude
+
+You can trigger Claude in several ways:
+
+| Method | Example |
+|--------|---------|
+| New issue with `@claude` in body | Create issue, include `@claude` in description |
+| Comment on existing issue | Add comment: `@claude please implement this` |
+| Assign Claude to an issue | Assign the `claude` user (if configured) |
+
+## Writing Good Prompts
+
+### Structure Your Request
+
+```
+@claude [What you want done]
+
+Context:
+- [Relevant background information]
+- [Links to related issues or designs]
+
+Requirements:
+- [ ] First requirement
+- [ ] Second requirement
+- [ ] Tests should pass
+```
+
+### Be Specific
+
+| Good | Less Good |
+|------|-----------|
+| "Add a 'Back to top' button that appears after scrolling 500px on blog posts" | "Add a back to top button" |
+| "Change the footer email from old@example.com to new@example.com" | "Update the contact info" |
+| "Fix the typo on the About page: 'recieve' should be 'receive'" | "Fix typos" |
+
+### Include Acceptance Criteria
+
+Use checkboxes to define what "done" looks like:
+
+```
+@claude Add dark mode toggle to the settings page
+
+Requirements:
+- [ ] Toggle appears in user settings
+- [ ] Persists preference to localStorage
+- [ ] Applies immediately without page refresh
+- [ ] Works with existing color scheme
+```
+
+## Example Prompts
+
+### Simple Text Change
+
+```
+@claude Fix the typo in the footer - "Copywrite 2024" should be "Copyright 2024"
+```
+
+### UI Addition
+
+```
+@claude Add a "scroll to top" button on long pages
+
+Requirements:
+- [ ] Button appears after scrolling down 400px
+- [ ] Styled consistently with existing buttons (use our Button component)
+- [ ] Smooth scroll animation
+- [ ] Accessible (has aria-label)
+```
+
+### Bug Fix
+
+```
+@claude The date picker on the events page shows the wrong timezone
+
+Steps to reproduce:
+1. Go to /events
+2. Click "Add Event"
+3. Select a date - it shows UTC instead of Pacific time
+
+Expected: Dates should display in the user's local timezone
+```
+
+### Content Update
+
+```
+@claude Update the team members on the About page
+
+Changes needed:
+- Remove: Jane Smith (departed)
+- Add: John Doe, role: "Avalanche Forecaster", joined 2024
+- Update: Sarah's title from "Intern" to "Junior Forecaster"
+```
+
+## What Claude Can and Cannot Do
+
+### Claude CAN:
+
+- Read and understand the entire codebase
+- Create new files and modify existing ones
+- Run tests and fix failures
+- Create well-documented pull requests
+- Follow existing code patterns and styles
+
+### Claude CANNOT:
+
+- Access external services or APIs not in the codebase
+- Deploy changes (PRs still need human approval)
+- Access secrets or environment variables
+- Make changes outside the repository
+
+## Tips for Success
+
+1. **Start simple** - Try small changes first to build confidence
+2. **One task per issue** - Don't combine unrelated changes
+3. **Provide context** - Link to designs, reference existing similar features
+4. **Use the template** - The "Claude Task" issue template guides you through writing good prompts
+5. **Review the PR** - Always review Claude's changes before merging
+
+## Troubleshooting
+
+### Claude didn't respond
+
+- Ensure `@claude` is in the issue body or comment (not just the title)
+- Check that the GitHub Action workflow ran (look in the Actions tab)
+- The repo must have `ANTHROPIC_API_KEY` configured in secrets
+
+### Claude made incorrect changes
+
+- Add a comment with more specific instructions
+- Reference specific files or line numbers if you know them
+- Break the task into smaller pieces
+
+### Claude's PR has test failures
+
+- Comment on the PR: `@claude please fix the failing tests`
+- Claude will analyze the failures and push fixes
+
+## For Developers
+
+See the workflow configuration in `.github/workflows/claude.yml` and the [CLAUDE.md](../CLAUDE.md) file for how Claude is configured for this repository.

--- a/docs/claude-github-issues.md
+++ b/docs/claude-github-issues.md
@@ -21,7 +21,6 @@ You can trigger Claude in several ways:
 |--------|---------|
 | New issue with `@claude` in body | Create issue, include `@claude` in description |
 | Comment on existing issue | Add comment: `@claude please implement this` |
-| Assign Claude to an issue | Assign the `claude` user (if configured) |
 
 ## Writing Good Prompts
 


### PR DESCRIPTION
## Description

Enables claude-code team members to request code changes by creating GitHub issues that mention `@claude`. Claude will implement the requested changes and create a pull request for review.

## Key Changes

- **`.github/workflows/claude.yml`** - GitHub Actions workflow that:
  - Triggers on `@claude` mentions in issues and PR comments
  - Checks team membership (`claude-users` team) before running
  - Posts friendly feedback to unauthorized users
  - Runs Claude with scoped tool permissions

- **`.github/ISSUE_TEMPLATE/claude-task.md`** - Issue template that guides users to write good prompts with context, requirements, and acceptance criteria

- **`docs/claude-github-issues.md`** - User guide for non-technical users explaining how to write effective prompts and what to expect

- **`CLAUDE.md`** - Added "Working on GitHub Issues" section with workflow guidance for Claude

- **`README.md`** - Added link to the Claude guide

## How to test

1. Create a `claude-users` team in the GitHub org
2. Add `ANTHROPIC_API_KEY` to repository secrets
3. Install the Claude GitHub App: https://github.com/apps/claude
4. Create a test issue using the "Claude Task" template
5. Verify Claude responds and creates a PR

## Future enhancements / Questions

- Consider adding a cost/usage monitoring solution
- May want to tune the `allowedTools` list based on actual usage patterns
- Could add label-based triggers as an alternative to team membership
