### PR TITLE
Improve production release - manual deploy & display tag

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -1,11 +1,12 @@
 name: production
+run-name: 'Deploy ${{ github.ref_name }}'
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 on:
   push:
-    branches:
-      - 'release'
+    tags:
+      - 'v*'
   # Allow manual triggering
   workflow_dispatch:
     inputs:
@@ -94,8 +95,7 @@ jobs:
           set -o nounset
           set -o pipefail
 
-          ref="${{ github.event.ref }}"
-          branch="${ref##refs/heads/}"
+          branch="release"
 
           echo "Cleaning up deployments and aliases for branch: $branch"
 

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -78,8 +78,9 @@ jobs:
           set -o pipefail
 
           fullName="${{ github.repository }}"
+          author="${{ github.event.pusher.name || github.actor }}"
           vercel deploy --yes --prebuilt --target=production \
-            --meta='githubCommitAuthorName=${{ github.event.pusher.name }}' \
+            --meta="githubCommitAuthorName=${author}" \
             --meta='githubCommitOrg=${{ github.repository_owner }}' \
             --meta='githubCommitRef=release' \
             --meta="githubCommitRepo=${fullName##*/}" \
@@ -87,7 +88,7 @@ jobs:
             --meta='githubDeployment=1' \
             --meta='githubOrg=${{ github.repository_owner }}' \
             --meta="githubRepo=${fullName##*/}" \
-            --meta='githubCommitAuthorLogin=${{ github.event.pusher.name }}' \
+            --meta="githubCommitAuthorLogin=${author}" \
             --token=${{ secrets.VERCEL_TOKEN }}
       - name: Remove old Vercel deployments (keep latest 2)
         run: |

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -38,6 +38,15 @@ jobs:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify release branch is up to date
+        run: |
+          git fetch origin release
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/release)" ]; then
+            echo "::error::Tag commit doesn't match release branch. Did you forget 'git push origin'?"
+            exit 1
+          fi
       - name: 🏗 Setup pnpm
         uses: pnpm/action-setup@v4
       - name: 🏗 Setup Node

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,6 +390,10 @@ When triggered via GitHub Issues (with `@claude` mention):
 3. Follow existing code patterns and styles in the codebase
 4. Run `pnpm prettify`, `pnpm tsc`, and `pnpm lint` before committing
 
+### Pull Request Descriptions
+
+When asked to write a PR description, follow the template in `.github/PULL_REQUEST_TEMPLATE.md` and return the description in markdown.
+
 ### Creating the PR
 
 1. Write a clear PR title summarizing the change


### PR DESCRIPTION
## Description

Update the production GHA workflow to trigger on version tag pushes (`v*`) instead of branch pushes, so workflow runs display as "Deploy v1.8.0" instead of "Merge pull request #943...".

## Related Issues

Just from chatting with @busbyk 

## Key Changes

- **Tag-based trigger**: Changed `on: push: branches: ['release']` to `on: push: tags: ['v*']` — deploys now trigger from the tag push in the existing release process
- **Run name**: Added `run-name: 'Deploy ${{ github.ref_name }}'` for clear version labeling in the Actions UI
- **Release branch verification**: Added a check that fails the workflow if the tag commit doesn't match the `release` branch, catching cases where someone pushes a tag without pushing the branch
- **Manual deploy fix**: `github.event.pusher.name` is empty on `workflow_dispatch` — added `|| github.actor` fallback to prevent Vercel meta validation error
- **Cleanup step**: Hardcoded `branch="release"` since the deploy meta already hardcodes `githubCommitRef=release` and deriving it from `github.event.ref` breaks with tag triggers

## How to test

1. Create a tag and push both tag and branch: `git tag -s v1.8.1-test -m 'v1.8.1-test' && git push origin --tags && git push origin`
2. Verify the production workflow triggers and the run shows "Deploy v1.8.1-test"
3. Verify the "Verify release branch is up to date" step passes
4. Trigger a manual `workflow_dispatch` and verify it no longer fails on the author meta
