### PR TITLE
Fix console errors - hydration from form & iframe

### DIFF
--- a/src/blocks/Form/Component.tsx
+++ b/src/blocks/Form/Component.tsx
@@ -3,12 +3,11 @@
 import RichText from '@/components/RichText'
 import { Button } from '@/components/ui/button'
 import { useRouter } from 'next/navigation'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useId, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 
 import { FormBlock as FormBlockType } from '@/payload-types'
 import { useTenant } from '@/providers/TenantProvider'
-import { generateInstanceId } from '@/utilities/generateInstanceId'
 import { getURL } from '@/utilities/getURL'
 import { isValidRelationship } from '@/utilities/relationships'
 import { getHostnameFromTenant } from '@/utilities/tenancy/getHostnameFromTenant'
@@ -31,7 +30,7 @@ type FormBlockTypeProps = { isLexical?: boolean } & FormBlockType
 export const FormBlockComponent = (props: FormBlockTypeProps) => {
   const { enableIntro, introContent, isLexical = true } = props
 
-  const uniqueFormId = generateInstanceId()
+  const uniqueFormId = useId()
 
   // Validate form has fields before initializing, use empty array as fallback for hooks
   const formFields = isValidRelationship(props.form) && props.form.fields ? props.form.fields : []

--- a/src/blocks/GenericEmbed/Component.tsx
+++ b/src/blocks/GenericEmbed/Component.tsx
@@ -88,7 +88,7 @@ export const GenericEmbedBlockComponent = ({
           id={String(id)}
           title={`Embedded content ${id}`}
           srcDoc={sanitizedHtml}
-          sandbox="allow-scripts allow-presentation allow-forms allow-same-origin allow-popups"
+          sandbox="allow-scripts allow-presentation allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox"
           className="w-full border-none m-0 p-0 transition-[height] duration-200 ease-in-out"
           height={0} // This iframe will resize to it's content height - this initial height is to avoid the iframe rendering at the browser default 150px initially
         />

--- a/src/blocks/GenericEmbed/Component.tsx
+++ b/src/blocks/GenericEmbed/Component.tsx
@@ -88,7 +88,7 @@ export const GenericEmbedBlockComponent = ({
           id={String(id)}
           title={`Embedded content ${id}`}
           srcDoc={sanitizedHtml}
-          sandbox="allow-scripts allow-forms allow-same-origin allow-popups"
+          sandbox="allow-scripts allow-presentation allow-forms allow-same-origin allow-popups"
           className="w-full border-none m-0 p-0 transition-[height] duration-200 ease-in-out"
           height={0} // This iframe will resize to it's content height - this initial height is to avoid the iframe rendering at the browser default 150px initially
         />

--- a/src/utilities/generateInstanceId.ts
+++ b/src/utilities/generateInstanceId.ts
@@ -1,5 +1,0 @@
-import { v4 as uuidv4 } from 'uuid'
-
-export const generateInstanceId = () => {
-  return uuidv4().substring(0, 8)
-}


### PR DESCRIPTION
## Description
Fix a React hydration error caused by the Form block generating a random UUID on each render via `generateInstanceId()`.
Also fixes iframe error suggestion to add `allow-presentation` 
YouTube "Watch on YouTube" button:
- `allow-popups` — permits the iframe to open new windows/tabs at all
- `allow-popups-to-escape-sandbox` — lets those opened windows/tabs run without inheriting the sandbox restrictions

Without `allow-popups`, the "Watch on YouTube" link would be blocked entirely. Without `allow-popups-to-escape-sandbox`, it opens but the new tab is still sandboxed, causing the error.

## Related Issues
Fixes https://github.com/NWACus/web/issues/861


### Issues
**Form Hydration error**
<img width="603" height="743" alt="Screenshot 2026-02-12 at 15 02 34" src="https://github.com/user-attachments/assets/46fc355b-fb7e-4f99-823b-e49080d4131f" />
<img width="596" height="390" alt="Screenshot 2026-02-12 at 15 02 45" src="https://github.com/user-attachments/assets/5ec72e95-6e8f-408d-a092-55706c04ac6a" />


**iframe error**

<img width="599" height="43" alt="Screenshot 2026-02-12 at 15 02 14" src="https://github.com/user-attachments/assets/de8bd204-bfa8-43eb-a920-e25171e8bba6" />



## Key Changes
- Replace `generateInstanceId()` (which called `uuidv4()`) with React's `useId()` hook, which produces stable, SSR-safe IDs
- Delete the now-unused `generateInstanceId` utility
- Add `allow-presentation` and `allow-popups-to-escape-sandbox` to `GenericEmbed`

## How to test
1. Load a page with a Form block and generic embed to page
2. Confirm no hydration mismatch warnings or iframe warnings in the console
3. Confirm "Watch on YouTube" button opens new tab to youtube
4. Confirm the form and embed still renders and submits correctly

## Video
https://www.loom.com/share/01a2933b7559456986295cce846a0a89