### PR TITLE
Reduce observability requests

### DIFF
--- a/sentry-base-config.ts
+++ b/sentry-base-config.ts
@@ -1,6 +1,6 @@
 const sentryBaseConfig = {
   dsn: 'https://7f836bd47bd79570fa140c3b0c60f193@o4504317391929344.ingest.us.sentry.io/4509675069702145',
-  tracesSampleRate: 0.5,
+  tracesSampleRate: 0, // effectively disables tracing
   enabled: process.env.NODE_ENV === 'production',
   environment: process.env.VERCEL_GIT_COMMIT_REF || 'local',
 }

--- a/src/providers/PostHogProvider.tsx
+++ b/src/providers/PostHogProvider.tsx
@@ -29,6 +29,9 @@ export function PostHogProvider({
           defaults: '2025-05-24',
           debug: process.env.NODE_ENV !== 'production',
           persistence, // localStorage+cookie is the PostHog default
+          advanced_disable_feature_flags_on_first_load: true,
+          advanced_disable_feature_flags: true,
+          disable_surveys: true,
         })
       }
     },


### PR DESCRIPTION
## Description                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                               
Reduces Vercel edge request volume by tuning observability and analytics config. Based on analysis of production traffic we're incurring cost from requests for unused features:                                                                

- **Sentry**: Disable performance tracing (`tracesSampleRate: 0.5` → `0`). We're not actively using Sentry's Performance product and PostHog covers frontend performance metrics. Error capturing remains at 100%. This eliminates the majority of `/monitoring` tunnel traffic (~36K requests/12h).                              
- **PostHog**: Disable feature flags and surveys SDK since we don't use either. This eliminates `/ingest/flags` (~5K requests/12h) and `/ingest/static/surveys.js` (~4K requests/12h).

## Related Issues

A first step for #821 

## Key Changes

- `sentry-base-config.ts` — Set `tracesSampleRate` to `0`
- `src/providers/PostHogProvider.tsx` — Add `advanced_disable_feature_flags_on_first_load`, `advanced_disable_feature_flags`, and `disable_surveys` to PostHog init config

## How to test

- Verify Sentry error reporting still works in production (trigger a test error)
- Verify PostHog events are still captured (check Live Events in PostHog dashboard)
- Confirm `/ingest/flags` and `/ingest/static/surveys.js` requests stop appearing in Vercel analytics
- Monitor `/monitoring` request volume drops in Vercel dashboard

## Migration Explanation

N/A — no schema changes.

## Future enhancements / Questions

- Could further reduce PostHog event volume by tuning autocapture settings
- If Sentry tracing is needed in the future, a `tracesSampleRate` of `0.1` provides good coverage at much lower cost