### PR TITLE
Update snfac button color to be accessible

### DIFF
--- a/src/app/(frontend)/colors.css
+++ b/src/app/(frontend)/colors.css
@@ -174,12 +174,12 @@
   --brand-900: hsl(210 4% 16%);
   --brand-950: hsl(210 4% 12%);
 
-  --secondary: var(--brand-300);
-  --secondary-hover: hsla(178 75% 42%/ 0.8);
+  --secondary: hsl(200 75% 42%);
+  --secondary-hover: hsl(200 75% 38%);
   --secondary-foreground: var(--brand-50);
 
-  --callout: var(--brand-200);
-  --callout-hover: hsla(178 83% 60%/ 0.6);
+  --callout: var(--brand-300);
+  --callout-hover: hsla(178 75% 38%);
   --callout-foreground: var(--brand-50);
 
   --header: var(--brand-400);


### PR DESCRIPTION
## Description
I changed the secondary and callout colors in #935, because the hover state was invalid, causing the button background to disappear. I didn't really think about the change but the button colors should be accessible before we release. brand-200 with a white foreground is a bit too light.