### PR TITLE
Fix: prevent widget getting stuck at `#/all` when navigating forecast dates

### DIFF
--- a/src/components/NACWidget/WidgetRouterHandler.client.tsx
+++ b/src/components/NACWidget/WidgetRouterHandler.client.tsx
@@ -31,7 +31,7 @@ export function WidgetRouterHandler({
   }
 
   useEffect(() => {
-    const hash = observedHash || window.location.hash
+    const hash = window.location.hash
     // Strip leading # from hash for path matching
     const hashSansHash = hash?.replace(/^#/, '') || ''
     // Ignore query parameters


### PR DESCRIPTION
## Description

Fixes a race condition in `WidgetRouterHandler` that caused the widget to get stuck at `#/all` during zone-date-zone navigation. The issue occurred when `useHash`'s `setTimeout`-delayed state captured intermediate widget routing states instead of the final hash value we wanted

## Related Issues

Fixes #918 

## Key Changes

**WidgetRouterHandler.client.tsx:**
- Changed to read `window.location.hash` directly instead of using `observedHash` state
- `observedHash` still triggers the effect when hash changes, but we always read the current hash value
- This ensures validation happens against the actual current hash, not a stale React state value

## How to test

1. Navigate to any zone forecast page (e.g., `/forecasts/avalanche/olympics`)
2. Use the date navigation in the widget to view previous/next forecasts
3. Navigate to **a different** zone forecast page
4. **Expected:** Smooth navigation between zones and display selected zone information
5. **Bug (before fix):** Widget would load all forecast information at `#/all` while URL showed correct place

Also test:
- Zone-to-zone navigation still works
- Initial page load sets correct hash
- No infinite loops or console errors

## Screenshots / Demo video
https://www.loom.com/share/d0b89b8ff5774699b0e5294381742ffe