### PR TITLE
Fix nav colors to use branding colors

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -78,6 +78,29 @@ This is optional. Our default theme will work but a center will likely want thei
 - [ ] Create center's theme in `src/app/(frontend)/colors.css`
 - [ ] Copy relevant theme colors to the `centerColorMap` in `src/utilities/generateOGImage.tsx`. We've been using the header colors.
 
+### Required colors
+
+Add a new CSS class using the tenant's slug (e.g. `.dvac`) in `src/app/(frontend)/colors.css`. All variables have defaults in `:root`, so you only need to override what differs from the defaults.
+
+| Variable | Purpose |
+|----------|---------|
+| `--primary` | Primary brand color (buttons, links) |
+| `--primary-hover` | Hover state for primary |
+| `--secondary` | Secondary brand color |
+| `--secondary-hover` | Hover state for secondary |
+| `--header` | Header background |
+| `--header-foreground` | Header text color |
+| `--header-foreground-highlight` | Header highlighted/active text |
+| `--footer` | Footer background |
+| `--footer-foreground` | Footer text color |
+| `--footer-foreground-highlight` | Footer highlighted/active text |
+| `--callout` | Callout/CTA background |
+| `--callout-hover` | Hover state for callout |
+| `--callout-foreground` | Callout text color |
+| `--nav-underline` | Active navigation underline color |
+| `--brand-50` through `--brand-950` | Brand color range used for block backgrounds |
+| `--brand-foreground-50` through `--brand-foreground-950` | Text colors for each brand background |
+
 ## Configuring a custom domain in production
 
 1. Update the `PRODUCTION_TENANTS` env var to include the tenant's slug. This should be a comma separated list of slugs (see `src/utilities/tenancy/tenants.ts`).

--- a/src/app/(frontend)/colors.css
+++ b/src/app/(frontend)/colors.css
@@ -16,6 +16,8 @@
   --secondary-hover: hsla(240, 25%, 39%, 0.8);
   --secondary-foreground: hsl(240 5.9% 10%);
 
+  --nav-underline: hsl(280, 63%, 17%);
+
   --muted: hsl(240 4.8% 95.9%);
   --muted-foreground: hsl(240 3.8% 46.1%);
 
@@ -109,6 +111,8 @@
   --callout: hsl(69 94% 64%);
   --callout-hover: hsla(69 94% 64% / 0.8);
   --callout-foreground: hsl(240 6% 10%);
+
+  --nav-underline: var(--secondary);
 }
 
 /* Sierra Avalanche Center */
@@ -144,8 +148,9 @@
   --callout-foreground: hsl(0 0% 100%);
 
   --accent: hsl(27 92% 62%);
-
   --destructive: hsl(0 59% 53%);
+
+  --nav-underline: var(--callout);
 
   --brand-50: var(--alice-blue);
   --brand-100: var(--ice-blue);
@@ -189,6 +194,8 @@
   --footer: var(--brand-400);
   --footer-foreground: var(--brand-900);
   --footer-foreground-highlight: var(--brand-700);
