### PR TITLE
Update timezone to use name instead of GMT-

### DIFF
--- a/src/components/EventPreviewSmallRow.tsx
+++ b/src/components/EventPreviewSmallRow.tsx
@@ -75,14 +75,15 @@ export const EventPreviewSmallRow = (props: { className?: string; doc?: Event })
           <h3 className="text-lg leading-tight group-hover:underline">{title}</h3>
           <div className="flex flex-col">
             {startDate && (
-              <p className="text-sm text-muted-foreground">
+              <div className="flex items-center flex-wrap gap-0.5 text-sm text-muted-foreground">
+                <Calendar className="h-3.5 w-3.5 flex-shrink-0" />
                 <StartAndEndDateDisplay
                   startDate={startDate}
                   startDate_tz={startDate_tz}
                   endDate={endDate}
                   endDate_tz={endDate_tz}
                 />
-              </p>
+              </div>
             )}
             {locationText && (
               <div className="flex items-center gap-0.5 text-sm text-muted-foreground">

--- a/src/components/StartAndEndDateDisplay.tsx
+++ b/src/components/StartAndEndDateDisplay.tsx
@@ -1,7 +1,7 @@
 import type { Event } from '@/payload-types'
 import { formatDateTime } from '@/utilities/formatDateTime'
 import { tz } from '@date-fns/tz'
-import { isSameDay } from 'date-fns'
+import { isSameDay, isSameYear } from 'date-fns'
 
 export function StartAndEndDateDisplay({
   startDate,
@@ -9,33 +9,31 @@ export function StartAndEndDateDisplay({
   endDate,
   endDate_tz,
 }: Pick<Event, 'startDate' | 'startDate_tz' | 'endDate' | 'endDate_tz'>) {
+  const sameDay = endDate && isSameDay(startDate, endDate, { in: tz(startDate_tz) })
+  const sameYear = endDate && isSameYear(startDate, endDate, { in: tz(startDate_tz) })
+
+  if (sameDay) {
+    return (
+      <span>
+        {formatDateTime(startDate, startDate_tz, 'MMM d, yyyy, p')} -{' '}
+        {formatDateTime(endDate, endDate_tz, 'p zzz')}
+      </span>
+    )
+  }
+
   return (
-    <>
-      {endDate && isSameDay(startDate, endDate, { in: tz(startDate_tz) }) ? (
+    <span>
+      {formatDateTime(
+        startDate,
+        startDate_tz,
+        endDate ? (sameYear ? 'MMM d, p' : 'MMM d, yyyy, p') : 'MMM d, yyyy, p zzz',
+      )}
+      {endDate && (
         <>
-          <span>
-            {formatDateTime(startDate, startDate_tz, 'MMM d, yyyy, p')}
-            <span className="mx-0.5">-</span>
-            {formatDateTime(endDate, endDate_tz, 'p zzz')}
-          </span>
-        </>
-      ) : (
-        <>
-          <span>
-            {formatDateTime(
-              startDate,
-              startDate_tz,
-              endDate ? 'MMM d, yyyy, p' : 'MMM d, yyyy, p zzz',
-            )}
-          </span>
-          {endDate && (
-            <>
-              <span className="mx-0.5">-</span>
-              <span>{formatDateTime(endDate, endDate_tz, 'MMM d, yyyy, p zzz')}</span>
-            </>
-          )}
+          {' - '}
+          {formatDateTime(endDate, endDate_tz, 'MMM d, yyyy, p zzz')}
         </>
       )}
-    </>
+    </span>
   )
 }

--- a/src/utilities/formatDateTime.ts
+++ b/src/utilities/formatDateTime.ts
@@ -1,4 +1,4 @@
-import { TZDate } from '@date-fns/tz'
+import { TZDate, tzName } from '@date-fns/tz'
 import { format } from 'date-fns/format'
 
 export const formatDateTime = (
@@ -6,5 +6,9 @@ export const formatDateTime = (
   tz: string | null | undefined,
   formatStr: string,
 ) => {
-  return tz ? format(new TZDate(dateString, tz), formatStr) : format(dateString, formatStr)
+  const date = tz ? new TZDate(dateString, tz) : new Date(dateString)
+
+  return tz && formatStr.includes('zzz')
+    ? `${format(date, formatStr.replace(/zzz/g, ''))} ${tzName(tz, date, 'short')}`
+    : format(date, formatStr)
 }


### PR DESCRIPTION
## Description
Fix timezone display to show human-readable abbreviations (e.g. "PST") instead of GMT offsets (e.g. "GMT-8"). Also improve date range formatting for multi-day events combining the year.

## Related Issues

## Key Changes
- Update `formatDateTime` to use `tzName()` for short timezone names instead of date-fns default GMT offset format
- Use custom `zzz` token in format strings to trigger timezone name rendering
- Simplify `StartAndEndDateDisplay` — omit redundant year for same-year date ranges, early return for same-day events
- Add calendar icon to `EventPreviewSmallRow` date display

## How to test
1. View events with start/end dates in various scenarios:
   - Single-day event (same start/end date) — should show `MMM d, yyyy, time - time TZ`
   - Multi-day event, same year — should omit year from start date
   - Multi-day event, different years — should show year on both dates
2. Verify timezone shows as e.g. "PST" not "GMT-8"

## Screenshots / Demo video
| Before | After |
|--------|--------|
| <img width="965" height="379" alt="Screenshot 2026-02-12 at 14 53 03" src="https://github.com/user-attachments/assets/1d10ba1f-9c2e-413c-90b1-b11801708e99" /> | <img width="1326" height="498" alt="Screenshot 2026-02-12 at 14 58 48" src="https://github.com/user-attachments/assets/fc82507a-60c2-48b6-95a6-0ae57c118595" /> |
| <img width="972" height="346" alt="Screenshot 2026-02-12 at 14 53 13" src="https://github.com/user-attachments/assets/d1e6b378-4aa5-440d-8dd1-8d30f408a7a9" /> | <img width="1347" height="342" alt="Screenshot 2026-02-12 at 14 59 02" src="https://github.com/user-attachments/assets/fa3b21b6-e960-4058-8530-bfd34da61638" />|
| <img width="581" height="526" alt="Screenshot 2026-02-12 at 14 53 22" src="https://github.com/user-attachments/assets/447ae749-6869-4e5d-bea9-c16f451d9de3" /> | <img width="724" height="503" alt="Screenshot 2026-02-12 at 14 59 09" src="https://github.com/user-attachments/assets/3b0fd723-cc89-4714-917a-d785e386f43b" /> | 