### PR TITLE
Add Observations Archive nav link for SAC only

### DIFF
--- a/src/components/Header/utils.ts
+++ b/src/components/Header/utils.ts
@@ -263,10 +263,12 @@ export const getTopLevelNavItems = async ({
   navigation,
   activeForecastZones,
   avalancheCenterPlatforms,
+  center,
 }: {
   navigation: Navigation
   activeForecastZones?: ActiveForecastZoneWithSlug[]
   avalancheCenterPlatforms: AvalancheCenterPlatforms
+  center: string
 }): Promise<{ topLevelNavItems: TopLevelNavItem[]; donateNavItem?: TopLevelNavItem }> => {
   let forecastsNavItem: TopLevelNavItem = {
     link: {
@@ -344,6 +346,18 @@ export const getTopLevelNavItems = async ({
         },
       },
     ],
+  }
+
+  // SAC-specific observations archive link — revert this block when no longer needed
+  if (center === 'sac') {
+    observationsNavItem.items?.push({
+      id: 'archive',
+      link: {
+        type: 'internal',
+        label: 'Observations Archive',
+        url: '/observations-archive',
+      },
+    })
   }
 
   const blogNavItem: TopLevelNavItem = {
@@ -438,6 +452,7 @@ export const getCachedTopLevelNavItems = (center: string, draft: boolean = false
         navigation,
         activeForecastZones,
         avalancheCenterPlatforms,
+        center,
       })
     },
     [`top-level-nav-items-${center}`],


### PR DESCRIPTION
## Description

Adds an "Observations Archive" link under the Observations nav dropdown, conditionally shown only for the Sierra Avalanche Center (sac). This is contained in a single commit for easy revert when no longer needed.

## Related Issues

Closes #975 

## Key Changes

Adds a nav link for SAC only that points to a page with slug "/observations-archive"

## How to test

1. Visit SAC's site and observe a nav link under observations for Observations Archive that points to /observations-archive

## Screenshots / Demo video

Demo: https://www.loom.com/share/01b069488a824aee8a21c2e2af2fb527

## Migration Explanation

N/A

## Future enhancements / Questions

We plan to remove this in #988 
