### PR TITLE
Speed up e2e tests with Playwright storageState auth caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ plans/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+__tests__/e2e/.auth/

--- a/__tests__/e2e/admin/tenant-selector/global-collections.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/global-collections.e2e.spec.ts
@@ -19,9 +19,7 @@ import { AdminUrlUtil, CollectionSlugs } from '../../helpers'
  * - Changing tenant in document view redirects to that tenant's document
  */
 
-// Each test creates its own browser context + login; run serially to avoid
-// overwhelming the dev server with simultaneous login requests.
-test.describe.configure({ mode: 'serial', timeout: 90000 })
+test.describe.configure({ timeout: 90000 })
 
 test.describe('Global Collection', () => {
   test.describe('List View', () => {

--- a/__tests__/e2e/admin/tenant-selector/non-tenant.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/non-tenant.e2e.spec.ts
@@ -19,9 +19,7 @@ import { AdminUrlUtil, CollectionSlugs } from '../../helpers'
  * - All documents are visible (subject to user permissions)
  */
 
-// Each test creates its own browser context + login; run with --workers=1
-// to avoid overwhelming the dev server with simultaneous login requests.
-test.describe.configure({ mode: 'serial', timeout: 90000 })
+test.describe.configure({ timeout: 90000 })
 
 test.describe('Non-Tenant Collection', () => {
   test.describe('Users', () => {

--- a/__tests__/e2e/admin/tenant-selector/payload-globals.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/payload-globals.e2e.spec.ts
@@ -19,9 +19,7 @@ import { AdminUrlUtil, CollectionSlugs, GlobalSlugs } from '../../helpers'
  * - Document is accessible regardless of current tenant cookie
  */
 
-// Each test creates its own browser context + login; run serially to avoid
-// overwhelming the dev server with simultaneous login requests.
-test.describe.configure({ mode: 'serial', timeout: 90000 })
+test.describe.configure({ timeout: 90000 })
 
 test.describe('Payload Global', () => {
   test.describe('A3Management', () => {

--- a/__tests__/e2e/admin/tenant-selector/role-based.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/role-based.e2e.spec.ts
@@ -15,9 +15,7 @@ import { TenantIds } from '../../helpers/tenant-cookie'
  * - Single-Center Admin: tenant selector hidden (only 1 option)
  */
 
-// Each test creates its own browser context + login; run serially to avoid
-// overwhelming the dev server with simultaneous login requests.
-test.describe.configure({ mode: 'serial', timeout: 90000 })
+test.describe.configure({ timeout: 90000 })
 
 test.describe('Super Admin', () => {
   test('should see all tenants in dropdown', async ({ loginAs, getTenantOptions }) => {

--- a/__tests__/e2e/admin/tenant-selector/tenant-cookie-edge-cases.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/tenant-cookie-edge-cases.e2e.spec.ts
@@ -17,9 +17,7 @@ import { AdminUrlUtil, CollectionSlugs } from '../../helpers'
  * - Cookie cleared manually
  */
 
-// Each test creates its own browser context + login; run serially to avoid
-// overwhelming the dev server with simultaneous login requests.
-test.describe.configure({ mode: 'serial', timeout: 60000 })
+test.describe.configure({ timeout: 60000 })
 
 test.describe('Tenant Cookie Edge Cases', () => {
   test('no cookie initially - page loads without crashing', async ({

--- a/__tests__/e2e/admin/tenant-selector/tenant-required.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/tenant-required.e2e.spec.ts
@@ -20,9 +20,7 @@ import { TenantIds } from '../../helpers/tenant-cookie'
  * - Document view (create): Tenant selector visible but read-only, pre-populated with cookie value
  */
 
-// Each test creates its own browser context + login; run serially to avoid
-// overwhelming the dev server with simultaneous login requests.
-test.describe.configure({ mode: 'serial', timeout: 90000 })
+test.describe.configure({ timeout: 90000 })
 
 test.describe('Tenant-Required Collection', () => {
   test.describe('List View', () => {

--- a/__tests__/e2e/auth.setup.ts
+++ b/__tests__/e2e/auth.setup.ts
@@ -1,0 +1,16 @@
+import { test as setup } from '@playwright/test'
+import { testUsers, type UserRole } from './fixtures/test-users'
+import { performLogin } from './helpers'
+import { authFile } from './helpers/auth-state'
+
+// Run setup logins serially to avoid overwhelming the dev server,
+// and with a longer timeout since each login involves form hydration.
+setup.describe.configure({ mode: 'serial', timeout: 60000 })
+
+for (const [role, user] of Object.entries(testUsers)) {
+  setup(`authenticate as ${role}`, async ({ page }) => {
+    await performLogin(page, user.email, user.password)
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    await page.context().storageState({ path: authFile(role as UserRole) })
+  })
+}

--- a/__tests__/e2e/fixtures/auth.fixture.ts
+++ b/__tests__/e2e/fixtures/auth.fixture.ts
@@ -1,6 +1,7 @@
 import { test as base, Page } from '@playwright/test'
 import { performLogin } from '../helpers'
-import { testUsers, UserRole } from './test-users'
+import { authFile } from '../helpers/auth-state'
+import { UserRole } from './test-users'
 
 type AuthFixtures = {
   /** Login as a specific user role and return the authenticated page */
@@ -14,10 +15,8 @@ type AuthFixtures = {
 export const authTest = base.extend<AuthFixtures>({
   loginAs: async ({ browser }, use) => {
     const loginAsRole = async (role: UserRole): Promise<Page> => {
-      const user = testUsers[role]
-      const context = await browser.newContext()
+      const context = await browser.newContext({ storageState: authFile(role) })
       const page = await context.newPage()
-      await performLogin(page, user.email, user.password)
       return page
     }
     // eslint-disable-next-line react-hooks/rules-of-hooks -- Playwright's `use` is not a React hook
@@ -36,10 +35,8 @@ export const authTest = base.extend<AuthFixtures>({
   },
 
   adminPage: async ({ browser }, use) => {
-    const user = testUsers.superAdmin
-    const context = await browser.newContext()
+    const context = await browser.newContext({ storageState: authFile('superAdmin') })
     const page = await context.newPage()
-    await performLogin(page, user.email, user.password)
     // eslint-disable-next-line react-hooks/rules-of-hooks -- Playwright's `use` is not a React hook
     await use(page)
     await context.close()

--- a/__tests__/e2e/fixtures/tenant-selector.fixture.ts
+++ b/__tests__/e2e/fixtures/tenant-selector.fixture.ts
@@ -4,7 +4,6 @@ import {
   getSelectInputValue,
   getTenantCookieFromPage,
   isSelectReadOnly,
-  performLogin,
   selectInput,
   setTenantCookieFromPage,
   TenantNames,
@@ -12,8 +11,9 @@ import {
   waitForTenantCookie,
   type TenantSlug,
 } from '../helpers'
+import { authFile } from '../helpers/auth-state'
 import { openNav } from './nav.fixture'
-import { testUsers, UserRole } from './test-users'
+import { UserRole } from './test-users'
 
 type TenantSelectorFixtures = {
   /**
@@ -76,10 +76,8 @@ type TenantSelectorFixtures = {
 export const tenantSelectorTest = base.extend<TenantSelectorFixtures>({
   loginAs: async ({ browser }, use) => {
     const loginAsRole = async (role: UserRole): Promise<Page> => {
-      const user = testUsers[role]
-      const context = await browser.newContext()
+      const context = await browser.newContext({ storageState: authFile(role) })
       const page = await context.newPage()
-      await performLogin(page, user.email, user.password)
       return page
     }
     // eslint-disable-next-line react-hooks/rules-of-hooks -- Playwright's `use` is not a React hook

--- a/__tests__/e2e/helpers/auth-state.ts
+++ b/__tests__/e2e/helpers/auth-state.ts
@@ -1,0 +1,11 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+import type { UserRole } from '../fixtures/test-users'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const authDir = path.join(__dirname, '..', '.auth')
+
+/** Get the path to a role's saved storage state file */
+export function authFile(role: UserRole): string {
+  return path.join(authDir, `${role}.json`)
+}

--- a/consistent-type-assertions.txt
+++ b/consistent-type-assertions.txt
@@ -1,3 +1,4 @@
+__tests__/e2e/auth.setup.ts
 src/app/(frontend)/[center]/[...segments]/page.tsx
 src/app/(frontend)/[center]/[slug]/page.tsx
 src/app/(frontend)/[center]/blog/[slug]/page.tsx

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,13 +16,19 @@ export default defineConfig({
   },
   projects: [
     {
+      name: 'setup',
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
       name: 'admin',
       testMatch: '**/admin/**/*.e2e.spec.ts',
+      dependencies: ['setup'],
       use: { ...devices['Desktop Chrome'] },
     },
     {
       name: 'frontend',
       testMatch: '**/frontend/**/*.e2e.spec.ts',
+      dependencies: ['setup'],
       use: { ...devices['Desktop Chrome'] },
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   reporter: process.env.CI ? 'github' : 'html',
   timeout: 30000,
   use: {


### PR DESCRIPTION
## Description

Speeds up E2E tests by caching authenticated browser sessions with Playwright's `storageState` feature. Instead of performing a full UI login (~5-15s) for every test, each user role logs in once during a setup phase and saves its session to disk. Tests then load the cached session instantly.

Also removes `mode: 'serial'` from all tenant-selector test files — serial mode was only needed to prevent concurrent UI logins from overwhelming the dev server. With cached auth, tests now run fully in parallel.

## Related Issues
#519 

## Key Changes

- **Auth setup project** (`__tests__/e2e/auth.setup.ts`): Logs in as all 8 test user roles and saves browser state to `__tests__/e2e/.auth/` files
- **Auth state helper** (`__tests__/e2e/helpers/auth-state.ts`): Exports `authFile(role)` to resolve storage state file paths
- **Playwright config**: Added `setup` project as a dependency for `admin` and `frontend` projects
- **Auth fixtures** (`auth.fixture.ts`, `tenant-selector.fixture.ts`): `loginAs()` now creates browser contexts with saved `storageState` instead of calling `performLogin()`
- **Tenant-selector test files**: Removed `mode: 'serial'` (kept extended timeouts for multi-navigation tests)
- **`.gitignore`**: Added `__tests__/e2e/.auth/`

## How to test

```bash
# Run all e2e tests
pnpm exec playwright test

# Run just tenant-selector tests to verify parallel execution
pnpm exec playwright test --project=admin -g "tenant"
```

## Future enhancements / Questions

- `loginWithCredentials` still uses UI login since it takes arbitrary credentials — could add caching if specific credential combos are reused