### PR TITLE
Exclude /ingest from middleware matcher

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,13 +8,14 @@ export const config = {
     /*
      * Match all paths except for:
      * 1. /api routes
-     * 2. /_next (Next.js internals)
-     * 3. /_static (inside /public)
-     * 4. all root files inside /public (e.g. /favicon.ico)
-     * 5. /media, /thumbnail, /assets (inside /public)
-     * 6. sitemap.xml, robots.txt, pages-sitemap.xml, posts-sitemap.xml
+     * 2. /ingest (PostHog analytics proxy)
+     * 3. /_next (Next.js internals)
+     * 4. /_static (inside /public)
+     * 5. all root files inside /public (e.g. /favicon.ico)
+     * 6. /media, /thumbnail, /assets (inside /public)
+     * 7. sitemap.xml, robots.txt, pages-sitemap.xml, posts-sitemap.xml
      */
-    '/((?!api|_next|_static|_vercel|[\\w-]+\\.\\w+|media|thumbnail|assets).*)',
+    '/((?!api|ingest|_next|_static|_vercel|[\\w-]+\\.\\w+|media|thumbnail|assets).*)',
     '/sitemap.xml',
     '/robots.txt',
     '/pages-sitemap.xml',


### PR DESCRIPTION
## Description
Exclude PostHog `/ingest` paths from middleware to reduce unnecessary edge invocations and Vercel usage.

I was able to confirm on Posthog that page views events alone. This might be related to the current avalanche warnings in Tahoe.
<img width="1440" height="729" alt="Screenshot 2026-02-18 at 10 29 21" src="https://github.com/user-attachments/assets/0b643473-4afa-497d-ae58-bc5363193410" />


## Related Issues
Production usage alerts — Edge Requests up 4.82x, Function Invocations up 4.37x, CPU Duration up 2.77x, Data Transfer up 5.37x.

## Key Changes
- Added `ingest` to the negative lookahead regex in the middleware matcher
- PostHog analytics traffic (`/ingest/s/`, `/ingest/i/v0/e/`, `/ingest/flags/`, etc.) now bypasses middleware entirely
- ~80% of middleware invocations were `/ingest/*` requests that called `getTenants()` only to pass through with no action

## How to test
- Deploy to preview and confirm PostHog analytics still works (events, session recording, feature flags)
- Run `vercel logs <deployment-url>` and confirm `/ingest/*` paths no longer appear
- Monitor Vercel usage dashboard for reduction in edge requests and function invocations

