### PR TITLE
GenericEmbed - fix broken videos

### DIFF
--- a/src/blocks/GenericEmbed/Component.tsx
+++ b/src/blocks/GenericEmbed/Component.tsx
@@ -12,6 +12,8 @@ type Props = GenericEmbedBlockProps & {
   className?: string
 }
 
+type IframeContent = { type: 'srcDoc'; value: string } | { type: 'src'; value: string }
+
 export const GenericEmbedBlockComponent = ({
   id,
   html,
@@ -20,7 +22,7 @@ export const GenericEmbedBlockComponent = ({
   className,
   isLayoutBlock = true,
 }: Props) => {
-  const [blobUrl, setBlobUrl] = useState<string | null>(null)
+  const [iframeContent, setIframeContent] = useState<IframeContent | null>(null)
 
   const bgColorClass = `bg-${backgroundColor}`
   const textColor = getTextColorFromBgColor(backgroundColor)
@@ -29,7 +31,7 @@ export const GenericEmbedBlockComponent = ({
     if (typeof window === 'undefined' || !html) return
 
     // Normalize problematic quotes that are parsed incorrectly by DOMParser and DOMPurify
-    const normalizedHTML = html.replaceAll('"', '"').replaceAll('"', '"')
+    const normalizedHTML = html.replaceAll('\u201C', '"').replaceAll('\u201D', '"')
 
     const sanitized = DOMPurify.sanitize(normalizedHTML, {
       ADD_TAGS: ['iframe', 'script', 'style', 'dbox-widget'],
@@ -67,17 +69,23 @@ export const GenericEmbedBlockComponent = ({
       </style>
     `
 
-    // Use a blob URL instead of srcDoc because Chromium doesn't re-execute
-    // scripts in srcDoc iframes after SPA client-side navigation.
     const fullHtml = `<!DOCTYPE html><html><head></head><body>${sanitized}${styleOverrides}</body></html>`
-    const blob = new Blob([fullHtml], { type: 'text/html' })
-    const url = URL.createObjectURL(blob)
-    setBlobUrl(url)
 
-    return () => URL.revokeObjectURL(url)
+    // Use a blob URL for embeds with <script> tags because Chromium doesn't re-execute
+    // scripts in srcDoc iframes after SPA client-side navigation (renderer-process MemoryCache).
+    // Use srcDoc for script-free embeds (e.g. YouTube iframes) so the embedding context is
+    // preserved — blob: URLs can cause third-party players to fail their origin/referrer checks.
+    if (/<script/i.test(sanitized)) {
+      const blob = new Blob([fullHtml], { type: 'text/html' })
+      const url = URL.createObjectURL(blob)
+      setIframeContent({ type: 'src', value: url })
+      return () => URL.revokeObjectURL(url)
+    } else {
+      setIframeContent({ type: 'srcDoc', value: fullHtml })
+    }
   }, [html])
 
-  if (blobUrl === null) return null
+  if (iframeContent === null) return null
 
   return (
     <div className={cn(bgColorClass, textColor)}>
@@ -94,10 +102,12 @@ export const GenericEmbedBlockComponent = ({
         <IframeResizer
           id={String(id)}
           title={`Embedded content ${id}`}
-          src={blobUrl}
+          {...(iframeContent.type === 'src'
+            ? { src: iframeContent.value }
+            : { srcDoc: iframeContent.value })}
           sandbox="allow-scripts allow-presentation allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox"
           className="w-full border-none m-0 p-0 transition-[height] duration-200 ease-in-out"
-          height={0} // This iframe will resize to it's content height - this initial height is to avoid the iframe rendering at the browser default 150px initially
+          height={0} // This iframe will resize to its content height - this initial height avoids the browser default 150px
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

YouTube embeds were broken on pages using the `GenericEmbedBlock`, showing "Error 153: Video player configuration error". This was caused by switching the embed iframe to use a `blob:` URL as its `src`. YouTube's player checks the origin/referrer of its embedding page to verify the domain is authorized — when the direct parent frame is a `blob:` URL, YouTube cannot properly resolve the embedding domain and rejects the embed.

## Related Issues

Fixes #963

## Key Changes

- **`src/blocks/GenericEmbed/Component.tsx`**: Replaced the single `blobUrl` state with a discriminated union `IframeContent` that holds either a `src` (blob URL) or `srcDoc` value
- Embeds containing `<script>` tags continue to use a blob URL — this preserves the fix for Chromium's renderer-process MemoryCache bug where external scripts in `srcDoc` iframes are not re-executed after SPA client-side navigation
- Embeds without `<script>` tags (e.g. YouTube `<iframe>` embeds) now use `srcDoc` — this restores the proper embedding context that YouTube and similar third-party players need to verify the embedding domain

## How to test

- Navigate to a page with an embedded YouTube video (e.g. a page using the `GenericEmbed` block with a YouTube `<iframe>` embed code)
- Verify the video loads and plays without "Error 153"
- Navigate away and back to the page, then verify the video still loads correctly
- Also verify that script-based embeds (e.g. Donorbox) still render correctly after SPA navigation

## Screenshots / Demo video

<img width="3030" height="4288" alt="image" src="https://github.com/user-attachments/assets/f760eabe-6a8b-4493-adad-f9edd87d24ab" />


## Future enhancements / Questions

- If other third-party players exhibit similar origin-check failures, they will automatically benefit from this fix as long as their embed code does not include `<script>` tags
