### PR TITLE
Generic embeds failing on chromium - switch to blob

### DIFF
--- a/src/blocks/GenericEmbed/Component.tsx
+++ b/src/blocks/GenericEmbed/Component.tsx
@@ -21,6 +21,9 @@ export const GenericEmbedBlockComponent = ({
   isLexical = true,
 }: Props) => {
   const [sanitizedHtml, setSanitizedHtml] = useState<string | null>(null)
+  // Unique key per mount forces a new iframe browsing context, ensuring scripts
+  // (especially type="module") re-execute after client-side navigation in Chrome.
+  const [iframeKey] = useState(() => Date.now())
 
   const bgColorClass = `bg-${backgroundColor}`
   const textColor = getTextColorFromBgColor(backgroundColor)
@@ -85,6 +88,7 @@ export const GenericEmbedBlockComponent = ({
         )}
       >
         <IframeResizer
+          key={iframeKey}
           id={String(id)}
           title={`Embedded content ${id}`}
           srcDoc={sanitizedHtml}

--- a/src/blocks/GenericEmbed/Component.tsx
+++ b/src/blocks/GenericEmbed/Component.tsx
@@ -55,13 +55,15 @@ export const GenericEmbedBlockComponent = ({
       FORCE_BODY: true,
     })
 
-    // Convert external module scripts to dynamic imports inside inline classic scripts.
-    // Chrome does not re-execute <script type="module" src="..."> in srcDoc iframes
-    // after client-side navigation. Inline classic scripts always execute, and dynamic
-    // import() bypasses Chrome's per-URL module evaluation cache.
+    // Replace static module script tags with inline scripts that programmatically
+    // create and inject the script element. Chrome does not re-execute static
+    // <script type="module" src="..."> in srcDoc iframes after client-side navigation
+    // because it considers the script already loaded. Using document.createElement
+    // forces the browser to treat it as a fresh script load every time.
     const withDynamicScripts = sanitized.replace(
       /<script[^>]*\btype="module"[^>]*\bsrc="([^"]+)"[^>]*><\/script>/gi,
-      (_, url) => `<script>import(${JSON.stringify(url)});<\/script>`,
+      (_, url) =>
+        `<script>var s=document.createElement("script");s.type="module";s.src=${JSON.stringify(url)};s.async=true;document.head.appendChild(s);<\/script>`,
     )
 
     const styleOverrides = `

--- a/src/blocks/GenericEmbed/Component.tsx
+++ b/src/blocks/GenericEmbed/Component.tsx
@@ -97,7 +97,7 @@ export const GenericEmbedBlockComponent = ({
           src={blobUrl}
           sandbox="allow-scripts allow-presentation allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox"
           className="w-full border-none m-0 p-0 transition-[height] duration-200 ease-in-out"
-          height={0}
+          height={0} // This iframe will resize to it's content height - this initial height is to avoid the iframe rendering at the browser default 150px initially
         />
       </div>
     </div>

--- a/src/blocks/GenericEmbed/Component.tsx
+++ b/src/blocks/GenericEmbed/Component.tsx
@@ -25,22 +25,19 @@ export const GenericEmbedBlockComponent = ({
   const bgColorClass = `bg-${backgroundColor}`
   const textColor = getTextColorFromBgColor(backgroundColor)
 
+  // TODO: remove debug logging
+  console.log('[GenericEmbed] component rendered, sanitizedHtml:', sanitizedHtml ? 'set' : 'null')
+
   useEffect(() => {
+    console.log('[GenericEmbed] useEffect fired, html:', html ? 'present' : 'missing')
     if (typeof window === 'undefined' || !html) return
 
     // Normalize problematic quotes that are parsed incorrectly by DOMParser and DOMPurify
     const normalizedHTML = html.replaceAll('"', '"').replaceAll('"', '"')
-
-    // Add cache-busting parameter to module script URLs to force re-evaluation.
-    // Chrome caches module scripts by URL and skips re-evaluation on client-side
-    // navigation, which prevents widgets from loading when revisiting a page.
-    DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-      const src = node.getAttribute('src')
-      if (node.tagName === 'SCRIPT' && node.getAttribute('type') === 'module' && src) {
-        const separator = src.includes('?') ? '&' : '?'
-        node.setAttribute('src', `${src}${separator}_cb=${Date.now()}`)
-      }
-    })
+    console.log(
+      '[GenericEmbed] normalizedHTML contains script:',
+      normalizedHTML.includes('<script'),
+    )
 
     const sanitized = DOMPurify.sanitize(normalizedHTML, {
       ADD_TAGS: ['iframe', 'script', 'style', 'dbox-widget'],
@@ -66,7 +63,8 @@ export const GenericEmbedBlockComponent = ({
       FORCE_BODY: true,
     })
 
-    DOMPurify.removeHook('afterSanitizeAttributes')
+    console.log('[GenericEmbed] sanitized contains script:', sanitized.includes('<script'))
+    console.log('[GenericEmbed] sanitized output:', sanitized)
 
     const styleOverrides = `
       <style>

--- a/src/blocks/GenericEmbed/Component.tsx
+++ b/src/blocks/GenericEmbed/Component.tsx
@@ -29,7 +29,7 @@ export const GenericEmbedBlockComponent = ({
     if (typeof window === 'undefined' || !html) return
 
     // Normalize problematic quotes that are parsed incorrectly by DOMParser and DOMPurify
-    const normalizedHTML = html.replaceAll('\u201C', '"').replaceAll('\u201D', '"')
+    const normalizedHTML = html.replaceAll('"', '"').replaceAll('"', '"')
 
     const sanitized = DOMPurify.sanitize(normalizedHTML, {
       ADD_TAGS: ['iframe', 'script', 'style', 'dbox-widget'],


### PR DESCRIPTION
## Description
Fix embedded scripts (e.g., Donorbox donation form) not loading after client-side navigation on Chromium browsers. Chromium does not re-execute scripts in `srcDoc` (`about:srcdoc`) iframes when the iframe is recreated during SPA navigation. Switching to blob URLs forces a real document navigation, ensuring scripts execute fresh every time.

## Related Issues
Fixes #816 

## Key Changes
- Replace `srcDoc` with `src={blobUrl}` on the GenericEmbed iframe
- Create a unique blob URL per mount via `URL.createObjectURL`, revoked on unmount

## How to test
1. Navigate to a page with a GenericEmbed block containing a script (e.g., Donorbox donate page)
2. Verify the widget loads on first visit
3. Navigate away via a site link, then navigate back
4. Verify the widget loads again on Chrome
5. Verify the widget still works on Firefox and Safari
