### PR TITLE
Remove vercel deployments for `main` branch

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -121,7 +121,7 @@ jobs:
             --meta="githubRepo=${fullName##*/}" \
             --meta='githubCommitAuthorLogin=${{ github.event.pusher.name }}' \
             --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Remove old Vercel deployments (keep last 2)
+      - name: Remove old Vercel deployments (keep latest 2)
         run: |
           set -o errexit
           set -o nounset
@@ -149,7 +149,7 @@ jobs:
             echo "$deployments" | tail -n +2 | while read -r DEPLOYMENT_URL; do
               if [ ! -z "$DEPLOYMENT_URL" ]; then
                 echo "Removing deployment: $DEPLOYMENT_URL"
-                vercel remove --scope=nwac "$DEPLOYMENT_URL" --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_URL"
+                vercel remove --scope=nwac "$DEPLOYMENT_URL" --safe --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_URL"
               fi
             done
           else

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -137,21 +137,11 @@ jobs:
             exit 1
           fi
 
-          # Get all deployments for the project filtered by branch
+          # All deployments for branch
           deployments=$(vercel list --scope=nwac --meta githubCommitRef=$branch --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null | tail -n +2)
 
           # Count total deployments
           total=$(echo "$deployments" | grep -c . || true)
-          echo "Found $total deployments for branch: $branch"
-          echo "All deployments:"
-          echo "$deployments"
-
-          # Show which ones we'll delete
-          if [ "$total" -gt 1 ]; then
-            echo ""
-            echo "Deployments to delete (all except latest 1):"
-            echo "$deployments" | tail -n +2
-          fi
 
           # Keep the last 1, delete the rest
           if [ "$total" -gt 1 ]; then
@@ -159,7 +149,7 @@ jobs:
             echo "$deployments" | tail -n +2 | while read -r DEPLOYMENT_URL; do
               if [ ! -z "$DEPLOYMENT_URL" ]; then
                 echo "Removing deployment: $DEPLOYMENT_URL"
-                # vercel remove --scope=nwac "$DEPLOYMENT_URL" --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_URL"
+                vercel remove --scope=nwac "$DEPLOYMENT_URL" --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_URL"
               fi
             done
           else

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -88,3 +88,36 @@ jobs:
             --meta="githubRepo=${fullName##*/}" \
             --meta='githubCommitAuthorLogin=${{ github.event.pusher.name }}' \
             --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Remove old Vercel deployments (keep latest 2)
+        run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
+          ref="${{ github.event.ref }}"
+          branch="${ref##refs/heads/}"
+
+          echo "Cleaning up deployments and aliases for branch: $branch"
+
+          # All deployments for branch
+          deployments=$(vercel list --scope=nwac --meta githubCommitRef=$branch --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null | tail -n +2)
+
+          # Count total deployments
+          total=$(echo "$deployments" | grep -c . || true)
+
+          # Keep the last 1, delete the rest
+          if [ "$total" -gt 1 ]; then
+            echo "Keeping last 1 deployment, deleting $(($total - 1))"
+            echo "$deployments" | tail -n +2 | while read -r DEPLOYMENT_URL; do
+              if [ ! -z "$DEPLOYMENT_URL" ]; then
+                echo "Removing deployment: $DEPLOYMENT_URL"
+                vercel remove --scope=nwac "$DEPLOYMENT_URL" --safe --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_URL"
+              fi
+            done
+          else
+            echo "Only 1 deployment found, nothing to delete"
+          fi
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/sync-prod-to-dev.yml
+++ b/.github/workflows/sync-prod-to-dev.yml
@@ -128,7 +128,7 @@ jobs:
             --meta="githubRepo=${fullName##*/}" \
             --meta='githubCommitAuthorLogin=${{ github.workflow }}' \
             --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Remove old Vercel deployments (keep last 2)
+      - name: Remove old Vercel deployments (keep latest 2)
         run: |
           set -o errexit
           set -o nounset
@@ -156,7 +156,7 @@ jobs:
             echo "$deployments" | tail -n +2 | while read -r DEPLOYMENT_URL; do
               if [ ! -z "$DEPLOYMENT_URL" ]; then
                 echo "Removing deployment: $DEPLOYMENT_URL"
-                vercel remove --scope=nwac "$DEPLOYMENT_URL" --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_URL"
+                vercel remove --scope=nwac "$DEPLOYMENT_URL" --safe --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_URL"
               fi
             done
           else

--- a/.github/workflows/sync-prod-to-dev.yml
+++ b/.github/workflows/sync-prod-to-dev.yml
@@ -128,3 +128,41 @@ jobs:
             --meta="githubRepo=${fullName##*/}" \
             --meta='githubCommitAuthorLogin=${{ github.workflow }}' \
             --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Remove old Vercel deployments (keep last 2)
+        run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
+          ref="${{ github.event.ref }}"
+          branch="${ref##refs/heads/}"
+
+          echo "Cleaning up deployments and aliases for branch: $branch"
+
+          if [ "$branch" = "release" ]; then
+            echo "[ERROR] Refusing to delete deployments and aliases from production branch: ${branch}"
+            exit 1
+          fi
+
+          # All deployments for branch
+          deployments=$(vercel list --scope=nwac --meta githubCommitRef=$branch --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null | tail -n +2)
+
+          # Count total deployments
+          total=$(echo "$deployments" | grep -c . || true)
+
+          # Keep the last 1, delete the rest
+          if [ "$total" -gt 1 ]; then
+            echo "Keeping last 1 deployment, deleting $(($total - 1))"
+            echo "$deployments" | tail -n +2 | while read -r DEPLOYMENT_URL; do
+              if [ ! -z "$DEPLOYMENT_URL" ]; then
+                echo "Removing deployment: $DEPLOYMENT_URL"
+                vercel remove --scope=nwac "$DEPLOYMENT_URL" --yes --token=${{ secrets.VERCEL_TOKEN }} || echo "[WARN] Failed to remove deployment: $DEPLOYMENT_URL"
+              fi
+            done
+          else
+            echo "Only 1 deployment found, nothing to delete"
+          fi
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Description
Updates `production.yml` `development.yml` and `sync-prod-to-dev.yml` to remove deployments from Vercel for `main` and `release` branch

## Related Issues
Fixes #790 

## Key Changes
Debugged in #876 #877 #878
Uses script that works from #856 #870
Added --safe to not delete any deployments with an alias. I did not add this to `cleanup,yml` since we will want to remove the deployments that have assigned preview aliases. This is just a guard rail for dev and prod
```md
➜  web git:(update-dev-gha) vercel remove "DEPLOYMENT_URL" --safe
Vercel CLI 48.12.0
> Could not find unaliased deployments or projects matching "DEPLOYMENT_URL". Run `vercel projects ls` to list.
```

## How to test
Look at previously run [development GHA](https://github.com/NWACus/web/actions/runs/21189866332/job/60953651279). This run had `vercel remove` commented out with debugging statements enabled to test
