### PR TITLE
Allow providers to edit and delete users they have access to

### DIFF
--- a/src/collections/Users/access/byGlobalRoleOrTenantRoleAssignmentOrDomain.ts
+++ b/src/collections/Users/access/byGlobalRoleOrTenantRoleAssignmentOrDomain.ts
@@ -70,30 +70,28 @@ export const byGlobalRoleOrTenantRoleAssignmentOrDomain: (method: ruleMethod) =>
       )
     }
 
-    // Provider managers can see all users with provider relationship(s) and themselves
-    if (method === 'read') {
-      const isManager = await isProviderManager(args.req.payload, args.req.user)
-      if (isManager) {
-        const orConditions: Where[] = [
-          {
-            providers: {
-              exists: true,
-            },
+    // Provider managers permissions for users with provider relationship(s) and themselves
+    const isManager = await isProviderManager(args.req.payload, args.req.user)
+    if (isManager) {
+      const orConditions: Where[] = [
+        {
+          providers: {
+            exists: true,
           },
-        ]
+        },
+      ]
 
-        if (args.req.user.id) {
-          orConditions.push({
-            id: {
-              equals: args.req.user.id,
-            },
-          })
-        }
-
-        conditions.push({
-          or: orConditions,
+      if (args.req.user.id) {
+        orConditions.push({
+          id: {
+            equals: args.req.user.id,
+          },
         })
       }
+
+      conditions.push({
+        or: orConditions,
+      })
     }
 
     if (conditions.length > 0) {

--- a/src/collections/Users/access/byGlobalRoleOrTenantRoleAssignmentOrDomain.ts
+++ b/src/collections/Users/access/byGlobalRoleOrTenantRoleAssignmentOrDomain.ts
@@ -71,29 +71,27 @@ export const byGlobalRoleOrTenantRoleAssignmentOrDomain: (method: ruleMethod) =>
     }
 
     // Provider managers can see all users with provider relationship(s) and themselves
-    if (method === 'read') {
-      const isManager = await isProviderManager(args.req.payload, args.req.user)
-      if (isManager) {
-        const orConditions: Where[] = [
-          {
-            providers: {
-              exists: true,
-            },
+    const isManager = await isProviderManager(args.req.payload, args.req.user)
+    if (isManager) {
+      const orConditions: Where[] = [
+        {
+          providers: {
+            exists: true,
           },
-        ]
+        },
+      ]
 
-        if (args.req.user.id) {
-          orConditions.push({
-            id: {
-              equals: args.req.user.id,
-            },
-          })
-        }
-
-        conditions.push({
-          or: orConditions,
+      if (args.req.user.id) {
+        orConditions.push({
+          id: {
+            equals: args.req.user.id,
+          },
         })
       }
+
+      conditions.push({
+        or: orConditions,
+      })
     }
 
     if (conditions.length > 0) {

--- a/src/collections/Users/access/byGlobalRoleOrTenantRoleAssignmentOrDomain.ts
+++ b/src/collections/Users/access/byGlobalRoleOrTenantRoleAssignmentOrDomain.ts
@@ -35,7 +35,7 @@ export const byGlobalRoleOrTenantRoleAssignmentOrDomain: (method: ruleMethod) =>
         assignment.role.rules.some(ruleMatches(method, 'users')),
     )
 
-    const conditions = []
+    const conditions: Where[] = []
 
     // Tenant scoped role based access
     const userCollectionRoleAssignmentsTenants = userCollectionRoleAssignments
@@ -99,18 +99,25 @@ export const byGlobalRoleOrTenantRoleAssignmentOrDomain: (method: ruleMethod) =>
     if (method === 'update' || method === 'delete') {
       const isManager = await isProviderManager(args.req.payload, args.req.user)
       if (isManager) {
-        const managerCondition: Where = {
-          providers: {
-            exists: true,
-          },
-          'roles.docs.0': {
-            exists: false,
-          },
-          'globalRoleAssignments.docs.0': {
-            exists: false,
-          },
-        }
-        conditions.push(managerCondition)
+        conditions.push({
+          and: [
+            {
+              providers: {
+                exists: true,
+              },
+            },
+            {
+              roles: {
+                exists: false,
+              },
+            },
+            {
+              globalRoleAssignments: {
+                exists: false,
+              },
+            },
+          ],
+        })
       }
     }
 

--- a/src/collections/Users/access/byGlobalRoleOrTenantRoleAssignmentOrDomain.ts
+++ b/src/collections/Users/access/byGlobalRoleOrTenantRoleAssignmentOrDomain.ts
@@ -96,31 +96,6 @@ export const byGlobalRoleOrTenantRoleAssignmentOrDomain: (method: ruleMethod) =>
       }
     }
 
-    if (method === 'update' || method === 'delete') {
-      const isManager = await isProviderManager(args.req.payload, args.req.user)
-      if (isManager) {
-        conditions.push({
-          and: [
-            {
-              providers: {
-                exists: true,
-              },
-            },
-            {
-              roles: {
-                exists: false,
-              },
-            },
-            {
-              globalRoleAssignments: {
-                exists: false,
-              },
-            },
-          ],
-        })
-      }
-    }
-
     if (conditions.length > 0) {
       return {
         or: conditions,

--- a/src/collections/Users/index.ts
+++ b/src/collections/Users/index.ts
@@ -120,5 +120,29 @@ export const Users: CollectionConfig = {
     afterLogin: [setLastLogin, posthogIdentifyAfterLogin],
     beforeLogin: [validateDomainAccessBeforeLogin],
     beforeValidate: [beforeValidatePassword],
+    beforeChange: [
+      async ({ data, operation }) => {
+        if (
+          ((data.globalRoleAssignments?.docs?.length ?? 0) > 0 ||
+            (data.roles?.docs?.length ?? 0) > 0) &&
+          operation === 'update'
+        )
+          throw new Error('Cannot edit users of avalanche center')
+      },
+    ],
+    beforeDelete: [
+      async ({ req, id }) => {
+        const userToDelete = await req.payload.findByID({
+          collection: 'users',
+          id,
+        })
+
+        if (
+          (userToDelete.globalRoleAssignments?.docs?.length ?? 0) > 0 ||
+          (userToDelete.roles?.docs?.length ?? 0) > 0
+        )
+          throw new Error('Cannot delete users of avalanche center')
+      },
+    ],
   },
 }

--- a/src/collections/Users/index.ts
+++ b/src/collections/Users/index.ts
@@ -1,8 +1,10 @@
 import type { CollectionConfig } from 'payload'
 
 import { byGlobalRole } from '@/access/byGlobalRole'
+import { hasSuperAdminPermissions } from '@/access/hasSuperAdminPermissions'
 import { contentHashField } from '@/fields/contentHashField'
 import { generateForgotPasswordEmail } from '@/utilities/email/generateForgotPasswordEmail'
+import { isProviderManager } from '@/utilities/rbac/isProviderManager'
 import { accessByGlobalRoleOrTenantRoleAssignmentOrDomain } from './access/byGlobalRoleOrTenantRoleAssignmentOrDomain'
 import { filterByTenantScopedDomain } from './access/filterByTenantScopedDomain'
 import { beforeValidatePassword } from './hooks/beforeValidatePassword'
@@ -121,26 +123,40 @@ export const Users: CollectionConfig = {
     beforeLogin: [validateDomainAccessBeforeLogin],
     beforeValidate: [beforeValidatePassword],
     beforeChange: [
-      async ({ data, operation }) => {
-        if (
-          ((data.globalRoleAssignments?.docs?.length ?? 0) > 0 ||
-            (data.roles?.docs?.length ?? 0) > 0) &&
-          operation === 'update'
-        )
+      async ({ data, operation, req }) => {
+        const user = req.user
+        if (!user) return
+        const isSuperAdmin = await hasSuperAdminPermissions({ req })
+        const loggedInAsManager =
+          (await isProviderManager(req.payload, user)) &&
+          !isSuperAdmin &&
+          user.roles?.docs?.length === 0
+        const isAvyUser =
+          (data.globalRoleAssignments?.docs?.length ?? 0) > 0 || (data.roles?.docs?.length ?? 0) > 0
+        if (operation === 'update' && loggedInAsManager && isAvyUser)
           throw new Error('Cannot edit users of avalanche center')
       },
     ],
     beforeDelete: [
       async ({ req, id }) => {
+        const user = req.user
+        if (!user) return
+        const isSuperAdmin = await hasSuperAdminPermissions({ req })
+        const loggedInAsManager =
+          (await isProviderManager(req.payload, user)) &&
+          !isSuperAdmin &&
+          user.roles?.docs?.length === 0
+
         const userToDelete = await req.payload.findByID({
           collection: 'users',
           id,
         })
 
-        if (
+        const isAvyUser =
           (userToDelete.globalRoleAssignments?.docs?.length ?? 0) > 0 ||
           (userToDelete.roles?.docs?.length ?? 0) > 0
-        )
+
+        if (loggedInAsManager && isAvyUser)
           throw new Error('Cannot delete users of avalanche center')
       },
     ],


### PR DESCRIPTION
## Description
As mentioned, we want to give a provider manager permission to:
- read any user with a providers relationship
- edit/delete that is not associated with an avy center


## Related Issues
Resolves #834 

## Key Changes
Changed permissions for provider managers on `users` collection and add beforeChange and beforeDelete hooks

## How to test
- Log in as provider manager
- Navigate to users
- Select user with checkmark
- See options to `Edit` and `Delete` 

## Screenshots / Demo video
https://www.loom.com/share/9a79a65e6cec4e35888171620ed448e4

## Migration Explanation
None