### PR TITLE
Fix event page featured image overlap

### DIFF
--- a/src/app/(frontend)/[center]/events/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/events/[slug]/page.tsx
@@ -77,78 +77,74 @@ export default async function Event({ params: paramsPromise }: Args) {
     event.registrationDeadline && new Date(event.registrationDeadline) < new Date()
 
   return (
-    <article className={cn('pt-4 pb-16', { 'pt-8': !event.featuredImage })}>
-      <div className="flex flex-col items-center gap-4">
-        {event.featuredImage && (
-          <Media
-            resource={event.featuredImage}
-            className="w-full absolute"
-            imgClassName="w-full h-[35vh] object-cover"
-          />
-        )}
-        <div className={cn('container z-10', { 'mt-40': event.featuredImage })}>
-          <div className="max-w-[48rem] mx-auto mb-8">
-            <div className="bg-card border rounded-lg p-6 shadow-sm">
-              <div className="prose dark:prose-invert max-w-[48rem] mx-auto pb-4">
-                <h1 className="font-bold mb-2">{event.title}</h1>
-                {event.subtitle && (
-                  <p className="text-xl text-muted-foreground mt-0">{event.subtitle}</p>
-                )}
-              </div>
+    <article className="pb-16">
+      {event.featuredImage && (
+        <Media resource={event.featuredImage} imgClassName="w-full h-[35vh] object-cover" />
+      )}
 
-              <EventInfo
-                startDate={event.startDate}
-                startDate_tz={event.startDate_tz}
-                endDate={event.endDate}
-                endDate_tz={event.endDate_tz}
-                location={event.location}
-                skillLevel={event.skillLevel}
-                showLabels={true}
-                className="columns-1 sm:columns-2"
-                itemsClassName="break-inside-avoid mb-4"
-              />
-
-              {/* Registration Information */}
-              {event.registrationUrl && (
-                <div className="mt-4 pt-4 border-t">
-                  {event.registrationDeadline && (
-                    <p className="text-sm text-muted-foreground mb-4">
-                      Registration Deadline:{' '}
-                      {formatDateTime(
-                        event.registrationDeadline,
-                        event.registrationDeadline_tz,
-                        'MMM d, yyyy',
-                      )}
-                    </p>
-                  )}
-                  {!isPastEvent && !isRegistrationClosed ? (
-                    <ButtonLink
-                      href={event.registrationUrl}
-                      size="lg"
-                      className="w-full md:w-auto"
-                      newTab
-                    >
-                      Register for Event
-                      <ExternalLink className="w-4 h-4 flex-shrink-0 ml-2 -mt-1.5 lg:-mt-0.5 text-muted" />
-                    </ButtonLink>
-                  ) : (
-                    <p className="text-destructive font-medium">
-                      {isPastEvent ? 'This event has passed' : 'Registration is closed'}
-                    </p>
-                  )}
-                </div>
+      <div
+        className={cn('container', { '-mt-24': event.featuredImage, 'pt-8': !event.featuredImage })}
+      >
+        <div className="relative z-10 max-w-[48rem] mx-auto mb-8">
+          <div className="bg-card border rounded-lg p-6 shadow-sm">
+            <div className="prose dark:prose-invert max-w-[48rem] mx-auto pb-4">
+              <h1 className="font-bold mb-2">{event.title}</h1>
+              {event.subtitle && (
+                <p className="text-xl text-muted-foreground mt-0">{event.subtitle}</p>
               )}
             </div>
-          </div>
 
-          {event.content && (
-            <RichText
-              className="prose max-w-[48rem] mx-auto"
-              data={event.content}
-              enableGutter={false}
+            <EventInfo
+              startDate={event.startDate}
+              startDate_tz={event.startDate_tz}
+              endDate={event.endDate}
+              endDate_tz={event.endDate_tz}
+              location={event.location}
+              skillLevel={event.skillLevel}
+              showLabels={true}
+              className="columns-1 sm:columns-2"
+              itemsClassName="break-inside-avoid mb-4"
             />
-          )}
+
+            {event.registrationUrl && (
+              <div className="mt-4 pt-4 border-t">
+                {event.registrationDeadline && (
+                  <p className="text-sm text-muted-foreground mb-4">
+                    Registration Deadline:{' '}
+                    {formatDateTime(
+                      event.registrationDeadline,
+                      event.registrationDeadline_tz,
+                      'MMM d, yyyy',
+                    )}
+                  </p>
+                )}
+                {!isPastEvent && !isRegistrationClosed ? (
+                  <ButtonLink
+                    href={event.registrationUrl}
+                    size="lg"
+                    className="w-full md:w-auto"
+                    newTab
+                  >
+                    Register for Event
+                    <ExternalLink className="w-4 h-4 flex-shrink-0 ml-2 -mt-1.5 lg:-mt-0.5 text-muted" />
+                  </ButtonLink>
+                ) : (
+                  <p className="text-destructive font-medium">
+                    {isPastEvent ? 'This event has passed' : 'Registration is closed'}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
         </div>
+
+        {event.content && (
+          <RichText
+            className="prose max-w-[48rem] mx-auto"
+            data={event.content}
+            enableGutter={false}
+          />
+        )}
       </div>
     </article>
   )

--- a/src/collections/Events/index.ts
+++ b/src/collections/Events/index.ts
@@ -70,6 +70,8 @@ export const Events: CollectionConfig = {
       overrides: {
         admin: {
           allowCreate: true,
+          description:
+            'A large banner image displayed behind the event details at the top of the page',
         },
         name: 'featuredImage',
         label: 'Featured image',

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -774,6 +774,9 @@ export interface Event {
      */
     extraInfo?: string | null;
   };
+  /**
+   * A large banner image displayed behind the event details at the top of the page
+   */
   featuredImage?: (number | null) | Media;
   thumbnailImage?: (number | null) | Media;
   /**


### PR DESCRIPTION
## Description

Rework the single event page layout so the featured image acts as a full-bleed hero with the event info card overlapping it. This PR uses a negative margin rather than position absolute

## Related Issues
Fixes https://github.com/NWACus/web/issues/842

## Key Changes

- Featured image renders full-width as a hero banner (`h-[35vh]`) outside the container
- Event info card overlaps the bottom of the hero image using negative margin (`-mt-24`) and `relative z-10`
- Simplified markup — removed unnecessary wrapper divs and absolute positioning
- Events without a featured image fall back to standard top padding

## How to test

- Visit an event with a featured image (e.g. `/nwac/events/<slug>`) — the card should overlap the bottom of the hero image
- Visit an event without a featured image — the card should render normally with top spacing
- Check responsive behavior at various viewport widths

## Screenshots / Demo video

No featured image
<img width="3380" height="2298" alt="Virtual-Avalanche-Awareness-Webinar-Sawtooth-Avalanche-Center-02-12-2026_04_57_PM (1)" src="https://github.com/user-attachments/assets/4ced9ba3-8a71-4ed6-89d1-6cc36bb7f2de" />

with featured image
<img width="3380" height="2708" alt="Virtual-Avalanche-Awareness-Webinar-Sawtooth-Avalanche-Center-02-12-2026_04_57_PM" src="https://github.com/user-attachments/assets/11892b81-4db7-4ee2-8564-a66c3d3b0625" />
