### PR TITLE
Verified dependabot formatting commits

### DIFF
--- a/.github/workflows/dependabot-auto-format.yml
+++ b/.github/workflows/dependabot-auto-format.yml
@@ -37,9 +37,19 @@ jobs:
       - name: Run prettify and lint:fix
         run: pnpm prettify && pnpm lint:fix
 
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'style: run prettify and lint:fix'
-          commit_user_name: github-actions[bot]
-          commit_user_email: github-actions[bot]@users.noreply.github.com
+          commit_author: ${{ steps.import-gpg.outputs.name }} <${{ steps.import-gpg.outputs.email }}>
+          commit_user_name: ${{ steps.import-gpg.outputs.name }}
+          commit_user_email: ${{ steps.import-gpg.outputs.email }}


### PR DESCRIPTION
## Description

I thought the git-auto-commit-action would be verified but I guess not. I created a GPG key using my GH no-reply email and added actions secrets for that key and it's passphrase. So commits will appear verified as me. We should get a bot account set up but this should at least work for now. Would love to just be able to accept dependabot PRs 🤦‍♂️

## Key Changes

Adds an import GPG key step and using in formatting commit