+
+  --nav-underline: var(--callout);
 }
 
 .a3 {

--- a/src/components/Header/DesktopNav.client.tsx
+++ b/src/components/Header/DesktopNav.client.tsx
@@ -16,7 +16,7 @@ import { RenderNavLink } from './RenderNavLink'
 import { TopLevelNavItem } from './utils'
 
 const underlineHoverClassName =
-  "relative w-fit after:content-[''] after:absolute after:left-2 after:bottom-0 after:h-[1px] after:w-0 after:bg-secondary after:transition-all after:duration-300 hover:after:w-[calc(100%-1rem)] hover:text-header-foreground-highlight"
+  "relative w-fit after:content-[''] after:absolute after:left-2 after:bottom-0 after:h-[1px] after:w-0 after:bg-callout after:transition-all after:duration-300 hover:after:w-[calc(100%-1rem)] hover:text-header-foreground-highlight"
 
 export const DesktopNav = ({
   topLevelNavItems,

--- a/src/components/Header/DesktopNav.client.tsx
+++ b/src/components/Header/DesktopNav.client.tsx
@@ -16,7 +16,7 @@ import { RenderNavLink } from './RenderNavLink'
 import { TopLevelNavItem } from './utils'
 
 const underlineHoverClassName =
-  "relative w-fit after:content-[''] after:absolute after:left-2 after:bottom-0 after:h-[1px] after:w-0 after:bg-callout after:transition-all after:duration-300 hover:after:w-[calc(100%-1rem)] hover:text-header-foreground-highlight"
+  "relative w-fit after:content-[''] after:absolute after:left-2 after:bottom-0 after:h-[1px] after:w-0 after:bg-nav-underline after:transition-all after:duration-300 hover:after:w-[calc(100%-1rem)] hover:text-header-foreground-highlight"
 
 export const DesktopNav = ({
   topLevelNavItems,

--- a/src/components/Header/MobileNavItem.tsx
+++ b/src/components/Header/MobileNavItem.tsx
@@ -6,7 +6,7 @@ import { RenderNavLink } from './RenderNavLink'
 import { NavItem } from './utils'
 
 const underlineHoverClassName =
-  "relative after:content-[''] after:absolute after:left-0 after:bottom-0 after:h-[1px] after:w-0 after:bg-callout after:transition-all after:duration-300 hover:after:w-full hover:text-header-foreground-highlight"
+  "relative after:content-[''] after:absolute after:left-0 after:bottom-0 after:h-[1px] after:w-0 after:bg-nav-underline after:transition-all after:duration-300 hover:after:w-full hover:text-header-foreground-highlight"
 
 type MobileNavItemProps = {
   label: string

--- a/src/components/Header/MobileNavItem.tsx
+++ b/src/components/Header/MobileNavItem.tsx
@@ -6,7 +6,7 @@ import { RenderNavLink } from './RenderNavLink'
 import { NavItem } from './utils'
 
 const underlineHoverClassName =
-  "relative after:content-[''] after:absolute after:left-0 after:bottom-0 after:h-[1px] after:w-0 after:bg-secondary after:transition-all after:duration-300 hover:after:w-full hover:text-header-foreground-highlight"
+  "relative after:content-[''] after:absolute after:left-0 after:bottom-0 after:h-[1px] after:w-0 after:bg-callout after:transition-all after:duration-300 hover:after:w-full hover:text-header-foreground-highlight"
 
 type MobileNavItemProps = {
   label: string

--- a/src/components/Header/RenderNavLink.tsx
+++ b/src/components/Header/RenderNavLink.tsx
@@ -37,7 +37,7 @@ export const RenderNavLink = ({ link, className = '', onClick, children }: Rende
       >
         {children || link.label}
         {link.newTab && (
-          <ExternalLink className="w-4 h-4 flex-shrink-0 ml-2 -mt-1.5 lg:-mt-0.5 text-muted" />
+          <ExternalLink className="w-4 h-4 flex-shrink-0 ml-2 -mt-1.5 lg:-mt-0.5 text-header-foreground" />
         )}
       </Link>
     )

--- a/src/components/Header/RenderNavLink.tsx
+++ b/src/components/Header/RenderNavLink.tsx
@@ -37,7 +37,7 @@ export const RenderNavLink = ({ link, className = '', onClick, children }: Rende
       >
         {children || link.label}
         {link.newTab && (
-          <ExternalLink className="w-4 h-4 flex-shrink-0 ml-2 -mt-1.5 lg:-mt-0.5 text-header-foreground" />
+          <ExternalLink className="w-4 h-4 flex-shrink-0 ml-2 -mt-1.5 lg:-mt-0.5 text-callout" />
         )}
       </Link>
     )

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -89,6 +89,9 @@ const config = {
           foreground: 'var(--destructive-foreground)',
           hover: 'var(--destructive-hover)',
         },
+        nav: {
+          underline: 'var(--nav-underline)',
+        },
         border: 'var(--border)',
         input: 'var(--input)',
         ring: 'var(--ring)',


### PR DESCRIPTION
## Description

Fix navigation link colors to use proper branding/theme colors instead of generic utility colors.

## Related Issues

## Key Changes

- **Desktop nav underline hover effect**: Changed the underline color from `bg-secondary` to `bg-callout` so it uses the the same brand color as the donate button
- **External link icon**: Changed the icon color from `text-muted` to `text-header-foreground` so it matches the nav link text instead of appearing faded

## How to test

1. Visit any tenant site (e.g., `nwac.localhost:3000`)
2. Hover over top-level nav links — the underline should match the tenant's branding color
3. Check any nav links that open in a new tab — the external link icon should match the link text color, not appear muted

## Screenshots / Demo video
Before
<img width="329" height="72" alt="Screenshot 2026-03-03 at 12 38 33" src="https://github.com/user-attachments/assets/90c2654d-7a29-4330-ad7e-4e6afe097efe" />

After
<img width="305" height="65" alt="Screenshot 2026-03-03 at 12 45 11" src="https://github.com/user-attachments/assets/534966e7-c555-4673-9696-95aa71c3057a" />



