### PR TITLE
Workflow to auto-format dependabot branches

### DIFF
--- a/.github/workflows/dependabot-auto-format.yml
+++ b/.github/workflows/dependabot-auto-format.yml
@@ -1,0 +1,45 @@
+name: Dependabot Auto-format
+
+on:
+  pull_request_target:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  prettify:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'pnpm'
+
+      - name: 📦 Install dependencies
+        run: pnpm ii
+        shell: bash
+
+      - name: Run prettify and lint:fix
+        run: pnpm prettify && pnpm lint:fix
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'style: run prettify and lint:fix'
+          commit_user_name: github-actions[bot]
+          commit_user_email: github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
## Description

Our dependabot PRs always fail on the prettier check in CI so let's `lint:fix` and `prettify`.