### PR TITLE
Rename `isLexical` to `isLayoutBlock` and fix background color logic

### DIFF
--- a/docs/coding-guide.md
+++ b/docs/coding-guide.md
@@ -181,10 +181,10 @@ blocks
 When creating a new block, you must register it in the following locations:
 
 1. **`src/blocks/RenderBlocks.tsx`** - For standalone page blocks
-   - Set `isLayoutBlock={false}`
+   - Set `isLayoutBlock={true}` so the block gets its own `container` wrapper
 
 2. **`src/components/RichText/index.tsx`** - For blocks used inline within rich text editors
-   - Set `isLayoutBlock={true}` to avoid double-wrapping
+   - Set `isLayoutBlock={false}` to avoid double-wrapping (the RichText component already provides a container)
    - Only add blocks that should be available in Lexical editors
 
 3. **`src/constants/defaults.ts`** - Add the block to the defaults configuration
@@ -195,8 +195,8 @@ When creating a new block, you must register it in the following locations:
    - This ensures Payload generates TypeScript types for your block
 
 **Why the different `isLayoutBlock` values?**
-- Standalone blocks (`RenderBlocks.tsx`) are not rendered by a Lexical editor → `isLayoutBlock={false}`
-- Inline Lexical blocks (`RichText/index.tsx`) are rendered inside a Lexical editor → `isLayoutBlock={true}`
+- Standalone blocks (`RenderBlocks.tsx`) are top-level page layout blocks that need their own container → `isLayoutBlock={true}`
+- Inline Lexical blocks (`RichText/index.tsx`) are embedded inside a rich text field that already provides a container → `isLayoutBlock={false}`
 
 
 ### BackgroundColorWrapper
@@ -205,7 +205,7 @@ A reusable layout component that wraps content with configurable background colo
 
 **Props:**
 - `backgroundColor` - Tailwind background color class name
-- `isLayoutBlock` - Whether the block is rendered within a Lexical editor (`default: false`)
+- `isLayoutBlock` - Whether the block is a standalone page layout block that needs its own container (`default: false`)
 - `containerClassName` - Optional - additional classes for the inner container div
 - `outerClassName` - Optional - additional classes for the outer wrapper div
 

--- a/docs/coding-guide.md
+++ b/docs/coding-guide.md
@@ -181,10 +181,10 @@ blocks
 When creating a new block, you must register it in the following locations:
 
 1. **`src/blocks/RenderBlocks.tsx`** - For standalone page blocks
-   - Set `isLexical={false}`
+   - Set `isLayoutBlock={false}`
 
 2. **`src/components/RichText/index.tsx`** - For blocks used inline within rich text editors
-   - Set `isLexical={true}` to avoid double-wrapping
+   - Set `isLayoutBlock={true}` to avoid double-wrapping
    - Only add blocks that should be available in Lexical editors
 
 3. **`src/constants/defaults.ts`** - Add the block to the defaults configuration
@@ -194,9 +194,9 @@ When creating a new block, you must register it in the following locations:
    - A `richText` field's `BlocksFeature` configuration
    - This ensures Payload generates TypeScript types for your block
 
-**Why the different `isLexical` values?**
-- Standalone blocks (`RenderBlocks.tsx`) are not rendered by a Lexical editor → `isLexical={false}`
-- Inline Lexical blocks (`RichText/index.tsx`) are rendered inside a Lexical editor → `isLexical={true}`
+**Why the different `isLayoutBlock` values?**
+- Standalone blocks (`RenderBlocks.tsx`) are not rendered by a Lexical editor → `isLayoutBlock={false}`
+- Inline Lexical blocks (`RichText/index.tsx`) are rendered inside a Lexical editor → `isLayoutBlock={true}`
 
 
 ### BackgroundColorWrapper
@@ -205,7 +205,7 @@ A reusable layout component that wraps content with configurable background colo
 
 **Props:**
 - `backgroundColor` - Tailwind background color class name
-- `isLexical` - Whether the block is rendered within a Lexical editor (`default: false`)
+- `isLayoutBlock` - Whether the block is rendered within a Lexical editor (`default: false`)
 - `containerClassName` - Optional - additional classes for the inner container div
 - `outerClassName` - Optional - additional classes for the outer wrapper div
 
