### PR TITLE
Fix content validation: remove filterOption for nacMediaBlock

### DIFF
--- a/src/collections/HomePages/index.tsx
+++ b/src/collections/HomePages/index.tsx
@@ -133,16 +133,7 @@ export const HomePages: CollectionConfig = {
       type: 'blocks',
       blocks: [...DEFAULT_BLOCKS, NACMediaBlock].sort((a, b) => a.slug.localeCompare(b.slug)),
       required: true,
-      filterOptions: ({ data }) => {
-        const layoutBlocks = data?.layout
 
-        if (!layoutBlocks) return true
-
-        const nacMediaBlockCount = layoutBlocks.filter(
-          (block: { blockType: string }) => block.blockType === 'nacMediaBlock',
-        ).length
-        return nacMediaBlockCount >= 1 ? DEFAULT_BLOCKS.map((block) => block.slug) : true
-      },
       validate: (value, args) => {
         if (!value || !Array.isArray(value)) return blocks(value, args)
 
@@ -153,7 +144,7 @@ export const HomePages: CollectionConfig = {
         if (nacMediaBlockCount > 1) throw Error('Only one NACMediaBlock is allowed per page')
 
         // Do not use default validation because of nacMediaBlock
-        return nacMediaBlockCount ? true : blocks(value, args)
+        return blocks(value, args)
       },
     },
     {

--- a/src/collections/HomePages/index.tsx
+++ b/src/collections/HomePages/index.tsx
@@ -24,6 +24,7 @@ import {
   InlineToolbarFeature,
   lexicalEditor,
 } from '@payloadcms/richtext-lexical'
+import { blocks } from 'payload/shared'
 import { populateBlocksInHighlightedContent } from './hooks/populateBlocksInHighlightedContent'
 import { revalidateHomePage, revalidateHomePageDelete } from './hooks/revalidateHomePage'
 
@@ -140,7 +141,19 @@ export const HomePages: CollectionConfig = {
         const nacMediaBlockCount = layoutBlocks.filter(
           (block: { blockType: string }) => block.blockType === 'nacMediaBlock',
         ).length
-        return nacMediaBlockCount > 1 ? DEFAULT_BLOCKS.map((block) => block.slug) : true
+        return nacMediaBlockCount >= 1 ? DEFAULT_BLOCKS.map((block) => block.slug) : true
+      },
+      validate: (value, args) => {
+        if (!value || !Array.isArray(value)) return blocks(value, args)
+
+        const nacMediaBlockCount = value.filter(
+          (block) => block.blockType === 'nacMediaBlock',
+        ).length
+
+        if (nacMediaBlockCount > 1) throw Error('Only one NACMediaBlock is allowed per page')
+
+        // Do not use default validation because of nacMediaBlock
+        return nacMediaBlockCount ? true : blocks(value, args)
       },
     },
     {

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -20,7 +20,6 @@ import { DEFAULT_BLOCKS } from '@/constants/defaults'
 import { titleField } from '@/fields/title'
 import { populatePublishedAt } from '@/hooks/populatePublishedAt'
 import { generatePreviewPath } from '@/utilities/generatePreviewPath'
-import { blocks } from 'payload/shared'
 import { revalidatePage, revalidatePageDelete } from './hooks/revalidatePage'
 
 export const Pages: CollectionConfig<'pages'> = {
@@ -84,8 +83,9 @@ export const Pages: CollectionConfig<'pages'> = {
                 ).length
                 return nacMediaBlockCount >= 1 ? DEFAULT_BLOCKS.map((block) => block.slug) : true
               },
-              validate: (value, args) => {
-                if (!value || !Array.isArray(value)) return blocks(value, args)
+              validate: (value) => {
+                // Do not use default validation because of nacMediaBlock
+                if (!value || !Array.isArray(value)) return true
 
                 const nacMediaBlockCount = value.filter(
                   (block) => block.blockType === 'nacMediaBlock',
@@ -95,7 +95,7 @@ export const Pages: CollectionConfig<'pages'> = {
                   throw Error('Only one NACMediaBlock is allowed per page')
                 }
 
-                return blocks(value, args)
+                return true
               },
             },
           ],

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -74,16 +74,7 @@ export const Pages: CollectionConfig<'pages'> = {
                 description:
                   'This is where you design your page. Add and move blocks around to change the layout. Use the Preview button to see your page edits in another tab.',
               },
-              filterOptions: ({ data }) => {
-                const layoutBlocks = data?.layout
 
-                if (!layoutBlocks) return true
-
-                const nacMediaBlockCount = layoutBlocks.filter(
-                  (block: { blockType: string }) => block.blockType === 'nacMediaBlock',
-                ).length
-                return nacMediaBlockCount >= 1 ? DEFAULT_BLOCKS.map((block) => block.slug) : true
-              },
               validate: (value, args) => {
                 if (!value || !Array.isArray(value)) return blocks(value, args)
 
@@ -95,7 +86,7 @@ export const Pages: CollectionConfig<'pages'> = {
                   throw Error('Only one NACMediaBlock is allowed per page')
 
                 // Do not use default validation because of nacMediaBlock
-                return nacMediaBlockCount ? true : blocks(value, args)
+                return blocks(value, args)
               },
             },
           ],

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -20,6 +20,7 @@ import { DEFAULT_BLOCKS } from '@/constants/defaults'
 import { titleField } from '@/fields/title'
 import { populatePublishedAt } from '@/hooks/populatePublishedAt'
 import { generatePreviewPath } from '@/utilities/generatePreviewPath'
+import { blocks } from 'payload/shared'
 import { revalidatePage, revalidatePageDelete } from './hooks/revalidatePage'
 
 export const Pages: CollectionConfig<'pages'> = {
@@ -83,19 +84,18 @@ export const Pages: CollectionConfig<'pages'> = {
                 ).length
                 return nacMediaBlockCount >= 1 ? DEFAULT_BLOCKS.map((block) => block.slug) : true
               },
-              validate: (value) => {
-                // Do not use default validation because of nacMediaBlock
-                if (!value || !Array.isArray(value)) return true
+              validate: (value, args) => {
+                if (!value || !Array.isArray(value)) return blocks(value, args)
 
                 const nacMediaBlockCount = value.filter(
                   (block) => block.blockType === 'nacMediaBlock',
                 ).length
 
-                if (nacMediaBlockCount > 1) {
+                if (nacMediaBlockCount > 1)
                   throw Error('Only one NACMediaBlock is allowed per page')
-                }
 
-                return true
+                // Do not use default validation because of nacMediaBlock
+                return nacMediaBlockCount ? true : blocks(value, args)
               },
             },
           ],


### PR DESCRIPTION
## Description
When messing around with #831 , I noticed a page with NACMedia block was no longer bale to be published. This was a regression from #895 .

This PR removes the `filterOptions` changes that would remove NAC Media if it was previously used on the page. Since we were removing `blockType === 'nacMediaBlock'`, it was causing an improper invalidation on save.

## Key Changes
Update the validation and also added to homepage content

## How to test
1. Add NACMedia block to page or hompage
2. Click Publish

## Future enhancements / Questions
We should really build out our tests or have a block page for testing