### PR TITLE
Fix infinite events api call

### DIFF
--- a/src/blocks/EventTable/Component.tsx
+++ b/src/blocks/EventTable/Component.tsx
@@ -86,7 +86,7 @@ export const EventTableBlockComponent = (args: EventTableComponentProps) => {
     }
 
     fetchEvents()
-  }, [eventOptions, byTypes, byGroups, byTags, maxEvents, tenant, staticEvents, fetchedEvents])
+  }, [eventOptions, byTypes, byGroups, byTags, maxEvents, tenant])
 
   if (eventOptions === 'dynamic') {
     displayEvents = filterValidPublishedRelationships(fetchedEvents)


### PR DESCRIPTION
## Description
When editing some pages, I noticed any page with event table on it was making infinite api calls. 
```bash
...
 GET /api/nwac/events?limit=6&startDate=01-28-2026 200 in 27ms
 GET /api/nwac/events?limit=6&startDate=01-28-2026 200 in 18ms
 GET /api/nwac/events?limit=6&startDate=01-28-2026 200 in 36ms
 GET /api/nwac/events?limit=6&startDate=01-28-2026 200 in 12ms
 GET /api/nwac/events?limit=6&startDate=01-28-2026 200 in 12ms
 GET /api/nwac/events?limit=6&startDate=01-28-2026 200 in 23ms
 GET /api/nwac/events?limit=6&startDate=01-28-2026 200 in 13ms
 GET /api/nwac/events?limit=6&startDate=01-28-2026 200 in 32ms
 GET /api/nwac/events?limit=6&startDate=01-28-2026 200 in 12ms
...
```


## Related Issues

## Key Changes
Remove fetchEvents as dependency causing infinite api call

## How to test
Add event table to a page