### PR TITLE
Remove avalanche centers with incomplete NAC API configs

### DIFF
--- a/__tests__/server/findCenterByDomain.server.test.ts
+++ b/__tests__/server/findCenterByDomain.server.test.ts
@@ -3,8 +3,8 @@ import { findCenterByDomain } from '../../src/utilities/tenancy/avalancheCenters
 describe('findCenterByDomain', () => {
   it('finds a center by exact domain match (no www)', () => {
     expect(findCenterByDomain('nwac.us')).toBe('nwac')
-    expect(findCenterByDomain('alaskasnow.org')).toBe('aaic')
-    expect(findCenterByDomain('avalanche.state.co.us')).toBe('caic')
+    expect(findCenterByDomain('alaskasnow.org')).toBe('hac')
+    expect(findCenterByDomain('hpavalanche.org')).toBe('hpac')
   })
 
   it('finds a center when domain has www. prefix', () => {
@@ -26,10 +26,10 @@ describe('findCenterByDomain', () => {
   })
 
   it('handles domains shared by multiple centers (returns first match)', () => {
-    // Multiple centers use 'alaskasnow.org': aaic, cac, earac, hac, vac
-    // Should return the first one found (aaic)
+    // Multiple centers use 'alaskasnow.org': hac, vac
+    // Should return the first one found (hac)
     const result = findCenterByDomain('alaskasnow.org')
-    expect(result).toBe('aaic')
+    expect(result).toBe('hac')
   })
 
   it('returns undefined for non-existent domains', () => {

--- a/__tests__/server/getEmailDomain.server.test.ts
+++ b/__tests__/server/getEmailDomain.server.test.ts
@@ -8,7 +8,7 @@ describe('getEmailDomain', () => {
   it('strips only the www. prefix, not other subdomains', () => {
     expect(getEmailDomain('cnfaic')).toBe('cnfaic.org')
 
-    expect(getEmailDomain('aaic')).toBe('alaskasnow.org')
+    expect(getEmailDomain('hac')).toBe('alaskasnow.org')
   })
 
   it('strips port numbers from domains (for local development)', () => {

--- a/__tests__/server/getHostnameFromTenant.server.test.ts
+++ b/__tests__/server/getHostnameFromTenant.server.test.ts
@@ -49,7 +49,7 @@ describe('server-side utilities: getHostnameFromTenant', () => {
 
   it('handles multiple production tenants correctly', () => {
     PRODUCTION_TENANTS.length = 0
-    PRODUCTION_TENANTS.push('nwac', 'sac', 'uac')
+    PRODUCTION_TENANTS.push('nwac', 'sac', 'snfac')
 
     const tenant1 = buildTenant({ slug: 'nwac' })
     const tenant2 = buildTenant({ slug: 'sac' })

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -710,19 +710,14 @@ export interface Tenant {
    * Avalanche center identifier. Used for subdomains and URL paths.
    */
   slug:
-    | 'aaic'
     | 'bac'
     | 'btac'
-    | 'cac'
-    | 'caic'
     | 'caac'
     | 'cbac'
     | 'cnfaic'
     | 'coaa'
     | 'dvac'
-    | 'earac'
     | 'esac'
-    | 'ewyaix'
     | 'fac'
     | 'gnfac'
     | 'hac'
@@ -735,9 +730,7 @@ export interface Tenant {
     | 'pac'
     | 'sac'
     | 'snfac'
-    | 'soaix'
     | 'tac'
-    | 'uac'
     | 'vac'
     | 'wac'
     | 'wcmac';

--- a/src/services/nac/types/schemas.ts
+++ b/src/services/nac/types/schemas.ts
@@ -44,16 +44,14 @@ export const avalancheCenterConfigurationSchema = z.object({
   expires_time: z
     .number()
     .nullable()
-    .optional()
     .transform((n) => n ?? 0),
   published_time: z
     .number()
     .nullable()
-    .optional()
     .transform((n) => n ?? 0),
-  blog: z.boolean().optional(),
-  blog_title: z.string().optional(),
-  weather_table: z.array(avalancheCenterWeatherConfigurationSchema).optional().default([]),
+  blog: z.boolean(),
+  blog_title: z.string(),
+  weather_table: z.array(avalancheCenterWeatherConfigurationSchema),
   zone_order: z.array(z.number()).optional(),
 })
 

--- a/src/services/nac/types/schemas.ts
+++ b/src/services/nac/types/schemas.ts
@@ -44,14 +44,16 @@ export const avalancheCenterConfigurationSchema = z.object({
   expires_time: z
     .number()
     .nullable()
+    .optional()
     .transform((n) => n ?? 0),
   published_time: z
     .number()
     .nullable()
+    .optional()
     .transform((n) => n ?? 0),
-  blog: z.boolean(),
-  blog_title: z.string(),
-  weather_table: z.array(avalancheCenterWeatherConfigurationSchema),
+  blog: z.boolean().optional(),
+  blog_title: z.string().optional(),
+  weather_table: z.array(avalancheCenterWeatherConfigurationSchema).optional().default([]),
   zone_order: z.array(z.number()).optional(),
 })
 

--- a/src/utilities/tenancy/avalancheCenters.ts
+++ b/src/utilities/tenancy/avalancheCenters.ts
@@ -11,19 +11,14 @@ type AvalancheCenterInfo = {
 }
 
 export const AVALANCHE_CENTERS = {
-  aaic: { name: 'Alaska Avalanche Information Center', customDomain: 'alaskasnow.org' },
   bac: { name: 'Bridgeport Avalanche Center', customDomain: 'bridgeportavalanchecenter.org' },
   btac: { name: 'Bridger-Teton Avalanche Center', customDomain: 'bridgertetonavalanchecenter.org' },
-  cac: { name: 'Cordova Avalanche Center', customDomain: 'alaskasnow.org' },
-  caic: { name: 'Colorado Avalanche Information Center', customDomain: 'avalanche.state.co.us' },
   caac: { name: 'Coastal Alaska Avalanche Center', customDomain: 'coastalakavalanche.org' },
   cbac: { name: 'Crested Butte Avalanche Center', customDomain: 'cbavalanchecenter.org' },
   cnfaic: { name: 'Chugach National Forest Avalanche Center', customDomain: 'www.cnfaic.org' },
   coaa: { name: 'Central Oregon Avalanche Center', customDomain: 'www.coavalanche.org' },
   dvac: { name: 'Death Valley Avalanche Center', customDomain: 'www.avy-fx-demo.org' }, // The "template tenant" - not a real avalanche center
-  earac: { name: 'Eastern Alaska Range Avalanche Center', customDomain: 'alaskasnow.org' },
   esac: { name: 'Eastern Sierra Avalanche Center', customDomain: 'www.esavalanche.org' },
-  ewyaix: { name: 'Eastern Wyoming Avalanche Info Exchange', customDomain: 'ewyoavalanche.org' },
   fac: { name: 'Flathead Avalanche Center', customDomain: 'www.flatheadavalanche.org' },
   gnfac: { name: 'Gallatin NF Avalanche Center', customDomain: 'www.mtavalanche.com' },
   hac: { name: 'Haines Avalanche Center', customDomain: 'alaskasnow.org' },
@@ -42,9 +37,7 @@ export const AVALANCHE_CENTERS = {
   pac: { name: 'Payette Avalanche Center', customDomain: 'payetteavalanche.org' },
   sac: { name: 'Sierra Avalanche Center', customDomain: 'www.sierraavalanchecenter.org' },
   snfac: { name: 'Sawtooth Avalanche Center', customDomain: 'www.sawtoothavalanche.com' },
-  soaix: { name: 'Southern Oregon Avalanche Info Exchange', customDomain: 'oregonsnow.org' },
   tac: { name: 'Taos Avalanche Center', customDomain: 'taosavalanchecenter.org' },
-  uac: { name: 'Utah Avalanche Center', customDomain: 'utahavalanchecenter.org' },
   vac: { name: 'Valdez Avalanche Center', customDomain: 'alaskasnow.org' },
   wac: { name: 'Wallowa Avalanche Center', customDomain: 'wallowaavalanchecenter.org' },
   wcmac: { name: 'West Central Montana Avalanche Center', customDomain: 'missoulaavalanche.org' },

--- a/src/utilities/tenancy/avalancheCenters.ts
+++ b/src/utilities/tenancy/avalancheCenters.ts
@@ -1,9 +1,20 @@
 /**
- * Hardcoded list of all US avalanche centers
+ * US avalanche centers with valid NAC API configurations
  *
  * This serves as the single source of truth for valid tenant slugs.
+ * Only centers that return a complete config from the NAC API
+ * (/v2/public/avalanche-center/{CENTER}) are included here.
  * Custom domains are used for production routing - they should match
  * the actual domains configured in Vercel.
+ *
+ * Excluded centers (missing required config fields in NAC API):
+ * - AAIC (Alaska Avalanche Information Center) — no config fields returned
+ * - CAC (Cordova Avalanche Center) — only blog_title returned
+ * - CAIC (Colorado Avalanche Information Center) — no config fields returned
+ * - EARAC (Eastern Alaska Range Avalanche Center) — only blog_title returned
+ * - EWYAIX (Eastern Wyoming Avalanche Info Exchange) — no config object at all
+ * - SOAIX (Southern Oregon Avalanche Info Exchange) — no config object at all
+ * - UAC (Utah Avalanche Center) — no config object at all
  */
 type AvalancheCenterInfo = {
   readonly name: string


### PR DESCRIPTION
## Description

Some avalanche centers don't return the required `config` fields from the NAC API (`/v2/public/avalanche-center/{CENTER}`), causing a Zod parse error and 404 on their homepage. Instead of loosening the schema, this removes the 7 centers that don't return valid configs.

DVAC (the template tenant) is kept — it already maps to NWAC for all NAC/AFP API calls.

**Note:** AAIC (Alaska Avalanche Information Center) was the parent organization for several Alaska centers (CAC, EARAC, HAC, VAC). With AAIC removed, HAC and VAC still reference `alaskasnow.org` as their custom domain.

## Related Issues

Fixes #995

## Key Changes

- Removed 7 centers from `AVALANCHE_CENTERS` that have missing/incomplete NAC API config:
  - **No config at all**: EWYAIX, SOAIX, UAC
  - **No config fields**: AAIC, CAIC
  - **Only `blog_title`**: CAC, EARAC
- Regenerated `payload-types.ts` to reflect updated slug options
- Updated tests referencing removed centers

## How to test

1. Run `pnpm tsc` — no type errors
2. Run `pnpm test` — all 245 tests pass
3. Visit `dvac.localhost:3000` — should still work (maps to NWAC data)

## Screenshots / Demo video

NAC API config field audit across all 30 centers:
```
Center  │ expires_time │ published_time │ blog │ blog_title │ weather_table │ zone_order
────────┼──────────────┼────────────────┼──────┼────────────┼───────────────┼───────────
AAIC    │      ❌       │       ❌        │  ❌   │     ❌      │       ❌       │     ❌
CAC     │      ❌       │       ❌        │  ❌   │     ✅      │       ❌       │     ❌
CAIC    │      ❌       │       ❌        │  ❌   │     ❌      │       ❌       │     ❌
EARAC   │      ❌       │       ❌        │  ❌   │     ✅      │       ❌       │     ❌
EWYAIX  │                      ⚠️ NO CONFIG
SOAIX   │                      ⚠️ NO CONFIG
UAC     │                      ⚠️ NO CONFIG
```

## Migration Explanation

No migration needed — only runtime type changes.

## Future enhancements / Questions

These centers can be re-added if/when their NAC API responses include the required config fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)