### PR TITLE
Fix bad migration json

### DIFF
--- a/src/migrations/20260131_012456_remove_wrap_in_container.json
+++ b/src/migrations/20260131_012456_remove_wrap_in_container.json
@@ -1490,8 +1490,8 @@
           "notNull": false,
           "autoincrement": false
         },
-        "button_appearance": {
-          "name": "button_appearance",
+        "button_variant": {
+          "name": "button_variant",
           "type": "text",
           "primaryKey": false,
           "notNull": false,
@@ -4222,8 +4222,8 @@
           "notNull": false,
           "autoincrement": false
         },
-        "button_appearance": {
-          "name": "button_appearance",
+        "button_variant": {
+          "name": "button_variant",
           "type": "text",
           "primaryKey": false,
           "notNull": false,
@@ -6923,8 +6923,8 @@
           "notNull": false,
           "autoincrement": false
         },
-        "button_appearance": {
-          "name": "button_appearance",
+        "button_variant": {
+          "name": "button_variant",
           "type": "text",
           "primaryKey": false,
           "notNull": false,
@@ -9452,8 +9452,8 @@
           "notNull": false,
           "autoincrement": false
         },
-        "button_appearance": {
-          "name": "button_appearance",
+        "button_variant": {
+          "name": "button_variant",
           "type": "text",
           "primaryKey": false,
           "notNull": false,


### PR DESCRIPTION
## Description

Fixes the migration JSON snapshot in `20260131_012456_remove_wrap_in_container.json` which still referenced the old `button_appearance` column name instead of `button_variant`. This caused Payload to repeatedly suggest creating a migration to rename `appearance` to `variant` — a migration that already exists.

## Related Issues

Caused by #899 (Improve and simplify `wrapInContainer` behavior with background color picker). That PR's migration snapshot was generated from a schema state that predated the `button_appearance` → `button_variant` rename from #892 (Clean up how we use links). Since the `remove_wrap_in_container` migration is the last in the list, its stale snapshot became the baseline Payload compares against, causing a perpetual diff.

## Key Changes

- Updated `20260131_012456_remove_wrap_in_container.json` to replace 8 occurrences of `button_appearance` with `button_variant`, matching the actual database state after migration `20260128_213937_rename_appearance_to_variant` runs

## How to test

1. Run `pnpm payload migrate:create` — it should report no schema changes needed (previously it would generate a rename migration every time)

## Migration Explanation

No new migration. This corrects the JSON snapshot of an existing migration so Payload's schema diffing works correctly.

## Future enhancements / Questions

When creating migrations on branches, we should ensure the latest snapshot reflects all prior migrations in the chain. This can happen when two PRs with migrations are developed in parallel — whichever merges second may have a snapshot that doesn't include the first PR's changes.
