### PR TITLE
Styling updates - update UI at tablet breakpoint, improve theme preview and all blocks pages

### DIFF
--- a/docs/coding-guide.md
+++ b/docs/coding-guide.md
@@ -228,6 +228,15 @@ Not using `BackgroundColorWrapper`
 - `HeaderComponent`
 
 
+## Theme Preview
+
+A dev-only page at `/{center}/theme-preview` that renders all UI components and semantic colors for a given tenant. Use this to visually verify theme changes across tenants.
+
+- **Not available in production** — gated by `disallowedEnvironments`
+- **Location:** `src/app/(frontend)/[center]/theme-preview/page.tsx`
+
+When adding a new shadcn UI component to `src/components/ui/`, add a demo section to the theme preview page to test styling across all tenant themes.
+
 ## ButtonLink
 Links styled as buttons with built-in analytics tracking. Supports both direct URLs and CMS-driven references.
 

--- a/src/app/(frontend)/[center]/blog/page.tsx
+++ b/src/app/(frontend)/[center]/blog/page.tsx
@@ -40,7 +40,7 @@ export default async function Page({ params, searchParams }: Args) {
   return (
     <FiltersTotalProvider initialTotal={total}>
       <div className="pt-4">
-        <div className="container md:max-lg:max-w-5xl mb-16 flex flex-col-reverse md:flex-row flex-1 gap-10 md:gap-16">
+        <div className="container md:max-xl:max-w-none mb-16 flex flex-col-reverse md:flex-row flex-1 gap-10 md:gap-16">
           <div className="grow">
             <div className="md:hidden mb-4">
               <PostsMobileFilters tags={tagsList} sort={sort} hasActiveFilters={hasActiveFilters} />

--- a/src/app/(frontend)/[center]/events/page.tsx
+++ b/src/app/(frontend)/[center]/events/page.tsx
@@ -74,7 +74,7 @@ export default async function Page({ params, searchParams }: Args) {
   return (
     <FiltersTotalProvider initialTotal={total}>
       <div className="pt-4">
-        <div className="container md:max-lg:max-w-5xl mb-16 flex flex-col md:flex-row flex-1 gap-6 md:gap-10 lg:gap-16">
+        <div className="container md:max-xl:max-w-none mb-16 flex flex-col md:flex-row flex-1 gap-6 md:gap-10 lg:gap-16">
           <div className="md:hidden">
             <EventsMobileFilters
               types={eventTypes}
@@ -95,7 +95,7 @@ export default async function Page({ params, searchParams }: Args) {
             />
           </div>
 
-          <div className="hidden md:flex flex-col shrink-0 justify-between md:justify-start md:w-[240px] lg:w-[300px] order-1 md:order-2">
+          <div className="hidden md:flex flex-col shrink-0 justify-between md:justify-start md:w-[240px] xl:w-[300px] order-1 md:order-2">
             <EventsFilters
               startDate={startDate}
               endDate={endDate}

--- a/src/app/(frontend)/[center]/theme-preview/page.tsx
+++ b/src/app/(frontend)/[center]/theme-preview/page.tsx
@@ -3,7 +3,22 @@ import type { Metadata } from 'next/types'
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -14,6 +29,15 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -35,6 +59,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Separator } from '@/components/ui/separator'
+import { Switch } from '@/components/ui/switch'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import { Textarea } from '@/components/ui/textarea'
 import { getEnvironmentFriendlyName } from '@/utilities/getEnvironmentFriendlyName'
 import { notFound } from 'next/navigation'
@@ -83,208 +117,182 @@ export default async function Page({ params }: Args) {
     <div className="pt-4">
       <div className="container mb-16 grid gap-14">
         <h1 className="text-3xl font-bold mb-6">Theme Preview for {center.toUpperCase()}</h1>
-
-        <div>
-          <div className="space-y-4">
-            {[100, 200, 300, 400, 500, 600, 700, 800, 900].map((weight) => (
-              <div key={weight} className="flex items-center gap-6">
-                <p
-                  style={{
-                    fontWeight: weight,
-                    fontStyle: 'normal',
-                  }}
-                  className="text-lg"
-                >
-                  {weight} Normal
-                </p>
-                <p
-                  style={{
-                    fontWeight: weight,
-                    fontStyle: 'italic',
-                  }}
-                  className="text-lg"
-                >
-                  {weight} Italic
-                </p>
-              </div>
-            ))}
+        <div className="grid sm:grid-cols-2 gap-2">
+          <div className="space-y-2">
+            <h1 className="text-4xl font-bold">Heading h1</h1>
+            <h2 className="text-3xl font-semibold">Heading h2</h2>
+            <h3 className="text-2xl font-semibold">Heading h3</h3>
+            <h4 className="text-xl font-semibold">Heading h4</h4>
+            <h5 className="text-lg font-semibold">Heading h5</h5>
+            <h6 className="text-base font-semibold">Heading h6</h6>
+          </div>
+          <div>
+            <div className="space-y-4">
+              {[100, 200, 300, 400, 500, 600, 700, 800, 900].map((weight) => (
+                <div key={weight} className="flex items-center gap-6">
+                  <p
+                    style={{
+                      fontWeight: weight,
+                      fontStyle: 'normal',
+                    }}
+                    className="text-lg"
+                  >
+                    {weight} Normal
+                  </p>
+                  <p
+                    style={{
+                      fontWeight: weight,
+                      fontStyle: 'italic',
+                    }}
+                    className="text-lg"
+                  >
+                    {weight} Italic
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
 
         <div className="grid gap-8">
           <h2 className="text-xl font-semibold">Semantic Class Colors</h2>
 
-          <div className="grid gap-8 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {/* background & foreground */}
-            <section className="space-y-2">
-              <h3 className="text-lg font-semibold">background / foreground</h3>
-              <div className="flex flex-wrap gap-4">
-                <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-background flex items-center justify-center"
-                  title="bg-background"
-                >
-                  <span className="text-foreground text-sm font-medium">Background</span>
-                </div>
-              </div>
-            </section>
-
-            {/* card */}
-            <section className="space-y-2">
-              <h3 className="text-lg font-semibold">card</h3>
-              <div className="flex flex-wrap gap-4">
-                <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-card flex items-center justify-center"
-                  title="bg-card"
-                >
-                  <span className="text-card-foreground text-sm font-medium">Card</span>
-                </div>
-              </div>
-            </section>
-
-            {/* popover */}
-            <section className="space-y-2">
-              <h3 className="text-lg font-semibold">popover</h3>
-              <div className="flex flex-wrap gap-4">
-                <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-popover flex items-center justify-center"
-                  title="bg-popover"
-                >
-                  <span className="text-popover-foreground text-sm font-medium">Popover</span>
-                </div>
-              </div>
-            </section>
-
-            {/* primary */}
-            <section className="space-y-2">
-              <h3 className="text-lg font-semibold">primary</h3>
-              <div className="flex flex-wrap gap-4">
-                <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-primary flex items-center justify-center"
-                  title="bg-primary"
-                >
-                  <span className="text-primary-foreground text-sm font-medium">Primary</span>
-                </div>
-              </div>
-            </section>
-
-            {/* secondary */}
-            <section className="space-y-2">
-              <h3 className="text-lg font-semibold">secondary</h3>
-              <div className="flex flex-wrap gap-4">
-                <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-secondary flex items-center justify-center"
-                  title="bg-secondary"
-                >
-                  <span className="text-secondary-foreground text-sm font-medium">Secondary</span>
-                </div>
-              </div>
-            </section>
-
-            {/* muted */}
-            <section className="space-y-2">
-              <h3 className="text-lg font-semibold">muted</h3>
-              <div className="flex flex-wrap gap-4">
-                <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-muted flex items-center justify-center"
-                  title="bg-muted"
-                >
-                  <span className="text-muted-foreground text-sm font-medium">Muted</span>
-                </div>
-              </div>
-            </section>
-
-            {/* accent */}
-            <section className="space-y-2">
-              <h3 className="text-lg font-semibold">accent</h3>
-              <div className="flex flex-wrap gap-4">
-                <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-accent flex items-center justify-center"
-                  title="bg-accent"
-                >
-                  <span className="text-accent-foreground text-sm font-medium">Accent</span>
-                </div>
-              </div>
-            </section>
-
-            {/* destructive */}
-            <section className="space-y-2">
-              <h3 className="text-lg font-semibold">destructive</h3>
-              <div className="flex flex-wrap gap-4">
-                <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-destructive flex items-center justify-center"
-                  title="bg-destructive"
-                >
-                  <span className="text-destructive-foreground text-sm font-medium">
-                    Destructive
-                  </span>
-                </div>
-              </div>
-            </section>
-
-            {/* border, input, ring */}
-            <section className="space-y-2">
-              <h3 className="text-lg font-semibold">border / input / ring</h3>
-              <div className="flex flex-wrap gap-4">
-                <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border-4 border-border flex items-center justify-center"
-                  title="border-border"
-                >
-                  <span className="text-foreground text-sm font-medium">Border</span>
-                </div>
-                <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border-4 border-input flex items-center justify-center"
-                  title="border-input"
-                >
-                  <span className="text-foreground text-sm font-medium">Input</span>
-                </div>
-                <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border-4 border-ring flex items-center justify-center"
-                  title="border-ring"
-                >
-                  <span className="text-foreground text-sm font-medium">Ring</span>
-                </div>
-              </div>
-            </section>
-
+          <div className="flex flex-wrap gap-8 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
             {/* header */}
             <section className="space-y-2">
-              <h3 className="text-lg font-semibold">header</h3>
               <div className="flex flex-wrap gap-4">
                 <div
                   className="w-32 h-32 flex-shrink-0 rounded-full border bg-header flex items-center justify-center"
                   title="bg-header"
                 >
-                  <span className="text-header-foreground text-sm font-medium">Header</span>
+                  <span className="text-header-foreground text-md font-medium">Header</span>
                 </div>
               </div>
             </section>
 
             {/* footer */}
             <section className="space-y-2">
-              <h3 className="text-lg font-semibold">footer</h3>
               <div className="flex flex-wrap gap-4">
                 <div
                   className="w-32 h-32 flex-shrink-0 rounded-full border bg-footer flex items-center justify-center"
                   title="bg-footer"
                 >
-                  <span className="text-footer-foreground text-sm font-medium">Footer</span>
+                  <span className="text-footer-foreground text-md font-medium">Footer</span>
+                </div>
+              </div>
+            </section>
+
+            {/* primary */}
+            <section className="space-y-2">
+              <div className="flex flex-wrap gap-4">
+                <div
+                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-primary flex items-center justify-center"
+                  title="bg-primary"
+                >
+                  <span className="text-primary-foreground text-md font-medium">Primary</span>
+                </div>
+              </div>
+            </section>
+
+            {/* secondary */}
+            <section className="space-y-2">
+              <div className="flex flex-wrap gap-4">
+                <div
+                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-secondary flex items-center justify-center"
+                  title="bg-secondary"
+                >
+                  <span className="text-secondary-foreground text-md font-medium">Secondary</span>
                 </div>
               </div>
             </section>
 
             {/* callout */}
             <section className="space-y-2">
-              <h3 className="text-lg font-semibold">callout</h3>
               <div className="flex flex-wrap gap-4">
                 <div
                   className="w-32 h-32 flex-shrink-0 rounded-full border bg-callout flex items-center justify-center"
                   title="bg-callout"
                 >
-                  <span className="text-callout-foreground text-sm font-medium">Callout</span>
+                  <span className="text-callout-foreground text-md font-medium">Callout</span>
                 </div>
               </div>
             </section>
 
+            {/* muted */}
+            <section className="space-y-2">
+              <div className="flex flex-wrap gap-4">
+                <div
+                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-muted flex items-center justify-center"
+                  title="bg-muted"
+                >
+                  <span className="text-muted-foreground text-md font-medium">Muted</span>
+                </div>
+              </div>
+            </section>
+
+            {/* accent */}
+            <section className="space-y-2">
+              <div className="flex flex-wrap gap-4">
+                <div
+                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-accent flex items-center justify-center"
+                  title="bg-accent"
+                >
+                  <span className="text-accent-foreground text-md font-medium">Accent</span>
+                </div>
+              </div>
+            </section>
+
+            {/* destructive */}
+            <section className="space-y-2">
+              <div className="flex flex-wrap gap-4">
+                <div
+                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-destructive flex items-center justify-center"
+                  title="bg-destructive"
+                >
+                  <span className="text-destructive-foreground text-md font-medium">
+                    Destructive
+                  </span>
+                </div>
+              </div>
+            </section>
+            {/* background & foreground */}
+            <section className="space-y-2">
+              <div className="flex flex-wrap gap-4">
+                <div
+                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-background flex items-center justify-center"
+                  title="bg-background"
+                >
+                  <span className="text-foreground text-md font-medium">Background</span>
+                </div>
+              </div>
+            </section>
+
+            {/* card */}
+            <section className="space-y-2">
+              <div className="flex flex-wrap gap-4">
+                <div
+                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-card flex items-center justify-center"
+                  title="bg-card"
+                >
+                  <span className="text-card-foreground text-md font-medium">Card</span>
+                </div>
+              </div>
+            </section>
+
+            {/* popover */}
+            <section className="space-y-2">
+              <div className="flex flex-wrap gap-4">
+                <div
+                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-popover flex items-center justify-center"
+                  title="bg-popover"
+                >
+                  <span className="text-popover-foreground text-md font-medium">Popover</span>
+                </div>
+              </div>
+            </section>
+          </div>
+
+          <div className="grid gap-8 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
             {/* brand */}
             <section className="space-y-2">
               <h3 className="text-lg font-semibold">brand</h3>
@@ -363,36 +371,60 @@ export default async function Page({ params }: Args) {
                 </div>
               </div>
             </section>
-
             {/* success, warning, error */}
             <section className="space-y-2">
               <h3 className="text-lg font-semibold">success / warning / error</h3>
               <div className="flex space-x-4">
                 <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-success flex items-center justify-center"
+                  className="w-24 h-24 flex-shrink-0 rounded-full border bg-success flex items-center justify-center"
                   title="bg-success"
                 >
                   <span className="text-success-foreground text-sm font-medium">Success</span>
                 </div>
                 <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-warning flex items-center justify-center"
+                  className="w-24 h-24 flex-shrink-0 rounded-full border bg-warning flex items-center justify-center"
                   title="bg-warning"
                 >
                   <span className="text-warning-foreground text-sm font-medium">Warning</span>
                 </div>
                 <div
-                  className="w-32 h-32 flex-shrink-0 rounded-full border bg-error flex items-center justify-center"
+                  className="w-24 h-24 flex-shrink-0 rounded-full border bg-error flex items-center justify-center"
                   title="bg-error"
                 >
                   <span className="text-error-foreground text-sm font-medium">Error</span>
                 </div>
               </div>
             </section>
+
+            {/* border, input, ring */}
+            <section className="space-y-2">
+              <h3 className="text-lg font-semibold">border / input / ring</h3>
+              <div className="flex flex-wrap gap-4">
+                <div
+                  className="w-24 h-24 flex-shrink-0 rounded-full border-4 border-border flex items-center justify-center"
+                  title="border-border"
+                >
+                  <span className="text-foreground text-sm font-medium">Border</span>
+                </div>
+                <div
+                  className="w-24 h-24 flex-shrink-0 rounded-full border-4 border-input flex items-center justify-center"
+                  title="border-input"
+                >
+                  <span className="text-foreground text-sm font-medium">Input</span>
+                </div>
+                <div
+                  className="w-24 h-24 flex-shrink-0 rounded-full border-4 border-ring flex items-center justify-center"
+                  title="border-ring"
+                >
+                  <span className="text-foreground text-sm font-medium">Ring</span>
+                </div>
+              </div>
+            </section>
           </div>
         </div>
-
+        <hr />
         <div className="grid gap-8">
-          <h2 className="text-xl font-semibold">Shadcn Components</h2>
+          <h2 className="text-2xl font-semibold">Shadcn Components</h2>
 
           {/* Avatar */}
           <section className="space-y-2">
@@ -409,14 +441,71 @@ export default async function Page({ params }: Args) {
             </div>
           </section>
 
+          {/* Accordion */}
+          <section className="space-y-2">
+            <h3 className="text-lg font-semibold">Accordion</h3>
+            <Accordion type="single" collapsible className="w-full max-w-sm">
+              <AccordionItem value="item-1">
+                <AccordionTrigger>Is it accessible?</AccordionTrigger>
+                <AccordionContent>Yes. It adheres to the WAI-ARIA design pattern.</AccordionContent>
+              </AccordionItem>
+              <AccordionItem value="item-2">
+                <AccordionTrigger>Is it styled?</AccordionTrigger>
+                <AccordionContent>
+                  Yes. It comes with default styles that match your theme.
+                </AccordionContent>
+              </AccordionItem>
+              <AccordionItem value="item-3">
+                <AccordionTrigger>Is it animated?</AccordionTrigger>
+                <AccordionContent>
+                  Yes. It uses CSS animations for smooth open/close transitions.
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+          </section>
+
+          {/* Badge */}
+          <section className="space-y-2">
+            <h3 className="text-lg font-semibold">Badge</h3>
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="default">Default</Badge>
+              <Badge variant="secondary">Secondary</Badge>
+              <Badge variant="destructive">Destructive</Badge>
+              <Badge variant="outline">Outline</Badge>
+            </div>
+          </section>
+
+          {/* Breadcrumb */}
+          <section className="space-y-2">
+            <h3 className="text-lg font-semibold">Breadcrumb</h3>
+            <Breadcrumb>
+              <BreadcrumbList>
+                <BreadcrumbItem>
+                  <BreadcrumbLink href="#">Home</BreadcrumbLink>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbLink href="#">Blog</BreadcrumbLink>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbPage>Current Page</BreadcrumbPage>
+                </BreadcrumbItem>
+              </BreadcrumbList>
+            </Breadcrumb>
+          </section>
+
           {/* Button */}
           <section className="space-y-2">
             <h3 className="text-lg font-semibold">Button</h3>
             <div className="flex flex-wrap gap-2">
               <Button variant="default">Default</Button>
-              <Button variant="outline">Outline</Button>
               <Button variant="secondary">Secondary</Button>
+              <Button variant="destructive">Destructive</Button>
+              <Button variant="outline">Outline</Button>
+              <Button variant="callout">Callout</Button>
               <Button variant="ghost">Ghost</Button>
+              <Button variant="link">Link</Button>
             </div>
           </section>
 
@@ -444,6 +533,35 @@ export default async function Page({ params }: Args) {
               <Checkbox id="terms" />
               <Label htmlFor="terms">Accept terms and conditions</Label>
             </div>
+          </section>
+
+          {/* Dialog */}
+          <section className="space-y-2">
+            <h3 className="text-lg font-semibold">Dialog</h3>
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button variant="outline">Open Dialog</Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Dialog Title</DialogTitle>
+                  <DialogDescription>
+                    This is a description of the dialog content.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="grid gap-4 py-4">
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="dialog-name" className="text-right">
+                      Name
+                    </Label>
+                    <Input id="dialog-name" className="col-span-3" placeholder="Enter name" />
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button type="submit">Save changes</Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
           </section>
 
           {/* Input */}
@@ -548,6 +666,65 @@ export default async function Page({ params }: Args) {
               <Label htmlFor="message">Your message</Label>
               <Textarea placeholder="Type your message here" id="message" />
             </div>
+          </section>
+
+          {/* Switch */}
+          <section className="space-y-2">
+            <h3 className="text-lg font-semibold">Switch</h3>
+            <div className="flex items-center space-x-2">
+              <Switch id="airplane-mode" />
+              <Label htmlFor="airplane-mode">Airplane Mode</Label>
+            </div>
+          </section>
+
+          {/* Separator */}
+          <section className="space-y-2">
+            <h3 className="text-lg font-semibold">Separator</h3>
+            <div className="sm:flex gap-32">
+              <div className="max-w-sm space-y-1">
+                <p className="text-sm font-medium">Content above</p>
+                <Separator />
+                <p className="text-sm text-muted-foreground">Content below</p>
+              </div>
+              <div className="flex h-5 items-center space-x-4 text-sm">
+                <span>Blog</span>
+                <Separator orientation="vertical" />
+                <span>Docs</span>
+                <Separator orientation="vertical" />
+                <span>Source</span>
+              </div>
+            </div>
+          </section>
+
+          {/* Table */}
+          <section className="space-y-2">
+            <h3 className="text-lg font-semibold">Table</h3>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Role</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Alice Johnson</TableCell>
+                  <TableCell>Active</TableCell>
+                  <TableCell>Admin</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Bob Smith</TableCell>
+                  <TableCell>Inactive</TableCell>
+                  <TableCell>Editor</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Carol Williams</TableCell>
+                  <TableCell>Active</TableCell>
+                  <TableCell>Viewer</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
           </section>
         </div>
       </div>

--- a/src/app/(frontend)/colors.css
+++ b/src/app/(frontend)/colors.css
@@ -160,6 +160,7 @@
   --brand-950: var(--oxford);
 }
 
+/* Sawtooth Avalanche Center */
 .snfac {
   --brand-50: hsl(0 0% 100%);
   --brand-100: hsl(178 100% 96%);
@@ -174,11 +175,11 @@
   --brand-950: hsl(210 4% 12%);
 
   --secondary: var(--brand-300);
-  --secondary-hover: hsla(var(--brand-300) / 0.8);
+  --secondary-hover: hsla(178 75% 42%/ 0.8);
   --secondary-foreground: var(--brand-50);
 
-  --callout: var(--brand-300);
-  --callout-hover: hsla(var(--brand-300) / 0.8);
+  --callout: var(--brand-200);
+  --callout-hover: hsla(178 83% 60%/ 0.6);
   --callout-foreground: var(--brand-50);
 
   --header: var(--brand-400);

--- a/src/blocks/Content/Component.tsx
+++ b/src/blocks/Content/Component.tsx
@@ -12,25 +12,42 @@ export const ContentBlockComponent = (props: ContentBlockProps) => {
 
   const colsClasses: { [key: string]: string[] } = {
     '1': ['lg:col-span-12'],
-    '11': ['lg:col-span-6', 'lg:col-span-6'],
-    '12': ['lg:col-span-8', 'lg:col-span-4'],
-    '21': ['lg:col-span-4', 'lg:col-span-8'],
-    '111': ['lg:col-span-4', 'lg:col-span-4', 'lg:col-span-4'],
-    '112': ['lg:col-span-6', 'lg:col-span-3', 'lg:col-span-3'],
+    '11': ['md:col-span-3 lg:col-span-6', 'md:col-span-3 lg:col-span-6'],
+    '12': ['md:col-span-2 lg:col-span-8', 'md:col-span-4'],
+    '21': ['md:col-span-4', 'md:col-span-2 lg:col-span-8'],
+    '111': [
+      'sm:col-span-2 lg:col-span-4',
+      'sm:col-span-2 lg:col-span-4',
+      'sm:col-span-2 lg:col-span-4',
+    ],
+    '112': [
+      'md:col-span-3 lg:col-span-6',
+      'md:col-span-3 lg:col-span-3',
+      'md:col-span-6 lg:col-span-3',
+    ],
     '121': ['lg:col-span-3', 'lg:col-span-6', 'lg:col-span-3'],
-    '211': ['lg:col-span-3', 'lg:col-span-3', 'lg:col-span-6'],
-    '1111': ['lg:col-span-3', 'lg:col-span-3', 'lg:col-span-3', 'lg:col-span-3'],
+    '211': [
+      'md:col-span-6 lg:col-span-3',
+      'md:col-span-3 lg:col-span-3',
+      'md:col-span-3 lg:col-span-6',
+    ],
+    '1111': [
+      'sm:col-span-3 lg:col-span-3',
+      'sm:col-span-3 lg:col-span-3',
+      'sm:col-span-3 lg:col-span-3',
+      'sm:col-span-3 lg:col-span-3',
+    ],
   }
   const colsSpanClass = colsClasses[layoutCols]
 
   return (
     <div className={`${bgColorClass}`}>
       <div className="container py-10">
-        <div className="grid grid-cols-2 lg:grid-cols-12 gap-y-6 gap-x-16">
+        <div className="grid grid-cols-6 lg:grid-cols-12 gap-y-6 gap-x-10">
           {columns?.map((col, index) => {
             const { richText } = col
             return (
-              <div className={cn('col-span-2', colsSpanClass[index], textColor)} key={index}>
+              <div className={cn('col-span-6', colsSpanClass[index], textColor)} key={index}>
                 {richText && <RichText data={richText} enableGutter={false} />}
               </div>
             )

--- a/src/blocks/ImageLinkGrid/Component.tsx
+++ b/src/blocks/ImageLinkGrid/Component.tsx
@@ -42,7 +42,7 @@ export const ImageLinkGridBlockComponent = (props: Props) => {
     1: 'sm:col-span-12',
     2: 'sm:col-span-6',
     3: 'sm:col-span-4',
-    4: 'sm:col-span-3',
+    4: 'sm:col-span-6 md:col-span-3',
   }
   const colsSpanClass = colsClasses[numOfCols]
   const imageSizes = getImageSizes(numOfCols)

--- a/src/components/Breadcrumbs/Breadcrumbs.client.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.client.tsx
@@ -95,7 +95,7 @@ export function Breadcrumbs() {
   }
 
   return (
-    <Breadcrumb className="container py-4 md:py-6 flex-nowrap whitespace-nowrap overflow-hidden">
+    <Breadcrumb className="container md:max-xl:max-w-none py-4 md:py-6 flex-nowrap whitespace-nowrap overflow-hidden">
       <BreadcrumbList className="flex-nowrap">
         <BreadcrumbItem className="shrink-0">
           <BreadcrumbLink

--- a/src/components/EventPreview/index.tsx
+++ b/src/components/EventPreview/index.tsx
@@ -67,12 +67,12 @@ export const EventPreview = (props: {
   return (
     <article
       className={cn(
-        'flex flex-col @lg:flex-row gap-4 w-full bg-card text-card-foreground border rounded-lg shadow-sm overflow-hidden p-4 @lg:p-6',
+        'flex flex-col-reverse @lg:flex-row gap-4 w-full bg-card text-card-foreground border rounded-lg shadow-sm overflow-hidden p-4 @lg:p-6',
         className,
       )}
     >
       {startDate && (
-        <div className="hidden @md:flex flex-col min-w-[80px] gap-1 items-center text-center">
+        <div className="hidden @xl:flex flex-col min-w-[80px] gap-1 items-center text-center">
           <div
             className={cn('flex flex-col pt-4', {
               'text-muted-foreground italic': isPastEvent,
@@ -102,7 +102,7 @@ export const EventPreview = (props: {
                   {title}
                 </h3>
               </Link>
-              {subtitle && <p className="text-muted-foreground line-clamp-1">{subtitle}</p>}
+              {subtitle && <p className="text-muted-foreground line-clamp-2">{subtitle}</p>}
             </div>
           )}
           {description && (

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -60,42 +60,49 @@ export async function Footer({ center }: { center?: string }) {
   )
 
   const currentYear = new Date().getFullYear()
+
   return (
     <footer className="mt-auto bg-footer text-footer-foreground">
-      <div className="container py-8 gap-8 grid md:grid-cols-3">
-        <div className="flex flex-col items-center md:items-start">
-          {footerForm?.title && <h4 className="font-medium text-xl mb-2">{footerForm.title}</h4>}
-          {footerForm?.subtitle && <p className="mb-2">{footerForm.subtitle}</p>}
-          {footerForm?.type === 'form' && (
-            <FormBlockComponent
-              form={footerForm.form?.value || 0}
-              blockType={'formBlock'}
-              isLexical={false}
-            />
-          )}
-          {footerForm?.type === 'embedded' && (
-            <GenericEmbedBlockComponent
-              html={footerForm.html || ''}
-              backgroundColor="transparent"
-              blockType="genericEmbed"
-              isLexical={false}
-            />
-          )}
-        </div>
-        <div>
+      <div className="container py-8 gap-8 flex flex-col sm:flex-row justify-between">
+        {footerForm.type != 'none' && (
+          <div className="flex flex-col items-center md:items-start">
+            {footerForm?.title && <h4 className="font-medium text-xl mb-2">{footerForm.title}</h4>}
+            {footerForm?.subtitle && <p className="mb-2">{footerForm.subtitle}</p>}
+            {footerForm?.type === 'form' && (
+              <FormBlockComponent
+                form={footerForm.form?.value || 0}
+                blockType={'formBlock'}
+                isLexical={false}
+              />
+            )}
+            {footerForm?.type === 'embedded' && (
+              <GenericEmbedBlockComponent
+                html={footerForm.html || ''}
+                backgroundColor="transparent"
+                blockType="genericEmbed"
+                isLexical={false}
+              />
+            )}
+          </div>
+        )}
+
+        <div className="sm:w-1/3">
           {logo && typeof logo === 'object' && (
             <Link className="flex items-center justify-center" href="/">
               <ImageMedia
                 resource={logo}
-                imgClassName="max-h-[200px] object-contain"
+                pictureClassName="max-w-36 w-full"
+                imgClassName="w-full"
                 sizes={getImageWidthFromMaxHeight(logo, 200)}
               />
             </Link>
           )}
         </div>
-        <div className="flex flex-col items-center md:items-start">
-          <h4 className="font-medium text-xl mb-2">{tenant.name}</h4>
-          {address && <div className="whitespace-pre-line text-center md:text-left">{address}</div>}
+        <div className="sm:w-1/3 flex flex-col items-center md:items-start gap-y-2">
+          <h4 className="font-medium text-xl">{tenant.name}</h4>
+          {address && (
+            <div className="mb-2 whitespace-pre-line text-center md:text-left">{address}</div>
+          )}
           {phone && (
             <div className="flex">
               {phoneLabel && <p className="capitalize">{phoneLabel}:&nbsp;</p>}
@@ -113,13 +120,13 @@ export async function Footer({ center }: { center?: string }) {
             </div>
           )}
           {email && (
-            <a className="mb-4 text-secondary underline" href={`mailto:${email}`}>
+            <a className="text-secondary underline" href={`mailto:${email}`}>
               {email}
             </a>
           )}
           {socialMedia && (
             // Icon colors controlled by color class
-            <div className="flex items-center gap-x-2 mb-2 text-secondary">
+            <div className="flex items-center gap-x-2 mt-2 text-secondary">
               {socialMedia.instagram && (
                 <a href={socialMedia.instagram} target="_blank" className="p-1">
                   <Icons.instagram />
@@ -152,7 +159,7 @@ export async function Footer({ center }: { center?: string }) {
           )}
         </div>
       </div>
-      <div className="container text-center pb-8">
+      <div className="container text-center text-xs pb-8">
         <p className="mb-2">
           All Content © {currentYear} {tenant.name}
         </p>

--- a/src/components/Header/DesktopNav.client.tsx
+++ b/src/components/Header/DesktopNav.client.tsx
@@ -60,7 +60,7 @@ export const DesktopNav = ({
                     e.preventDefault()
                   }
                 }}
-                className="data-[state=open]:text-header-foreground-highlight font-medium"
+                className="data-[state=open]:text-header-foreground-highlight font-medium lg:px-1.5 xl:px-3.5"
               >
                 {label}
               </NavigationMenuTrigger>

--- a/src/components/PostPreview/index.tsx
+++ b/src/components/PostPreview/index.tsx
@@ -61,12 +61,12 @@ export const PostPreview = (props: {
           className,
         )}
       >
-        <div className="w-full @md:w-56 @xl:w-72 @2xl:w-80 @md:flex-shrink-0 h-48 @md:h-auto overflow-hidden flex items-center">
+        <div className="w-full @md:w-48 @xl:w-72 @2xl:w-80 @md:flex-shrink-0 h-48 @md:h-auto overflow-hidden flex items-center">
           {featuredImage && typeof featuredImage !== 'number' && (
             <ImageMedia
-              imgClassName="w-full object-cover transition-transform duration-300"
+              imgClassName="w-full h-full object-cover transition-transform duration-300 "
               resource={featuredImage}
-              pictureClassName="w-full"
+              pictureClassName="w-full h-full"
               sizes={imageSizes}
             />
           )}

--- a/src/endpoints/seed/blocks/content-columns.ts
+++ b/src/endpoints/seed/blocks/content-columns.ts
@@ -1,0 +1,159 @@
+import { RequiredDataFromCollectionSlug } from 'payload'
+import { simpleContent } from '../utilities'
+
+export const contentColumns: RequiredDataFromCollectionSlug<'pages'>['layout'] = [
+  // 4 columns
+  {
+    blockType: 'content',
+    backgroundColor: 'transparent',
+    layout: '4_1111',
+    blockName: null,
+    columns: [
+      {
+        richText: simpleContent(
+          'Four dollar toast plaid mustache, shaman vape celiac lyft synth PBR&B normcore la croix. Pok pok church-key meggings salvia tonx mumblecore, man braid master cleanse kombucha. Before they sold out iPhone echo park, wolf irony bicycle rights asymmetrical deep v knausgaard ugh.',
+        ),
+      },
+      {
+        richText: simpleContent(
+          'Tbh blog hammock, hashtag fit taiyaki retro. Master cleanse plaid iPhone leggings. Yuccie PBR&B actually jean shorts intelligentsia austin. Deep v scenester tilde yr mukbang drinking vinegar cray snackwave gatekeep four loko heirloom selfies meditation organic.Tbh blog hammock, hashtag fit taiyaki retro. Master cleanse plaid iPhone leggings. Yuccie PBR&B actually jean shorts intelligentsia austin. Deep v scenester tilde yr mukbang drinking vinegar cray snackwave gatekeep four loko heirloom selfies meditation organic.',
+        ),
+      },
+      {
+        richText: simpleContent(
+          'Authentic edison bulb ennui, scenester poutine four loko lyft poke plaid disrupt listicle single-origin coffee. Unicorn kale chips venmo put a bird on it fit plaid snackwave four loko tofu PBR&B cornhole distillery hella. Forage meditation palo santo, paleo locavore 8-bit retro farm-to-table activated charcoal cloud bread Brooklyn JOMO plaid.',
+        ),
+      },
+      {
+        richText: simpleContent(
+          "Unicorn cardigan tattooed, street art brunch yes plz cred you probably haven't heard of them poutine readymade synth. Hexagon DSA pitchfork chartreuse vaporware prism godard vibecession fixie offal roof party gastropub poke truffaut. Man bun try-hard ascot, sriracha PBR&B swag af DSA fanny pack echo park poutine. Tousled helvetica readymade woke subway tile food truck 90s.",
+        ),
+      },
+    ],
+  },
+  // 3 columns
+  {
+    blockType: 'content',
+    backgroundColor: 'transparent',
+    layout: '3_111',
+    blockName: null,
+    columns: [
+      {
+        richText: simpleContent(
+          'Four dollar toast plaid mustache, shaman vape celiac lyft synth PBR&B normcore la croix. Pok pok church-key meggings salvia tonx mumblecore, man braid master cleanse kombucha. Before they sold out iPhone echo park, wolf irony bicycle rights asymmetrical deep v knausgaard ugh.',
+        ),
+      },
+      {
+        richText: simpleContent(
+          'Tbh blog hammock, hashtag fit taiyaki retro. Master cleanse plaid iPhone leggings. Yuccie PBR&B actually jean shorts intelligentsia austin. Deep v scenester tilde yr mukbang drinking vinegar cray snackwave gatekeep four loko heirloom selfies meditation organic.Tbh blog hammock, hashtag fit taiyaki retro. Master cleanse plaid iPhone leggings. Yuccie PBR&B actually jean shorts intelligentsia austin. Deep v scenester tilde yr mukbang drinking vinegar cray snackwave gatekeep four loko heirloom selfies meditation organic.',
+        ),
+      },
+      {
+        richText: simpleContent(
+          'Authentic edison bulb ennui, scenester poutine four loko lyft poke plaid disrupt listicle single-origin coffee. Unicorn kale chips venmo put a bird on it fit plaid snackwave four loko tofu PBR&B cornhole distillery hella. Forage meditation palo santo, paleo locavore 8-bit retro farm-to-table activated charcoal cloud bread Brooklyn JOMO plaid.',
+        ),
+      },
+    ],
+  },
+  {
+    blockType: 'content',
+    backgroundColor: 'transparent',
+    layout: '3_112',
+    blockName: null,
+    columns: [
+      {
+        richText: simpleContent(
+          'Four dollar toast plaid mustache, shaman vape celiac lyft synth PBR&B normcore la croix. Pok pok church-key meggings salvia tonx mumblecore, man braid master cleanse kombucha. Before they sold out iPhone echo park, wolf irony bicycle rights asymmetrical deep v knausgaard ugh.',
+        ),
+      },
+      {
+        richText: simpleContent(
+          'Authentic edison bulb ennui, scenester poutine four loko lyft poke plaid disrupt listicle single-origin coffee. Unicorn kale chips venmo put a bird on it fit plaid snackwave four loko tofu PBR&B cornhole distillery hella. Forage meditation palo santo, paleo locavore 8-bit retro farm-to-table activated charcoal cloud bread Brooklyn JOMO plaid.',
+        ),
+      },
+      {
+        richText: simpleContent(
+          "Unicorn cardigan tattooed, street art brunch yes plz cred you probably haven't heard of them poutine readymade synth. Hexagon DSA pitchfork chartreuse vaporware prism godard vibecession fixie offal roof party gastropub poke truffaut. Man bun try-hard ascot, sriracha PBR&B swag af DSA fanny pack echo park poutine. Tousled helvetica readymade woke subway tile food truck 90s.",
+        ),
+      },
+    ],
+  },
+  {
+    blockType: 'content',
+    backgroundColor: 'transparent',
+    layout: '3_211',
+    blockName: null,
+    columns: [
+      {
+        richText: simpleContent(
+          'Four dollar toast plaid mustache, shaman vape celiac lyft synth PBR&B normcore la croix. Pok pok church-key meggings salvia tonx mumblecore, man braid master cleanse kombucha. Before they sold out iPhone echo park, wolf irony bicycle rights asymmetrical deep v knausgaard ugh.',
+        ),
+      },
+      {
+        richText: simpleContent(
+          'Tbh blog hammock, hashtag fit taiyaki retro. Master cleanse plaid iPhone leggings. Yuccie PBR&B actually jean shorts intelligentsia austin. Deep v scenester tilde yr mukbang drinking vinegar cray snackwave gatekeep four loko heirloom selfies meditation organic.Tbh blog hammock, hashtag fit taiyaki retro. Master cleanse plaid iPhone leggings. Yuccie PBR&B actually jean shorts intelligentsia austin. Deep v scenester tilde yr mukbang drinking vinegar cray snackwave gatekeep four loko heirloom selfies meditation organic.',
+        ),
+      },
+      {
+        richText: simpleContent(
+          "Unicorn cardigan tattooed, street art brunch yes plz cred you probably haven't heard of them poutine readymade synth. Hexagon DSA pitchfork chartreuse vaporware prism godard vibecession fixie offal roof party gastropub poke truffaut. Man bun try-hard ascot, sriracha PBR&B swag af DSA fanny pack echo park poutine. Tousled helvetica readymade woke subway tile food truck 90s.",
+        ),
+      },
+    ],
+  },
+  // 2 columns
+  {
+    blockType: 'content',
+    backgroundColor: 'transparent',
+    layout: '2_11',
+    blockName: null,
+    columns: [
+      {
+        richText: simpleContent(
+          'Authentic edison bulb ennui, scenester poutine four loko lyft poke plaid disrupt listicle single-origin coffee. Unicorn kale chips venmo put a bird on it fit plaid snackwave four loko tofu PBR&B cornhole distillery hella. Forage meditation palo santo, paleo locavore 8-bit retro farm-to-table activated charcoal cloud bread Brooklyn JOMO plaid.',
+        ),
+      },
+      {
+        richText: simpleContent(
+          "Unicorn cardigan tattooed, street art brunch yes plz cred you probably haven't heard of them poutine readymade synth. Hexagon DSA pitchfork chartreuse vaporware prism godard vibecession fixie offal roof party gastropub poke truffaut. Man bun try-hard ascot, sriracha PBR&B swag af DSA fanny pack echo park poutine. Tousled helvetica readymade woke subway tile food truck 90s.",
+        ),
+      },
+    ],
+  },
+  {
+    blockType: 'content',
+    backgroundColor: 'transparent',
+    layout: '2_21',
+    blockName: null,
+    columns: [
+      {
+        richText: simpleContent(
+          'Four dollar toast plaid mustache, shaman vape celiac lyft synth PBR&B normcore la croix. Pok pok church-key meggings salvia tonx mumblecore, man braid master cleanse kombucha. Before they sold out iPhone echo park, wolf irony bicycle rights asymmetrical deep v knausgaard ugh.',
+        ),
+      },
+      {
+        richText: simpleContent(
+          'Authentic edison bulb ennui, scenester poutine four loko lyft poke plaid disrupt listicle single-origin coffee. Unicorn kale chips venmo put a bird on it fit plaid snackwave four loko tofu PBR&B cornhole distillery hella. Forage meditation palo santo, paleo locavore 8-bit retro farm-to-table activated charcoal cloud bread Brooklyn JOMO plaid.',
+        ),
+      },
+    ],
+  },
+  {
+    blockType: 'content',
+    backgroundColor: 'transparent',
+    layout: '2_12',
+    blockName: null,
+    columns: [
+      {
+        richText: simpleContent(
+          'Tbh blog hammock, hashtag fit taiyaki retro. Master cleanse plaid iPhone leggings. Yuccie PBR&B actually jean shorts intelligentsia austin. Deep v scenester tilde yr mukbang drinking vinegar cray snackwave gatekeep four loko heirloom selfies meditation organic.Tbh blog hammock, hashtag fit taiyaki retro. Master cleanse plaid iPhone leggings. Yuccie PBR&B actually jean shorts intelligentsia austin. Deep v scenester tilde yr mukbang drinking vinegar cray snackwave gatekeep four loko heirloom selfies meditation organic.',
+        ),
+      },
+      {
+        richText: simpleContent(
+          "Unicorn cardigan tattooed, street art brunch yes plz cred you probably haven't heard of them poutine readymade synth. Hexagon DSA pitchfork chartreuse vaporware prism godard vibecession fixie offal roof party gastropub poke truffaut. Man bun try-hard ascot, sriracha PBR&B swag af DSA fanny pack echo park poutine. Tousled helvetica readymade woke subway tile food truck 90s.",
+        ),
+      },
+    ],
+  },
+]

--- a/src/endpoints/seed/blocks/form.ts
+++ b/src/endpoints/seed/blocks/form.ts
@@ -1,0 +1,9 @@
+import type { Form } from '@/payload-types'
+import { RequiredDataFromCollectionSlug } from 'payload'
+
+export const formBlock = (form: Form): RequiredDataFromCollectionSlug<'pages'>['layout'][0] => ({
+  blockType: 'formBlock',
+  form: form.id,
+  enableIntro: false,
+  blockName: null,
+})

--- a/src/endpoints/seed/blocks/header.ts
+++ b/src/endpoints/seed/blocks/header.ts
@@ -1,0 +1,15 @@
+import { RequiredDataFromCollectionSlug } from 'payload'
+import { headingContent } from '../utilities'
+
+export const headerBlock: RequiredDataFromCollectionSlug<'pages'>['layout'] = [
+  {
+    blockType: 'headerBlock',
+    richText: headingContent('Welcome to the Avalanche Center', 'h2'),
+    backgroundColor: 'brand-200',
+  },
+  {
+    blockType: 'headerBlock',
+    richText: headingContent('Stay Informed, Stay Safe', 'h3'),
+    backgroundColor: 'transparent',
+  },
+]

--- a/src/endpoints/seed/blocks/nac-media.ts
+++ b/src/endpoints/seed/blocks/nac-media.ts
@@ -1,0 +1,9 @@
+import { RequiredDataFromCollectionSlug } from 'payload'
+
+export const nacMediaBlocks: RequiredDataFromCollectionSlug<'pages'>['layout'] = [
+  {
+    blockType: 'nacMediaBlock',
+    backgroundColor: 'brand-100',
+    mode: 'grid',
+  },
+]

--- a/src/endpoints/seed/blocks/sponsors.ts
+++ b/src/endpoints/seed/blocks/sponsors.ts
@@ -1,0 +1,19 @@
+import type { Sponsor } from '@/payload-types'
+import { RequiredDataFromCollectionSlug } from 'payload'
+
+export const sponsorsBlock = (
+  sponsor: Sponsor,
+): RequiredDataFromCollectionSlug<'pages'>['layout'] => [
+  {
+    blockType: 'sponsorsBlock',
+    backgroundColor: 'transparent',
+    sponsorsLayout: 'static',
+    sponsors: [sponsor.id],
+  },
+  {
+    blockType: 'sponsorsBlock',
+    backgroundColor: 'brand-100',
+    sponsorsLayout: 'carousel',
+    sponsors: [sponsor.id],
+  },
+]

--- a/src/endpoints/seed/blocks/team.ts
+++ b/src/endpoints/seed/blocks/team.ts
@@ -1,0 +1,7 @@
+import type { Team } from '@/payload-types'
+import { RequiredDataFromCollectionSlug } from 'payload'
+
+export const teamBlock = (team: Team): RequiredDataFromCollectionSlug<'pages'>['layout'][0] => ({
+  blockType: 'team',
+  team: team.id,
+})

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -962,6 +962,19 @@ export const seed = async ({
         .flat(),
     )
 
+    payload.logger.info(`— Seeding sponsors...`)
+    const seededSponsors = await upsert(
+      'sponsors',
+      payload,
+      incremental,
+      tenantsById,
+      () => 'sponsors',
+      Object.values(tenants).map(
+        (tenant): RequiredDataFromCollectionSlug<'sponsors'> =>
+          sponsors(tenant, images[tenant.slug]['acmeCorp']),
+      ),
+    )
+
     const pages = await upsert(
       'pages',
       payload,
@@ -971,12 +984,15 @@ export const seed = async ({
       Object.values(tenants)
         .map((tenant): RequiredDataFromCollectionSlug<'pages'>[] => [
           contactPageData(tenant, contactForms[tenant.name]),
-          allBlocksPage(
+          allBlocksPage({
             tenant,
-            images[tenant.slug]['imageMountain'],
-            Object.values(posts[tenant.slug]),
-            Object.values(events[tenant.slug]),
-          ),
+            image1: images[tenant.slug]['imageMountain'],
+            posts: Object.values(posts[tenant.slug]),
+            events: Object.values(events[tenant.slug]),
+            contactForm: contactForms[tenant.name],
+            teams: teams[tenant.slug] || [],
+            sponsor: seededSponsors[tenant.slug]['sponsors'],
+          }),
           whoWeArePage(tenant, teams, images[tenant.slug]['image2']),
           page(
             tenant,
@@ -1142,19 +1158,6 @@ export const seed = async ({
           ),
         ])
         .flat(),
-    )
-
-    payload.logger.info(`— Seeding sponsors...`)
-    await upsert(
-      'sponsors',
-      payload,
-      incremental,
-      tenantsById,
-      () => 'sponsors',
-      Object.values(tenants).map(
-        (tenant): RequiredDataFromCollectionSlug<'sponsors'> =>
-          sponsors(tenant, images[tenant.slug]['acmeCorp']),
-      ),
     )
 
     payload.logger.info(`— Updating home page quick links...`)

--- a/src/endpoints/seed/pages/all-blocks-page.ts
+++ b/src/endpoints/seed/pages/all-blocks-page.ts
@@ -1,28 +1,49 @@
-import type { Event, Media, Post, Tenant } from '@/payload-types'
+import type { Event, Form, Media, Post, Sponsor, Team, Tenant } from '@/payload-types'
 import { RequiredDataFromCollectionSlug } from 'payload'
 import { blogListBlock } from '../blocks/blog-list'
 import { contentColumns } from '../blocks/content-columns'
 import { contentWithCallout } from '../blocks/content-with-callout'
 import { eventListBlock } from '../blocks/event-list'
+import { formBlock } from '../blocks/form'
 import { genericEmbed } from '../blocks/generic-embed'
+import { headerBlock } from '../blocks/header'
 import { imageLinkGrid } from '../blocks/image-link-grid'
 import { imageText } from '../blocks/image-text'
 import { linkPreview } from '../blocks/link-preview'
 import { mediaBlocks } from '../blocks/media-blocks'
+import { nacMediaBlocks } from '../blocks/nac-media'
 import { singleBlogPostBlock } from '../blocks/single-blog-post'
 import { singleEventBlock } from '../blocks/single-event'
+import { sponsorsBlock } from '../blocks/sponsors'
+import { teamBlock } from '../blocks/team'
+import { headingContent } from '../utilities'
 
-export const allBlocksPage: (
-  tenant: Tenant,
-  image1: Media,
-  posts: Post[],
-  events: Event[],
-) => RequiredDataFromCollectionSlug<'pages'> = (
-  tenant: Tenant,
-  image1: Media,
-  posts: Post[],
-  events: Event[],
-): RequiredDataFromCollectionSlug<'pages'> => {
+type AllBlocksPageArgs = {
+  tenant: Tenant
+  image1: Media
+  posts: Post[]
+  events: Event[]
+  contactForm: Form
+  teams: Team[]
+  sponsor: Sponsor
+}
+
+const sectionLabel = (text: string): RequiredDataFromCollectionSlug<'pages'>['layout'][0] => ({
+  blockType: 'headerBlock',
+  backgroundColor: 'transparent',
+  blockName: null,
+  richText: headingContent(text, 'h2'),
+})
+
+export const allBlocksPage = ({
+  tenant,
+  image1,
+  posts,
+  events,
+  contactForm,
+  teams,
+  sponsor,
+}: AllBlocksPageArgs): RequiredDataFromCollectionSlug<'pages'> => {
   return {
     slug: 'blocks',
     tenant: tenant.id,
@@ -30,13 +51,25 @@ export const allBlocksPage: (
     _status: 'published',
     publishedAt: new Date().toISOString(),
     layout: [
+      sectionLabel('Header Block'),
+      ...headerBlock,
+      sectionLabel('Content Columns'),
       ...contentColumns,
+      sectionLabel('Image Link Grid'),
       ...imageLinkGrid(image1),
+      sectionLabel('Image Text'),
       ...imageText(image1),
+      sectionLabel('Link Preview'),
       ...linkPreview(image1),
+      sectionLabel('Media Block'),
       ...mediaBlocks(image1),
+      sectionLabel('Content with Callout'),
       ...contentWithCallout,
+      sectionLabel('Generic Embed'),
       ...genericEmbed,
+      sectionLabel('NAC Media Block'),
+      ...nacMediaBlocks,
+      sectionLabel('Blog List (Dynamic)'),
       {
         ...blogListBlock,
         postOptions: 'dynamic',
@@ -45,6 +78,7 @@ export const allBlocksPage: (
           sortBy: '-publishedAt',
         },
       },
+      sectionLabel('Blog List (Static)'),
       {
         ...blogListBlock,
         postOptions: 'static',
@@ -52,10 +86,12 @@ export const allBlocksPage: (
           staticPosts: posts.slice(0, 2).map((post) => post.id), // Use first 2 posts
         },
       },
+      sectionLabel('Single Blog Post'),
       {
         ...singleBlogPostBlock,
         post: posts[0]?.id || 0, // Use first post
       },
+      sectionLabel('Event List (Dynamic)'),
       {
         ...eventListBlock,
         eventOptions: 'dynamic',
@@ -63,6 +99,7 @@ export const allBlocksPage: (
           maxEvents: 4,
         },
       },
+      sectionLabel('Event List (Static)'),
       {
         ...eventListBlock,
         eventOptions: 'static',
@@ -70,6 +107,7 @@ export const allBlocksPage: (
           staticEvents: events.slice(0, 3).map((event) => event.id), // Use first 3 events
         },
       },
+      sectionLabel('Single Event'),
       {
         ...singleEventBlock,
         event: events[0]?.id || 0, // Use first event
@@ -79,10 +117,10 @@ export const allBlocksPage: (
         event: events[1]?.id || 0, // Use second event
         backgroundColor: 'gray',
       },
+      sectionLabel('Event Table'),
       {
         blockName: '',
         eventOptions: 'dynamic',
-
         dynamicOpts: {
           maxEvents: 6,
         },
@@ -92,6 +130,11 @@ export const allBlocksPage: (
         blockType: 'eventTable',
         backgroundColor: 'transparent',
       },
+      sectionLabel('Form Block'),
+      formBlock(contactForm),
+      sectionLabel('Sponsors Block'),
+      ...sponsorsBlock(sponsor),
+      ...(teams.length > 0 ? [sectionLabel('Team Block'), teamBlock(teams[0])] : []),
     ],
     meta: {
       image: null,

--- a/src/endpoints/seed/pages/all-blocks-page.ts
+++ b/src/endpoints/seed/pages/all-blocks-page.ts
@@ -1,6 +1,7 @@
 import type { Event, Media, Post, Tenant } from '@/payload-types'
 import { RequiredDataFromCollectionSlug } from 'payload'
 import { blogListBlock } from '../blocks/blog-list'
+import { contentColumns } from '../blocks/content-columns'
 import { contentWithCallout } from '../blocks/content-with-callout'
 import { eventListBlock } from '../blocks/event-list'
 import { genericEmbed } from '../blocks/generic-embed'
@@ -29,6 +30,7 @@ export const allBlocksPage: (
     _status: 'published',
     publishedAt: new Date().toISOString(),
     layout: [
+      ...contentColumns,
       ...imageLinkGrid(image1),
       ...imageText(image1),
       ...linkPreview(image1),

--- a/src/endpoints/seed/utilities.ts
+++ b/src/endpoints/seed/utilities.ts
@@ -1,4 +1,8 @@
-import { SerializedParagraphNode, SerializedTextNode } from '@payloadcms/richtext-lexical'
+import {
+  SerializedHeadingNode,
+  SerializedParagraphNode,
+  SerializedTextNode,
+} from '@payloadcms/richtext-lexical'
 import { promises as fs } from 'fs'
 import path from 'path'
 import { File } from 'payload'
@@ -128,6 +132,29 @@ export const paragraphNode = (text: string): SerializedParagraphNode => ({
   indent: 0,
   textFormat: 0,
   version: 1,
+})
+
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+
+export const headingNode = (text: string, tag: HeadingTag = 'h2'): SerializedHeadingNode => ({
+  type: 'heading',
+  children: [textNode(text)],
+  direction: null,
+  format: '',
+  indent: 0,
+  tag,
+  version: 1,
+})
+
+export const headingContent = (text: string, tag: HeadingTag = 'h2') => ({
+  root: {
+    type: 'root' as const,
+    children: [headingNode(text, tag)],
+    direction: null,
+    format: '' as const,
+    indent: 0,
+    version: 1,
+  },
 })
 
 export const simpleContent = (...paragraphs: string[]) => ({


### PR DESCRIPTION
## Description

Tablet layout improvements across multiple components, footer styling overhaul, theme preview page expansion, and seed data improvements for the all-blocks page.

## Related Issues
Fixes #655 
Fixes #736 

## Key Changes

**Tablet Layout Fixes** : 
- Content block: Switch from fixed grid columns to responsive `auto-fit` with `minmax` for better tablet rendering
- Blog & events pages & Breadcrumbs: Use `md:max-xl:max-w-none` to allow full-width container on tablet
- ImageLinkGrid: Fix 4-column layout for tablet with `md:grid-cols-2 xl:grid-cols-4`
- PostPreview & EventPreview: Full-height cover images using `h-full` on the image wrapper
- DesktopNav: Fix 1024px breakpoint by switching `lg:` to `md:` prefix

**Footer Styling**
- Replace grid layout with flexbox (`flex-col sm:flex-row`)
- Conditional rendering of the footer form section
- Smaller logo sizing (`max-w-36`)
- Centered layout with proper responsive alignment

**Theme Preview Page**
- Fix heading size hierarchy (h3/h4 had copy-paste errors showing same size as h1)
- Add missing UI component demos: Accordion, Badge, Breadcrumb, Dialog, Separator, Switch, Table
- Add missing button variants: destructive, link
- Add documentation section to `docs/coding-guide.md`

**Seed Data**
- Add seed blocks for: Header, Form, NAC Media, Sponsors, Team
- Add `headingNode` and `headingContent` utilities for building Lexical heading JSON
- Add section labels to all-blocks page for easier visual identification
- Add content-columns seed data for multi-column Content block variations
- Fix sponsors seeding order (moved before pages since pages depend on sponsors)
- Header block config now defaults rich text editor to an h2 node

**Color Fixes**
- SNFAC: Update `--callout-foreground` and `--secondary-foreground` to use `--brand-950` instead of `--brand-50` for better contrast

## How to test

1. Visit the site at tablet widths (768px–1279px) and verify:
   - Blog and events list pages use full container width
   - Content blocks with columns render responsively
   - ImageLinkGrid shows 2 columns (not 4) on tablet
   - Footer layout stacks properly on small screens, side-by-side on larger
   - Desktop nav appears at 768px (md breakpoint)
2. Visit `/{center}/theme-preview` on localhost to verify all UI component demos render correctly across tenant themes (nwac, dvac, sac, snfac)
3. Run `pnpm seed` and verify the all-blocks page renders all block types with section labels
4. Check SNFAC theme callout and secondary button foreground colors have proper contrast

## Screenshots / Demo video


## Future enhancements / Questions

- `documentBlock` was intentionally skipped from the all-blocks seed page since the documents collection requires file uploads that aren't seeded