### PR TITLE
Update robots file to include facebook and twitter

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -5,11 +5,25 @@ export default function robots(): MetadataRoute.Robots {
   const SITE_URL = getURL()
 
   return {
-    rules: {
-      userAgent: '*',
-      allow: '/',
-      disallow: ['/admin', '/admin/'],
-    },
+    rules: [
+      {
+        userAgent: 'facebookexternaluser',
+        disallow: '/',
+      },
+      {
+        userAgent: 'facebookexternaluser',
+        disallow: '/',
+      },
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/admin', '/admin/'],
+      },
+      {
+        userAgent: '*',
+        disallow: ['/*.pdf', '/*.jpg', '/*.jpeg', '/*.png', '/*.gif', '/*.svg', '/*.webp'],
+      },
+    ],
     sitemap: `${SITE_URL}/sitemap.xml`,
   }
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -15,6 +15,10 @@ export default function robots(): MetadataRoute.Robots {
         disallow: '/',
       },
       {
+        userAgent: 'Twitterbot',
+        disallow: '/',
+      },
+      {
         userAgent: '*',
         allow: '/',
         disallow: ['/admin', '/admin/'],


### PR DESCRIPTION
## Description
When investigating #865, we received a lot of 500s from facebook crawlers. This likely wont fix all of our issues, but should help with verified crawler issues. In the same log, I also noticed failing requests for file paths like PDFs and images, which is why the rule is added as well.

## Key Changes
Updated robots.txt