@@ -213,7 +213,7 @@ A reusable layout component that wraps content with configurable background colo
 ```tsx
 <BackgroundColorWrapper
   backgroundColor={backgroundColor} // Intended for prop from colorPickerField prop
-  isLexical={isLexical} // Intended for prop from standalone or lexical block declaration
+  isLayoutBlock={isLayoutBlock} // Intended for prop from standalone or lexical block declaration
   containerClassName="py-8"
 >
   <YourContent />

--- a/src/blocks/BlogList/Component.tsx
+++ b/src/blocks/BlogList/Component.tsx
@@ -14,7 +14,7 @@ import { cn } from '@/utilities/ui'
 import { useEffect, useState } from 'react'
 
 type BlogListComponentProps = BlogListBlockProps & {
-  isLexical: boolean
+  isLayoutBlock: boolean
   className?: string
 }
 
@@ -24,7 +24,7 @@ export const BlogListBlockComponent = (args: BlogListComponentProps) => {
     belowHeadingContent,
     backgroundColor,
     className,
-    isLexical = true,
+    isLayoutBlock = true,
     postOptions,
   } = args
 
@@ -91,7 +91,7 @@ export const BlogListBlockComponent = (args: BlogListComponentProps) => {
   return (
     <BackgroundColorWrapper
       backgroundColor={backgroundColor}
-      isLexical={isLexical}
+      isLayoutBlock={isLayoutBlock}
       containerClassName={className}
     >
       <div className="bg-card text-card-foreground p-6 border shadow rounded-lg flex flex-col gap-6">

--- a/src/blocks/Document/Component.tsx
+++ b/src/blocks/Document/Component.tsx
@@ -7,11 +7,11 @@ import { getHostnameFromTenant } from '@/utilities/tenancy/getHostnameFromTenant
 import { cn } from '@/utilities/ui'
 
 type Props = DocumentBlockProps & {
-  isLexical: boolean
+  isLayoutBlock: boolean
 }
 
 export const DocumentBlockComponent = (props: Props) => {
-  const { document, isLexical = true } = props
+  const { document, isLayoutBlock = true } = props
   const { tenant } = useTenant()
 
   if (!isValidRelationship(document) || !document.url) {
@@ -21,7 +21,7 @@ export const DocumentBlockComponent = (props: Props) => {
   const src = getMediaURL(document.url, null, getHostnameFromTenant(tenant))
 
   return (
-    <div className={cn('my-4', { container: isLexical })}>
+    <div className={cn('my-4', { container: isLayoutBlock })}>
       <iframe src={src} width="100%" height="600px" title="Document PDF" />
     </div>
   )

--- a/src/blocks/EventList/Component.tsx
+++ b/src/blocks/EventList/Component.tsx
@@ -12,7 +12,7 @@ import { format } from 'date-fns'
 import { useEffect, useState } from 'react'
 
 type EventListComponentProps = EventListBlockProps & {
-  isLexical: boolean
+  isLayoutBlock: boolean
   className?: string
 }
 
@@ -22,7 +22,7 @@ export const EventListBlockComponent = (args: EventListComponentProps) => {
     belowHeadingContent,
     backgroundColor,
     className,
-    isLexical = true,
+    isLayoutBlock = true,
     eventOptions,
   } = args
 
@@ -98,7 +98,7 @@ export const EventListBlockComponent = (args: EventListComponentProps) => {
   return (
     <BackgroundColorWrapper
       backgroundColor={backgroundColor}
-      isLexical={isLexical}
+      isLayoutBlock={isLayoutBlock}
       containerClassName={className}
     >
       <div className="bg-card text-card-foreground p-6 border shadow rounded-lg flex flex-col gap-6">

--- a/src/blocks/EventTable/Component.tsx
+++ b/src/blocks/EventTable/Component.tsx
@@ -104,7 +104,7 @@ export const EventTableBlockComponent = (args: EventTableComponentProps) => {
       isLayoutBlock={isLayoutBlock}
       containerClassName={className}
     >
-      <div className={cn('container bg-card text-card-foreground p-6 rounded-lg', className)}>
+      <div className={cn('bg-card text-card-foreground', className)}>
         <div className="flex flex-col justify-start gap-1">
           {heading && (
             <div className="prose md:prose-md dark:prose-invert">

--- a/src/blocks/EventTable/Component.tsx
+++ b/src/blocks/EventTable/Component.tsx
@@ -11,7 +11,7 @@ import { format } from 'date-fns'
 import { useEffect, useState } from 'react'
 
 type EventTableComponentProps = EventTableBlockProps & {
-  isLexical: boolean
+  isLayoutBlock: boolean
   className?: string
 }
 
@@ -22,7 +22,7 @@ export const EventTableBlockComponent = (args: EventTableComponentProps) => {
     className,
     eventOptions,
     backgroundColor,
-    isLexical = true,
+    isLayoutBlock = true,
   } = args
   const { byTypes, byGroups, byTags, maxEvents } = args.dynamicOpts || {}
   const { staticEvents } = args.staticOpts || {}
@@ -101,7 +101,7 @@ export const EventTableBlockComponent = (args: EventTableComponentProps) => {
   return (
     <BackgroundColorWrapper
       backgroundColor={backgroundColor}
-      isLexical={isLexical}
+      isLayoutBlock={isLayoutBlock}
       containerClassName={className}
     >
       <div className={cn('container bg-card text-card-foreground p-6 rounded-lg', className)}>

--- a/src/blocks/Form/Component.tsx
+++ b/src/blocks/Form/Component.tsx
@@ -25,10 +25,10 @@ export interface Data {
   [key: string]: Property | Property[]
 }
 
-type FormBlockTypeProps = { isLexical?: boolean } & FormBlockType
+type FormBlockTypeProps = { isLayoutBlock?: boolean } & FormBlockType
 
 export const FormBlockComponent = (props: FormBlockTypeProps) => {
-  const { enableIntro, introContent, isLexical = true } = props
+  const { enableIntro, introContent, isLayoutBlock = true } = props
 
   const uniqueFormId = useId()
 
@@ -129,7 +129,7 @@ export const FormBlockComponent = (props: FormBlockTypeProps) => {
   }
 
   return (
-    <div className={cn('lg:max-w-[48rem]', isLexical && 'container')}>
+    <div className={cn('lg:max-w-[48rem]', isLayoutBlock && 'container')}>
       {enableIntro && introContent && !hasSubmitted && (
         <RichText className="mb-8 lg:mb-12" data={introContent} enableGutter={false} />
       )}

--- a/src/blocks/GenericEmbed/Component.tsx
+++ b/src/blocks/GenericEmbed/Component.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react'
 import type { GenericEmbedBlock as GenericEmbedBlockProps } from 'src/payload-types'
 
 type Props = GenericEmbedBlockProps & {
-  isLexical: boolean
+  isLayoutBlock: boolean
   className?: string
 }
 
@@ -18,7 +18,7 @@ export const GenericEmbedBlockComponent = ({
   backgroundColor,
   alignContent = 'left',
   className,
-  isLexical = true,
+  isLayoutBlock = true,
 }: Props) => {
   const [blobUrl, setBlobUrl] = useState<string | null>(null)
 
@@ -83,7 +83,7 @@ export const GenericEmbedBlockComponent = ({
     <div className={cn(bgColorClass, textColor)}>
       <div
         className={cn(
-          isLexical && 'container py-10',
+          isLayoutBlock && 'container py-10',
           'flex flex-col',
           alignContent === 'left' && 'items-start',
           alignContent === 'center' && 'items-center',

--- a/src/blocks/Header/Component.tsx
+++ b/src/blocks/Header/Component.tsx
@@ -4,12 +4,12 @@ import getTextColorFromBgColor from '@/utilities/getTextColorFromBgColor'
 import { cn } from '@/utilities/ui'
 
 type Props = HeaderBlockProps & {
-  isLexical: boolean
+  isLayoutBlock: boolean
   fullWidthColor?: boolean
 }
 
 export const HeaderBlockComponent = (props: Props) => {
-  const { backgroundColor, fullWidthColor, richText, isLexical } = props
+  const { backgroundColor, fullWidthColor, richText, isLayoutBlock } = props
 
   const bgColorClass = `bg-${backgroundColor}`
   const textColor = getTextColorFromBgColor(backgroundColor)
@@ -20,11 +20,11 @@ export const HeaderBlockComponent = (props: Props) => {
         className={cn(
           'py-4 w-full',
           textColor,
-          { container: isLexical },
+          { container: isLayoutBlock },
           !fullWidthColor && `${bgColorClass}`,
         )}
       >
-        <RichText data={richText} enableGutter={false} className={cn(!isLexical && 'px-4')} />
+        <RichText data={richText} enableGutter={false} className={cn(!isLayoutBlock && 'px-4')} />
       </div>
     </div>
   )

--- a/src/blocks/Media/Component.tsx
+++ b/src/blocks/Media/Component.tsx
@@ -12,7 +12,7 @@ import getTextColorFromBgColor from '@/utilities/getTextColorFromBgColor'
 const { breakpoints } = cssVariables
 
 type Props = MediaBlockProps & {
-  isLexical: boolean
+  isLayoutBlock: boolean
   captionClassName?: string
   className?: string
   imgClassName?: string
@@ -24,7 +24,7 @@ export const MediaBlockComponent = (props: Props) => {
     caption,
     captionClassName,
     className,
-    isLexical = true,
+    isLayoutBlock = true,
     imgClassName,
     media,
     staticImage,
@@ -74,7 +74,7 @@ export const MediaBlockComponent = (props: Props) => {
     <div className={cn(bgColorClass, textColor)}>
       <div
         className={cn(
-          isLexical && 'container py-10',
+          isLayoutBlock && 'container py-10',
           'flex flex-col',
           alignContent === 'left' && 'items-start',
           alignContent === 'center' && 'items-center',

--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -32,7 +32,7 @@ export const RenderBlocks = (props: { blocks: Page['layout'][0][]; payload: Payl
         {blocks.map((block) => {
           return (
             <div key={`${block.id}__${block.blockType}`}>
-              <RenderBlock block={block} payload={props.payload} />
+              <RenderBlock block={block} />
             </div>
           )
         })}
@@ -43,7 +43,7 @@ export const RenderBlocks = (props: { blocks: Page['layout'][0][]; payload: Payl
   return null
 }
 
-export const RenderBlock = ({ block, payload }: { block: Page['layout'][0]; payload: Payload }) => {
+export const RenderBlock = ({ block }: { block: Page['layout'][0] }) => {
   const { blockType } = block
   // if a block has two variants - to make TS happy we fallback to the default for the block variant
   switch (blockType) {

--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -48,21 +48,21 @@ export const RenderBlock = ({ block }: { block: Page['layout'][0] }) => {
   // if a block has two variants - to make TS happy we fallback to the default for the block variant
   switch (blockType) {
     case 'blogList':
-      return <BlogListBlockComponent {...block} isLexical={true} />
+      return <BlogListBlockComponent {...block} isLayoutBlock={true} />
     case 'content':
       return <ContentBlockComponent {...block} />
     case 'documentBlock':
-      return <DocumentBlockComponent {...block} isLexical={true} />
+      return <DocumentBlockComponent {...block} isLayoutBlock={true} />
     case 'eventList':
-      return <EventListBlockComponent {...block} isLexical={true} />
+      return <EventListBlockComponent {...block} isLayoutBlock={true} />
     case 'eventTable':
-      return <EventTableBlockComponent {...block} isLexical={true} />
+      return <EventTableBlockComponent {...block} isLayoutBlock={true} />
     case 'formBlock':
       return <FormBlockComponent {...block} />
     case 'genericEmbed':
-      return <GenericEmbedBlockComponent {...block} isLexical={true} />
+      return <GenericEmbedBlockComponent {...block} isLayoutBlock={true} />
     case 'headerBlock':
-      return <HeaderBlockComponent {...block} isLexical={true} />
+      return <HeaderBlockComponent {...block} isLayoutBlock={true} />
     case 'imageLinkGrid':
       return <ImageLinkGridBlockComponent {...block} />
     case 'imageText':
@@ -70,15 +70,15 @@ export const RenderBlock = ({ block }: { block: Page['layout'][0] }) => {
     case 'linkPreview':
       return <LinkPreviewBlockComponent {...block} />
     case 'mediaBlock':
-      return <MediaBlockComponent {...block} isLexical={true} />
+      return <MediaBlockComponent {...block} isLayoutBlock={true} />
     case 'nacMediaBlock':
       return <NACMediaBlockComponent {...block} />
     case 'singleBlogPost':
-      return <SingleBlogPostBlockComponent {...block} isLexical={true} />
+      return <SingleBlogPostBlockComponent {...block} isLayoutBlock={true} />
     case 'singleEvent':
-      return <SingleEventBlockComponent {...block} isLexical={true} />
+      return <SingleEventBlockComponent {...block} isLayoutBlock={true} />
     case 'sponsorsBlock':
-      return <SponsorsBlockComponent {...block} isLexical={true} />
+      return <SponsorsBlockComponent {...block} isLayoutBlock={true} />
     case 'team':
       return <TeamBlockComponent {...block} />
   }

--- a/src/blocks/SingleBlogPost/Component.tsx
+++ b/src/blocks/SingleBlogPost/Component.tsx
@@ -5,7 +5,7 @@ import { isValidPublishedRelationship } from '@/utilities/relationships'
 import { cn } from '@/utilities/ui'
 
 type SingleBlogPostComponentProps = SingleBlogPostBlockProps & {
-  isLexical: boolean
+  isLayoutBlock: boolean
   className?: string
 }
 
@@ -13,7 +13,7 @@ export const SingleBlogPostBlockComponent = ({
   post,
   backgroundColor,
   className,
-  isLexical = true,
+  isLayoutBlock = true,
 }: SingleBlogPostComponentProps) => {
   if (!isValidPublishedRelationship(post)) {
     return null
@@ -22,7 +22,7 @@ export const SingleBlogPostBlockComponent = ({
   return (
     <BackgroundColorWrapper
       backgroundColor={backgroundColor}
-      isLexical={isLexical}
+      isLayoutBlock={isLayoutBlock}
       containerClassName={className}
     >
       <PostPreview doc={post} className={cn('not-prose')} />

--- a/src/blocks/SingleEvent/Component.tsx
+++ b/src/blocks/SingleEvent/Component.tsx
@@ -4,7 +4,7 @@ import type { SingleEventBlock as SingleEventBlockProps } from '@/payload-types'
 import { cn } from '@/utilities/ui'
 
 type SingleEventComponentProps = SingleEventBlockProps & {
-  isLexical: boolean
+  isLayoutBlock: boolean
   className?: string
 }
 
@@ -12,7 +12,7 @@ export const SingleEventBlockComponent = ({
   event,
   backgroundColor,
   className,
-  isLexical = true,
+  isLayoutBlock = true,
 }: SingleEventComponentProps) => {
   if (!event || typeof event !== 'object') {
     return null
@@ -21,7 +21,7 @@ export const SingleEventBlockComponent = ({
   return (
     <BackgroundColorWrapper
       backgroundColor={backgroundColor}
-      isLexical={isLexical}
+      isLayoutBlock={isLayoutBlock}
       containerClassName={className}
     >
       <EventPreview event={event} className={cn('not-prose')} />

--- a/src/blocks/Sponsors/components/index.tsx
+++ b/src/blocks/Sponsors/components/index.tsx
@@ -7,13 +7,13 @@ import { SponsorsBlockCarousel } from './Carousel'
 import { SponsorsBlockStatic } from './Static'
 
 type Props = SponsorsBlockProps & {
-  isLexical: boolean
+  isLayoutBlock: boolean
 }
 export const SponsorsBlockComponent = ({
   backgroundColor,
   sponsors,
   sponsorsLayout,
-  isLexical = false,
+  isLayoutBlock = false,
 }: Props) => {
   const now = new Date()
 
@@ -26,7 +26,7 @@ export const SponsorsBlockComponent = ({
   if (validSponsors.length === 0) return null
 
   return (
-    <BackgroundColorWrapper backgroundColor={backgroundColor} isLexical={isLexical}>
+    <BackgroundColorWrapper backgroundColor={backgroundColor} isLayoutBlock={isLayoutBlock}>
       <div className="flex flex-wrap justify-evenly items-center">
         {(() => {
           switch (sponsorsLayout) {

--- a/src/components/BackgroundColorWrapper.tsx
+++ b/src/components/BackgroundColorWrapper.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react'
 type BackgroundColorWrapperProps = {
   backgroundColor: string
   children: ReactNode
-  isLexical: boolean
+  isLayoutBlock: boolean
   containerClassName?: string
   outerClassName?: string
 }
@@ -13,7 +13,7 @@ type BackgroundColorWrapperProps = {
 export const BackgroundColorWrapper = ({
   children,
   backgroundColor,
-  isLexical = false,
+  isLayoutBlock = false,
   containerClassName,
   outerClassName,
 }: BackgroundColorWrapperProps) => {
@@ -29,7 +29,7 @@ export const BackgroundColorWrapper = ({
     >
       <div
         className={cn(
-          (!isLexical || bgColorClass !== 'transparent') && 'container py-10',
+          (!isLayoutBlock || bgColorClass !== 'transparent') && 'container py-10',
           '@container',
           containerClassName,
         )}

--- a/src/components/BackgroundColorWrapper.tsx
+++ b/src/components/BackgroundColorWrapper.tsx
@@ -23,13 +23,13 @@ export const BackgroundColorWrapper = ({
   return (
     <div
       className={cn(
-        bgColorClass !== 'transparent' && `${bgColorClass} ${textColor}`,
+        bgColorClass !== 'bg-transparent' && `${bgColorClass} ${textColor}`,
         outerClassName,
       )}
     >
       <div
         className={cn(
-          (!isLayoutBlock || bgColorClass !== 'transparent') && 'container py-10',
+          (isLayoutBlock || bgColorClass !== 'bg-transparent') && 'container py-10',
           '@container',
           containerClassName,
         )}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -72,7 +72,7 @@ export async function Footer({ center }: { center?: string }) {
               <FormBlockComponent
                 form={footerForm.form?.value || 0}
                 blockType={'formBlock'}
-                isLexical={false}
+                isLayoutBlock={false}
               />
             )}
             {footerForm?.type === 'embedded' && (
@@ -80,7 +80,7 @@ export async function Footer({ center }: { center?: string }) {
                 html={footerForm.html || ''}
                 backgroundColor="transparent"
                 blockType="genericEmbed"
-                isLexical={false}
+                isLayoutBlock={false}
               />
             )}
           </div>

--- a/src/components/RichText/index.tsx
+++ b/src/components/RichText/index.tsx
@@ -111,28 +111,30 @@ const jsxConverters: JSXConvertersFunction<NodeTypes> = ({ defaultConverters }) 
   ...LinkJSXConverter({ internalDocToHref }),
   // if block has two variants - to make TS happy we fallback to the default for the block variant
   blocks: {
-    blogList: ({ node }) => <BlogListBlockComponent {...node.fields} isLexical={false} />,
+    blogList: ({ node }) => <BlogListBlockComponent {...node.fields} isLayoutBlock={false} />,
     buttonBlock: ({ node }) => <ButtonBlockComponent {...node.fields} />,
     calloutBlock: ({ node }) => <CalloutBlockComponent {...node.fields} />,
-    documentBlock: ({ node }) => <DocumentBlockComponent {...node.fields} isLexical={false} />,
-    eventList: ({ node }) => <EventListBlockComponent {...node.fields} isLexical={false} />,
-    eventTable: ({ node }) => <EventTableBlockComponent {...node.fields} isLexical={false} />,
-    singleEvent: ({ node }) => <SingleEventBlockComponent {...node.fields} isLexical={false} />,
-    genericEmbed: ({ node }) => <GenericEmbedBlockComponent {...node.fields} isLexical={false} />,
-    headerBlock: ({ node }) => <HeaderBlockComponent {...node.fields} isLexical={false} />,
+    documentBlock: ({ node }) => <DocumentBlockComponent {...node.fields} isLayoutBlock={false} />,
+    eventList: ({ node }) => <EventListBlockComponent {...node.fields} isLayoutBlock={false} />,
+    eventTable: ({ node }) => <EventTableBlockComponent {...node.fields} isLayoutBlock={false} />,
+    singleEvent: ({ node }) => <SingleEventBlockComponent {...node.fields} isLayoutBlock={false} />,
+    genericEmbed: ({ node }) => (
+      <GenericEmbedBlockComponent {...node.fields} isLayoutBlock={false} />
+    ),
+    headerBlock: ({ node }) => <HeaderBlockComponent {...node.fields} isLayoutBlock={false} />,
     mediaBlock: ({ node }) => (
       <MediaBlockComponent
         className="col-start-1 col-span-3"
         imgClassName="m-0"
         {...node.fields}
-        isLexical={false}
+        isLayoutBlock={false}
         captionClassName="mx-auto max-w-[48rem]"
       />
     ),
     singleBlogPost: ({ node }) => (
-      <SingleBlogPostBlockComponent {...node.fields} isLexical={false} />
+      <SingleBlogPostBlockComponent {...node.fields} isLayoutBlock={false} />
     ),
-    sponsorsBlock: ({ node }) => <SponsorsBlockComponent {...node.fields} isLexical={false} />,
+    sponsorsBlock: ({ node }) => <SponsorsBlockComponent {...node.fields} isLayoutBlock={false} />,
   },
 })
 

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -26,6 +26,7 @@ import { imageMountain } from './image-mountain'
 import { navigationSeed } from './navigation'
 import { allBlocksPage } from './pages/all-blocks-page'
 import { contact as contactPageData } from './pages/contact-page'
+import { lexicalBlocksPage } from './pages/lexical-blocks-page'
 import { post1 } from './post-1'
 import { post2 } from './post-2'
 import { post3 } from './post-3'
@@ -991,6 +992,13 @@ export const seed = async ({
             events: Object.values(events[tenant.slug]),
             contactForm: contactForms[tenant.name],
             teams: teams[tenant.slug] || [],
+            sponsor: seededSponsors[tenant.slug]['sponsors'],
+          }),
+          lexicalBlocksPage({
+            tenant,
+            image1: images[tenant.slug]['imageMountain'],
+            posts: Object.values(posts[tenant.slug]),
+            events: Object.values(events[tenant.slug]),
             sponsor: seededSponsors[tenant.slug]['sponsors'],
           }),
           whoWeArePage(tenant, teams, images[tenant.slug]['image2']),

--- a/src/endpoints/seed/pages/lexical-blocks-page.ts
+++ b/src/endpoints/seed/pages/lexical-blocks-page.ts
@@ -1,0 +1,167 @@
+import type { Event, Media, Post, Sponsor, Tenant } from '@/payload-types'
+import { RequiredDataFromCollectionSlug } from 'payload'
+import { blockNode, headingNode, paragraphNode, richTextRoot, simpleContent } from '../utilities'
+
+type LexicalBlocksPageArgs = {
+  tenant: Tenant
+  image1: Media
+  posts: Post[]
+  events: Event[]
+  sponsor: Sponsor
+}
+
+export const lexicalBlocksPage = ({
+  tenant,
+  image1,
+  posts,
+  events,
+  sponsor,
+}: LexicalBlocksPageArgs): RequiredDataFromCollectionSlug<'pages'> => {
+  return {
+    slug: 'lexical-blocks',
+    tenant: tenant.id,
+    title: 'Lexical Blocks',
+    _status: 'published',
+    publishedAt: new Date().toISOString(),
+    layout: [
+      {
+        blockType: 'content',
+        backgroundColor: 'transparent',
+        layout: '1_1',
+        blockName: null,
+        columns: [
+          {
+            richText: richTextRoot(
+              headingNode('Blocks Embedded in Rich Text', 'h2'),
+              paragraphNode(
+                'This page tests blocks rendered inside a Lexical rich text field (isLayoutBlock=false), as opposed to the Blocks page where they are top-level layout blocks (isLayoutBlock=true).',
+              ),
+
+              // Header block
+              headingNode('Header Block', 'h3'),
+              blockNode({
+                blockType: 'headerBlock',
+                richText: simpleContent('An lexical header block'),
+                backgroundColor: 'brand-200',
+              }),
+
+              // Generic embed
+              headingNode('Generic Embed', 'h3'),
+              blockNode({
+                blockType: 'genericEmbed',
+                html: '<div style="padding: 20px; border: 2px solid #3b82f6; border-radius: 8px; background-color: #eff6ff;"><h3 style="color: #3b82f6; margin-top: 0;">Embedded Generic Embed</h3><p>This generic embed is rendered inside rich text.</p></div>',
+                backgroundColor: 'transparent',
+                alignContent: 'center',
+              }),
+
+              // Media block
+              headingNode('Media Block', 'h3'),
+              blockNode({
+                blockType: 'mediaBlock',
+                media: image1.id,
+                caption: simpleContent('An lexical media block with center alignment'),
+                backgroundColor: 'brand-100',
+                alignContent: 'center',
+                imageSize: 'medium',
+              }),
+
+              // Callout block
+              headingNode('Callout Block', 'h3'),
+              blockNode({
+                blockType: 'calloutBlock',
+                backgroundColor: 'brand-500',
+                callout: simpleContent(
+                  'This is a callout block lexical in rich text. It should render without its own container.',
+                ),
+              }),
+
+              // Blog list (dynamic)
+              headingNode('Blog List (Dynamic)', 'h3'),
+              blockNode({
+                blockType: 'blogList',
+                heading: 'Recent Blogs',
+                backgroundColor: 'brand-200',
+                belowHeadingContent: simpleContent(
+                  'A dynamic blog list rendered inside rich text.',
+                ),
+                postOptions: 'dynamic',
+                dynamicOptions: {
+                  filterByTags: null,
+                  sortBy: '-publishedAt',
+                },
+                staticOptions: {
+                  staticPosts: [],
+                },
+              }),
+
+              // Single blog post
+              headingNode('Single Blog Post', 'h3'),
+              blockNode({
+                blockType: 'singleBlogPost',
+                backgroundColor: 'brand-400',
+                post: posts[0]?.id || 0,
+              }),
+
+              // Document block (no document to reference, so skip if problematic)
+
+              // Event list (dynamic)
+              headingNode('Event List (Dynamic)', 'h3'),
+              blockNode({
+                blockType: 'eventList',
+                heading: 'Upcoming Events',
+                backgroundColor: 'brand-500',
+                belowHeadingContent: simpleContent(
+                  'A dynamic event list rendered inside rich text.',
+                ),
+                eventOptions: 'dynamic',
+                dynamicOpts: {
+                  maxEvents: 3,
+                },
+                staticOpts: {
+                  staticEvents: [],
+                },
+              }),
+
+              // Event table (dynamic)
+              headingNode('Event Table (Dynamic)', 'h3'),
+              blockNode({
+                blockType: 'eventTable',
+                backgroundColor: 'transparent',
+                eventOptions: 'dynamic',
+                dynamicOpts: {
+                  maxEvents: 4,
+                },
+                staticOpts: {
+                  staticEvents: [],
+                },
+              }),
+
+              // Single event
+              headingNode('Single Event', 'h3'),
+              blockNode({
+                blockType: 'singleEvent',
+                backgroundColor: 'transparent',
+                event: events[0]?.id || 0,
+              }),
+
+              // Sponsors block
+              headingNode('Sponsors Block', 'h3'),
+              blockNode({
+                blockType: 'sponsorsBlock',
+                backgroundColor: 'brand-100',
+                sponsorsLayout: 'static',
+                sponsors: [sponsor.id],
+              }),
+
+              paragraphNode('End of lexical blocks test page.'),
+            ),
+          },
+        ],
+      },
+    ],
+    meta: {
+      image: null,
+      description: null,
+    },
+  }
+}

--- a/src/endpoints/seed/utilities.ts
+++ b/src/endpoints/seed/utilities.ts
@@ -167,3 +167,28 @@ export const simpleContent = (...paragraphs: string[]) => ({
     version: 1,
   },
 })
+
+// Wraps block field data as a Lexical block node for embedding inside rich text
+export const blockNode = (fields: Record<string, unknown>) => ({
+  type: 'block' as const,
+  version: 2,
+  format: '' as const,
+  fields: {
+    blockName: '',
+    ...fields,
+  },
+})
+
+// Wraps an array of Lexical child nodes (paragraphs, headings, block nodes, etc.) in a root
+export const richTextRoot = (
+  ...children: { type: string; version: number; [k: string]: unknown }[]
+) => ({
+  root: {
+    type: 'root' as const,
+    children,
+    direction: null,
+    format: '' as const,
+    indent: 0,
+    version: 1,
+  },
+})


### PR DESCRIPTION
## Description

When working on adding ImageText to posts, I noticed our conatiner/bg logic was named wrong. This PR renames the confusingly-named `isLexical` block prop to `isLayoutBlock`. The old name was misleading — `isLexical={true}` was used for blocks that were NOT inside Lexical (page layout blocks), and `isLexical={false}` for blocks that WERE inside Lexical. The new name makes the intent clear: layout blocks get their own `container` wrapper, embedded blocks don't.

Also fixes a bug in `BackgroundColorWrapper` where `bgColorClass` (e.g. `'bg-transparent'`) was compared against `'transparent'`, meaning the transparent check never matched.

## Key Changes

- **Rename `isLexical` → `isLayoutBlock`** across 13 block components, `RenderBlocks`, `RichText`, `BackgroundColorWrapper`, and `Footer`
- **Fix `BackgroundColorWrapper` container logic**:  container is applied for layout blocks, or for embedded blocks with a non-transparent background
- **Fix transparent comparison bug**: Both lines now correctly compare against `'bg-transparent'` 
- **Remove unused `payload` prop** from `RenderBlock`
- **Update docs** to reflect the rename
- **Add `lexical-blocks` seed page**: A test page with blocks embedded inside a Content block's rich text field, useful for visually comparing embedded vs layout block rendering
- **Add seed helpers**: `blockNode()`, `richTextRoot()` in seed utilities for constructing Lexical block nodes in seed data

## How to test

1. Run `pnpm seed` 
2. Visit the `/blocks` page — layout blocks should render with containers as before
3. Visit `/lexical-blocks` — embedded blocks should render without their own container (unless they have a non-transparent background)
4. Compare the two pages side-by-side to verify container/padding differences are correct

## Screenshots / Demo video

### Blocks page
https://nwac.fix-is-lexical.preview.avy-fx.org/blocks


### NEW lexical blocks page
https://nwac.fix-is-lexical.preview.avy-fx.org/lexical-blocks

<img width="3380" height="8991" alt="Lexical-Blocks-Northwest-Avalanche-Center-02-28-2026_11_20_AM" src="https://github.com/user-attachments/assets/3a393ce4-5e8f-4a75-a3e6-a699281589e9" />

