### PR TITLE
GHA: Add post-release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: apexskier/github-release-commenter@v1
         with:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,18 @@
+name: post-release
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  post_release:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: apexskier/github-release-commenter@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          comment-template: |
+            🚀 This is included in version {release_link}


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow that automatically comments on issues and PRs when a release includes their fix, so contributors and reporters know which version contains their change.

## Related Issues

Fixes #938 

## Key Changes

- Added `.github/workflows/post-release.yml` triggered on `release: published` events
- Uses [`apexskier/github-release-commenter@v1`](https://github.com/apexskier/github-release-commenter) to scan commits between releases and comment on associated issues/PRs

**Why `apexskier/github-release-commenter` instead of Payload's fork?**

This workflow was originally copied from [Payload's `post-release.yml`](https://github.com/payloadcms/payload/blob/main/.github/workflows/post-release.yml), which uses a custom composite action (`.github/actions/release-commenter`) — a fork of the apexskier action with modifications for Payload's monorepo release process (tag filtering for non-linear multi-package releases, commenting on locked issues). Those features aren't relevant to us, and using the published action avoids maintaining a vendored copy of their fork.

## How to test

1. Merge this PR
2. Create and publish a GitHub release
3. Verify that issues and PRs included in the release receive a comment like "🚀 This is included in version [v1.0.0](link)"


## Future enhancements / Questions

- Could add `label-template` to automatically label released issues (e.g., `released`)
- Could add `skip-label` to exclude certain issues (e.g., dependency bumps) from being commented on
