### PR TITLE
Auto build provisioning from AFP & track tenant provisioning lifecycle

### DIFF
--- a/__tests__/builders.ts
+++ b/__tests__/builders.ts
@@ -23,7 +23,15 @@ export function buildPage(fields: Partial<Page>): Page {
 }
 
 export function buildTenant(fields: Partial<Tenant>): Tenant {
-  return { id: 0, name: '', slug: 'dvac', updatedAt: '', createdAt: '', ...fields }
+  return {
+    id: 0,
+    name: '',
+    slug: 'dvac',
+    provisioning: { status: 'complete', lastRunAt: '' },
+    updatedAt: '',
+    createdAt: '',
+    ...fields,
+  }
 }
 
 export function buildPost(fields: Partial<Post>): Post {

--- a/__tests__/client/components/OnboardingChecklist.client.test.tsx
+++ b/__tests__/client/components/OnboardingChecklist.client.test.tsx
@@ -39,7 +39,8 @@ jest.mock('../../../src/collections/Tenants/components/onboardingActions', () =>
 }))
 
 const buildStatus = (overrides: Partial<ProvisioningStatus> = {}): ProvisioningStatus => ({
-  builtInPages: { count: 0, expected: 7 },
+  forecastPages: { count: 0, expected: 2, zoneCount: 0 },
+  defaultBuiltInPages: { count: 0, expected: 5 },
   pages: { created: 0, expected: 5, missing: [] },
   homePage: false,
   navigation: false,
@@ -49,7 +50,8 @@ const buildStatus = (overrides: Partial<ProvisioningStatus> = {}): ProvisioningS
 })
 
 const fullyProvisioned = buildStatus({
-  builtInPages: { count: 7, expected: 7 },
+  forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+  defaultBuiltInPages: { count: 5, expected: 5 },
   pages: { created: 5, expected: 5, missing: [] },
   homePage: true,
   navigation: true,
@@ -83,7 +85,7 @@ describe('OnboardingChecklist', () => {
       render(<OnboardingChecklist />)
       await flushAsync()
 
-      expect(screen.queryByText('(0/7)')).not.toBeInTheDocument()
+      expect(screen.queryByText('(0/2)')).not.toBeInTheDocument()
       expect(screen.queryByText('(0/5)')).not.toBeInTheDocument()
       expect(screen.queryByText('colors.css')).not.toBeInTheDocument()
       expect(screen.queryByText('centerColorMap')).not.toBeInTheDocument()
@@ -93,7 +95,8 @@ describe('OnboardingChecklist', () => {
       // Automated items complete but pages incomplete — needsProvisioning returns false,
       // so auto-provision doesn't run but the button shows
       const incompleteStatus = buildStatus({
-        builtInPages: { count: 7, expected: 7 },
+        forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+        defaultBuiltInPages: { count: 5, expected: 5 },
         pages: { created: 3, expected: 5, missing: ['About Us', 'Donate'] },
         homePage: true,
         navigation: true,
@@ -122,7 +125,8 @@ describe('OnboardingChecklist', () => {
     it('shows missing pages', async () => {
       mockCheckStatus.mockResolvedValue({
         status: buildStatus({
-          builtInPages: { count: 7, expected: 7 },
+          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          defaultBuiltInPages: { count: 5, expected: 5 },
           pages: { created: 3, expected: 5, missing: ['About Us', 'Donate'] },
           homePage: true,
           navigation: true,

--- a/__tests__/client/components/OnboardingChecklist.client.test.tsx
+++ b/__tests__/client/components/OnboardingChecklist.client.test.tsx
@@ -39,7 +39,7 @@ jest.mock('../../../src/collections/Tenants/components/onboardingActions', () =>
 }))
 
 const buildStatus = (overrides: Partial<ProvisioningStatus> = {}): ProvisioningStatus => ({
-  forecastPages: { count: 0, expected: 2, zoneCount: 0 },
+  forecastPages: { count: 0, expected: 2 },
   defaultBuiltInPages: { count: 0, expected: 5 },
   pages: { created: 0, expected: 5, missing: [] },
   homePage: false,
@@ -50,7 +50,7 @@ const buildStatus = (overrides: Partial<ProvisioningStatus> = {}): ProvisioningS
 })
 
 const fullyProvisioned = buildStatus({
-  forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+  forecastPages: { count: 2, expected: 2 },
   defaultBuiltInPages: { count: 5, expected: 5 },
   pages: { created: 5, expected: 5, missing: [] },
   homePage: true,
@@ -95,7 +95,7 @@ describe('OnboardingChecklist', () => {
       // Automated items complete but pages incomplete — needsProvisioning returns false,
       // so auto-provision doesn't run but the button shows
       const incompleteStatus = buildStatus({
-        forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+        forecastPages: { count: 2, expected: 2 },
         defaultBuiltInPages: { count: 5, expected: 5 },
         pages: { created: 3, expected: 5, missing: ['About Us', 'Donate'] },
         homePage: true,
@@ -125,7 +125,7 @@ describe('OnboardingChecklist', () => {
     it('shows missing pages', async () => {
       mockCheckStatus.mockResolvedValue({
         status: buildStatus({
-          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          forecastPages: { count: 2, expected: 2 },
           defaultBuiltInPages: { count: 5, expected: 5 },
           pages: { created: 3, expected: 5, missing: ['About Us', 'Donate'] },
           homePage: true,

--- a/__tests__/client/components/OnboardingChecklist.client.test.tsx
+++ b/__tests__/client/components/OnboardingChecklist.client.test.tsx
@@ -122,6 +122,32 @@ describe('OnboardingChecklist', () => {
   })
 
   describe('loaded', () => {
+    it('shows forecast and default built-in page labels', async () => {
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(screen.getByText('Forecast Built-In pages')).toBeInTheDocument()
+      expect(screen.getByText('Default Built-In pages')).toBeInTheDocument()
+    })
+
+    it('shows forecast and default built-in page counts', async () => {
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(screen.getByText('(2/2)')).toBeInTheDocument()
+      // (5/5) appears for both defaultBuiltInPages and pages
+      expect(screen.getAllByText('(5/5)')).toHaveLength(2)
+    })
+
+    it('shows NAC zones description when fully provisioned', async () => {
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(
+        screen.getByText('Forecast built-ins are automatically based on NAC zones.'),
+      ).toBeInTheDocument()
+    })
+
     it('shows missing pages', async () => {
       mockCheckStatus.mockResolvedValue({
         status: buildStatus({

--- a/__tests__/client/components/OnboardingChecklist.client.test.tsx
+++ b/__tests__/client/components/OnboardingChecklist.client.test.tsx
@@ -132,7 +132,7 @@ describe('OnboardingChecklist', () => {
       expect(screen.queryByText('Pages')).not.toBeInTheDocument()
       expect(screen.queryByText('Home page')).not.toBeInTheDocument()
       expect(screen.queryByText('Navigation')).not.toBeInTheDocument()
-      expect(screen.queryByText('Website Settings')).not.toBeInTheDocument()
+      expect(screen.queryByText('Website Settings', { selector: 'span' })).not.toBeInTheDocument()
     })
 
     it('shows theme nag when theme is incomplete', async () => {
@@ -156,9 +156,8 @@ describe('OnboardingChecklist', () => {
       render(<OnboardingChecklist />)
       await flushAsync()
 
-      expect(screen.getByText('Update Brand Assets')).toBeInTheDocument()
-      const settingsLink = screen.getByText('Settings')
-      expect(settingsLink.closest('a')).toHaveAttribute('href', '/admin/collections/settings/1')
+      const settingsLink = screen.getByText('Website Settings', { selector: 'a' })
+      expect(settingsLink).toHaveAttribute('href', '/admin/collections/settings/1')
     })
 
     it('shows a Rerun button', async () => {

--- a/__tests__/client/components/OnboardingChecklist.client.test.tsx
+++ b/__tests__/client/components/OnboardingChecklist.client.test.tsx
@@ -207,6 +207,26 @@ describe('OnboardingChecklist', () => {
 
       expect(screen.getByText('Rerun')).toBeInTheDocument()
     })
+
+    it('renders the timedOut message when stale in_progress was recovered', async () => {
+      // checkProvisioningStatusAction synthesizes failed.timedOut when it
+      // recovers a stuck in_progress run past the stale cutoff.
+      mockCheckStatus.mockResolvedValue({
+        status: buildStatus({
+          status: 'partial',
+          lastRunAt: '2026-04-15T00:00:00.000Z',
+          failed: { timedOut: 'Provisioning timed out. It may still be running.' },
+          settings: { id: 1 },
+        }),
+      })
+
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(
+        screen.getByText('Provisioning timed out. It may still be running.'),
+      ).toBeInTheDocument()
+    })
   })
 
   describe('in_progress', () => {

--- a/__tests__/client/components/OnboardingChecklist.client.test.tsx
+++ b/__tests__/client/components/OnboardingChecklist.client.test.tsx
@@ -229,6 +229,44 @@ describe('OnboardingChecklist', () => {
     })
   })
 
+  describe('manual', () => {
+    // checkProvisioningStatusAction synthesizes 'manual' when DB says complete
+    // but theme items (colors.css / centerColorMap) aren't done yet.
+    beforeEach(() => {
+      mockCheckStatus.mockResolvedValue({
+        status: buildStatus({
+          status: 'manual',
+          lastRunAt: '2026-04-22T00:00:00.000Z',
+          theme: { brandColors: false, ogColors: false },
+          settings: { id: 1 },
+        }),
+      })
+    })
+
+    it('shows "Complete manual actions" header', async () => {
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(screen.getByText('Complete manual actions')).toBeInTheDocument()
+    })
+
+    it('still renders the theme nag items', async () => {
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(screen.getByText('Add brand colors')).toBeInTheDocument()
+      expect(screen.getByText('Add OG image colors')).toBeInTheDocument()
+    })
+
+    it('does not render the partial failure detail block', async () => {
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(screen.queryByText(/failed to provision/i)).not.toBeInTheDocument()
+      expect(screen.queryByText('Missing pages:')).not.toBeInTheDocument()
+    })
+  })
+
   describe('in_progress', () => {
     // Matches what a mid-run page reload would see from the DB
     beforeEach(() => {

--- a/__tests__/client/components/OnboardingChecklist.client.test.tsx
+++ b/__tests__/client/components/OnboardingChecklist.client.test.tsx
@@ -39,24 +39,21 @@ jest.mock('../../../src/collections/Tenants/components/onboardingActions', () =>
 }))
 
 const buildStatus = (overrides: Partial<ProvisioningStatus> = {}): ProvisioningStatus => ({
-  forecastPages: { count: 0, expected: 2 },
-  defaultBuiltInPages: { count: 0, expected: 5 },
-  pages: { created: 0, expected: 5, missing: [] },
-  homePage: false,
-  navigation: false,
-  settings: { exists: false },
+  status: 'not_started',
+  lastRunAt: null,
+  failed: {},
   theme: { brandColors: false, ogColors: false },
+  tenantCreatedAt: null,
+  settings: {},
   ...overrides,
 })
 
-const fullyProvisioned = buildStatus({
-  forecastPages: { count: 2, expected: 2 },
-  defaultBuiltInPages: { count: 5, expected: 5 },
-  pages: { created: 5, expected: 5, missing: [] },
-  homePage: true,
-  navigation: true,
-  settings: { exists: true, id: 1 },
+const completeStatus = buildStatus({
+  status: 'complete',
+  lastRunAt: '2026-04-15T00:00:00.000Z',
+  tenantCreatedAt: '2026-03-01T00:00:00.000Z',
   theme: { brandColors: true, ogColors: true },
+  settings: { id: 1 },
 })
 
 const flushAsync = () => act(() => new Promise((r) => setTimeout(r, 0)))
@@ -65,114 +62,180 @@ describe('OnboardingChecklist', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockUseDocumentInfo.mockReturnValue({ data: { id: 1 } })
-    mockCheckStatus.mockResolvedValue({ status: fullyProvisioned })
+    mockCheckStatus.mockResolvedValue({ status: completeStatus })
   })
 
-  describe('provisioning', () => {
+  describe('initial load', () => {
+    it('shows a loading spinner before status has been fetched', () => {
+      // checkStatus hangs → loaded stays false → only the spinner renders
+      mockCheckStatus.mockReturnValue(new Promise(() => {}))
+
+      render(<OnboardingChecklist />)
+
+      expect(screen.getAllByTestId('spinner').length).toBeGreaterThan(0)
+      expect(screen.getByText('Loading...')).toBeInTheDocument()
+      expect(screen.queryByText('Needs action')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('not_started (brand new tenant)', () => {
     beforeEach(() => {
       mockCheckStatus.mockResolvedValue({ status: buildStatus() })
       mockRunProvision.mockReturnValue(new Promise(() => {}))
     })
 
-    it('shows spinners while provisioning', async () => {
+    it('auto-provisions on mount and shows spinner', async () => {
       render(<OnboardingChecklist />)
       await flushAsync()
 
+      expect(mockRunProvision).toHaveBeenCalledWith(1)
       expect(screen.getAllByTestId('spinner').length).toBeGreaterThan(0)
     })
 
-    it('hides details while provisioning', async () => {
+    it('renders placeholder items for each automated step', async () => {
       render(<OnboardingChecklist />)
       await flushAsync()
 
-      expect(screen.queryByText('(0/2)')).not.toBeInTheDocument()
-      expect(screen.queryByText('(0/5)')).not.toBeInTheDocument()
-      expect(screen.queryByText('colors.css')).not.toBeInTheDocument()
-      expect(screen.queryByText('centerColorMap')).not.toBeInTheDocument()
-    })
-
-    it('updates button text when rerunning', async () => {
-      // Automated items complete but pages incomplete — needsProvisioning returns false,
-      // so auto-provision doesn't run but the button shows
-      const incompleteStatus = buildStatus({
-        forecastPages: { count: 2, expected: 2 },
-        defaultBuiltInPages: { count: 5, expected: 5 },
-        pages: { created: 3, expected: 5, missing: ['About Us', 'Donate'] },
-        homePage: true,
-        navigation: true,
-        settings: { exists: true, id: 1 },
-      })
-      mockCheckStatus.mockResolvedValue({ status: incompleteStatus })
-
-      render(<OnboardingChecklist />)
-      await flushAsync()
-
-      const button = screen.getByText('Rerun Provisioning')
-      expect(button).toBeInTheDocument()
-
-      // Click rerun — provision hangs so we stay in provisioning state
-      mockRunProvision.mockReturnValue(new Promise(() => {}))
-      await act(async () => {
-        button.click()
-      })
-
-      expect(screen.getByText('Provisioning...')).toBeInTheDocument()
-      expect(screen.queryByText('Rerun Provisioning')).not.toBeInTheDocument()
+      expect(screen.getByText('Pages')).toBeInTheDocument()
+      expect(screen.getByText('Home page')).toBeInTheDocument()
+      expect(screen.getByText('Navigation')).toBeInTheDocument()
+      expect(screen.getByText('Website Settings')).toBeInTheDocument()
     })
   })
 
-  describe('loaded', () => {
-    it('shows forecast and default built-in page labels', async () => {
+  describe('complete', () => {
+    it('shows "Complete" header', async () => {
       render(<OnboardingChecklist />)
       await flushAsync()
 
-      expect(screen.getByText('Forecast Built-In pages')).toBeInTheDocument()
-      expect(screen.getByText('Default Built-In pages')).toBeInTheDocument()
+      expect(screen.getByText('Complete')).toBeInTheDocument()
     })
 
-    it('shows forecast and default built-in page counts', async () => {
+    it('does not show failed pages list when failedPages is empty', async () => {
       render(<OnboardingChecklist />)
       await flushAsync()
 
-      expect(screen.getByText('(2/2)')).toBeInTheDocument()
-      // (5/5) appears for both defaultBuiltInPages and pages
-      expect(screen.getAllByText('(5/5)')).toHaveLength(2)
+      expect(screen.queryByText('Failed pages:')).not.toBeInTheDocument()
     })
 
-    it('shows NAC zones description when fully provisioned', async () => {
+    it('shows the last provisioned date', async () => {
+      const { container } = render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(container.textContent).toContain('Last provisioned:')
+    })
+
+    it('hides the automated placeholder checklist once complete', async () => {
       render(<OnboardingChecklist />)
       await flushAsync()
 
-      expect(
-        screen.getByText('Forecast built-ins are automatically based on NAC zones.'),
-      ).toBeInTheDocument()
+      expect(screen.queryByText('Pages')).not.toBeInTheDocument()
+      expect(screen.queryByText('Home page')).not.toBeInTheDocument()
+      expect(screen.queryByText('Navigation')).not.toBeInTheDocument()
+      expect(screen.queryByText('Website Settings')).not.toBeInTheDocument()
     })
 
-    it('shows missing pages', async () => {
+    it('shows theme nag when theme is incomplete', async () => {
       mockCheckStatus.mockResolvedValue({
         status: buildStatus({
-          forecastPages: { count: 2, expected: 2 },
-          defaultBuiltInPages: { count: 5, expected: 5 },
-          pages: { created: 3, expected: 5, missing: ['About Us', 'Donate'] },
-          homePage: true,
-          navigation: true,
-          settings: { exists: true, id: 1 },
+          status: 'complete',
+          lastRunAt: '2026-04-15T00:00:00.000Z',
+          settings: { id: 1 },
+          theme: { brandColors: false, ogColors: false },
         }),
       })
 
       render(<OnboardingChecklist />)
       await flushAsync()
 
-      expect(screen.getByText('Missing: About Us, Donate')).toBeInTheDocument()
+      expect(screen.getByText('Add brand colors')).toBeInTheDocument()
+      expect(screen.getByText('Add OG image colors')).toBeInTheDocument()
     })
 
-    it('shows link to settings when settings exist', async () => {
+    it('shows link to settings', async () => {
       render(<OnboardingChecklist />)
       await flushAsync()
 
-      const link = screen.getByText('Update Brand Assets')
-      expect(link).toBeInTheDocument()
-      expect(link.closest('a')).toHaveAttribute('href', '/admin/collections/settings/1')
+      expect(screen.getByText('Update Brand Assets')).toBeInTheDocument()
+      const settingsLink = screen.getByText('Settings')
+      expect(settingsLink.closest('a')).toHaveAttribute('href', '/admin/collections/settings/1')
+    })
+
+    it('shows a Rerun button', async () => {
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(screen.getByText('Rerun')).toBeInTheDocument()
+    })
+  })
+
+  describe('partial', () => {
+    beforeEach(() => {
+      mockCheckStatus.mockResolvedValue({
+        status: buildStatus({
+          status: 'partial',
+          lastRunAt: '2026-04-15T00:00:00.000Z',
+          failed: {
+            pages: { 'About Us': 'err', Donate: 'err' },
+            homePage: 'Something went wrong',
+          },
+          theme: { brandColors: true, ogColors: true },
+          settings: { id: 1 },
+        }),
+      })
+    })
+
+    it('shows "Failed" header', async () => {
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(screen.getByText('Failed')).toBeInTheDocument()
+    })
+
+    it('lists the failed pages', async () => {
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(screen.getByText('Missing pages:')).toBeInTheDocument()
+      expect(screen.getByText('About Us')).toBeInTheDocument()
+      expect(screen.getByText('Donate')).toBeInTheDocument()
+    })
+
+    it('shows a Rerun button', async () => {
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(screen.getByText('Rerun')).toBeInTheDocument()
+    })
+  })
+
+  describe('in_progress', () => {
+    // Matches what a mid-run page reload would see from the DB
+    beforeEach(() => {
+      mockCheckStatus.mockResolvedValue({
+        status: buildStatus({
+          status: 'in_progress',
+          lastRunAt: '2026-04-22T00:00:00.000Z',
+        }),
+      })
+    })
+
+    it('shows placeholder items with spinners', async () => {
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(screen.getByText('Pages')).toBeInTheDocument()
+      expect(screen.getByText('Home page')).toBeInTheDocument()
+      expect(screen.getByText('Navigation')).toBeInTheDocument()
+      expect(screen.getByText('Website Settings')).toBeInTheDocument()
+      expect(screen.getAllByTestId('spinner').length).toBeGreaterThan(0)
+    })
+
+    it('does not auto-provision (another run is already active)', async () => {
+      render(<OnboardingChecklist />)
+      await flushAsync()
+
+      expect(mockRunProvision).not.toHaveBeenCalled()
     })
   })
 })

--- a/__tests__/client/components/OnboardingChecklist.client.test.tsx
+++ b/__tests__/client/components/OnboardingChecklist.client.test.tsx
@@ -164,7 +164,7 @@ describe('OnboardingChecklist', () => {
       render(<OnboardingChecklist />)
       await flushAsync()
 
-      expect(screen.getByText('Rerun')).toBeInTheDocument()
+      expect(screen.getByText('Rerun provisioning')).toBeInTheDocument()
     })
   })
 
@@ -204,7 +204,7 @@ describe('OnboardingChecklist', () => {
       render(<OnboardingChecklist />)
       await flushAsync()
 
-      expect(screen.getByText('Rerun')).toBeInTheDocument()
+      expect(screen.getByText('Rerun provisioning')).toBeInTheDocument()
     })
 
     it('renders the timedOut message when stale in_progress was recovered', async () => {
@@ -242,11 +242,11 @@ describe('OnboardingChecklist', () => {
       })
     })
 
-    it('shows "Complete manual actions" header', async () => {
+    it('shows the manual-actions header', async () => {
       render(<OnboardingChecklist />)
       await flushAsync()
 
-      expect(screen.getByText('Complete manual actions')).toBeInTheDocument()
+      expect(screen.getByText('Complete — manual actions remaining')).toBeInTheDocument()
     })
 
     it('still renders the theme nag items', async () => {

--- a/__tests__/client/components/needsProvisioning.client.test.ts
+++ b/__tests__/client/components/needsProvisioning.client.test.ts
@@ -2,7 +2,8 @@ import { needsProvisioning } from '@/collections/Tenants/components/needsProvisi
 import type { ProvisioningStatus } from '@/collections/Tenants/components/onboardingActions'
 
 const buildStatus = (overrides: Partial<ProvisioningStatus> = {}): ProvisioningStatus => ({
-  builtInPages: { count: 0, expected: 7 },
+  forecastPages: { count: 0, expected: 2, zoneCount: 0 },
+  defaultBuiltInPages: { count: 0, expected: 5 },
   pages: { created: 0, expected: 5, missing: [] },
   homePage: false,
   navigation: false,
@@ -20,7 +21,8 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          builtInPages: { count: 7, expected: 7 },
+          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          defaultBuiltInPages: { count: 5, expected: 5 },
           pages: { created: 5, expected: 5, missing: [] },
           homePage: true,
           navigation: true,
@@ -34,7 +36,8 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          builtInPages: { count: 3, expected: 7 },
+          forecastPages: { count: 1, expected: 2, zoneCount: 2 },
+          defaultBuiltInPages: { count: 2, expected: 5 },
           pages: { created: 5, expected: 5, missing: [] },
           homePage: true,
           navigation: true,
@@ -48,7 +51,8 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          builtInPages: { count: 7, expected: 7 },
+          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          defaultBuiltInPages: { count: 5, expected: 5 },
           pages: { created: 3, expected: 5, missing: ['About Us', 'Donate'] },
           homePage: true,
           navigation: true,
@@ -62,7 +66,8 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          builtInPages: { count: 7, expected: 7 },
+          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          defaultBuiltInPages: { count: 5, expected: 5 },
           pages: { created: 5, expected: 5, missing: [] },
           homePage: false,
           navigation: true,
@@ -76,7 +81,8 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          builtInPages: { count: 7, expected: 7 },
+          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          defaultBuiltInPages: { count: 5, expected: 5 },
           pages: { created: 5, expected: 5, missing: [] },
           homePage: true,
           navigation: false,
@@ -90,7 +96,8 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          builtInPages: { count: 7, expected: 7 },
+          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          defaultBuiltInPages: { count: 5, expected: 5 },
           pages: { created: 5, expected: 5, missing: [] },
           homePage: true,
           navigation: true,
@@ -104,7 +111,8 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          builtInPages: { count: 7, expected: 7 },
+          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          defaultBuiltInPages: { count: 5, expected: 5 },
           homePage: true,
           navigation: true,
           settings: { exists: true },

--- a/__tests__/client/components/needsProvisioning.client.test.ts
+++ b/__tests__/client/components/needsProvisioning.client.test.ts
@@ -2,7 +2,7 @@ import { needsProvisioning } from '@/collections/Tenants/components/needsProvisi
 import type { ProvisioningStatus } from '@/collections/Tenants/components/onboardingActions'
 
 const buildStatus = (overrides: Partial<ProvisioningStatus> = {}): ProvisioningStatus => ({
-  forecastPages: { count: 0, expected: 2, zoneCount: 0 },
+  forecastPages: { count: 0, expected: 2 },
   defaultBuiltInPages: { count: 0, expected: 5 },
   pages: { created: 0, expected: 5, missing: [] },
   homePage: false,
@@ -21,7 +21,7 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          forecastPages: { count: 2, expected: 2 },
           defaultBuiltInPages: { count: 5, expected: 5 },
           pages: { created: 5, expected: 5, missing: [] },
           homePage: true,
@@ -36,7 +36,7 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          forecastPages: { count: 1, expected: 2, zoneCount: 2 },
+          forecastPages: { count: 1, expected: 2 },
           defaultBuiltInPages: { count: 2, expected: 5 },
           pages: { created: 5, expected: 5, missing: [] },
           homePage: true,
@@ -51,7 +51,7 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          forecastPages: { count: 2, expected: 2 },
           defaultBuiltInPages: { count: 5, expected: 5 },
           pages: { created: 3, expected: 5, missing: ['About Us', 'Donate'] },
           homePage: true,
@@ -66,7 +66,7 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          forecastPages: { count: 2, expected: 2 },
           defaultBuiltInPages: { count: 5, expected: 5 },
           pages: { created: 5, expected: 5, missing: [] },
           homePage: false,
@@ -81,7 +81,7 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          forecastPages: { count: 2, expected: 2 },
           defaultBuiltInPages: { count: 5, expected: 5 },
           pages: { created: 5, expected: 5, missing: [] },
           homePage: true,
@@ -96,7 +96,7 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          forecastPages: { count: 2, expected: 2 },
           defaultBuiltInPages: { count: 5, expected: 5 },
           pages: { created: 5, expected: 5, missing: [] },
           homePage: true,
@@ -111,7 +111,7 @@ describe('needsProvisioning', () => {
     expect(
       needsProvisioning(
         buildStatus({
-          forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+          forecastPages: { count: 2, expected: 2 },
           defaultBuiltInPages: { count: 5, expected: 5 },
           homePage: true,
           navigation: true,

--- a/__tests__/client/components/needsProvisioning.client.test.ts
+++ b/__tests__/client/components/needsProvisioning.client.test.ts
@@ -2,120 +2,38 @@ import { needsProvisioning } from '@/collections/Tenants/components/needsProvisi
 import type { ProvisioningStatus } from '@/collections/Tenants/components/onboardingActions'
 
 const buildStatus = (overrides: Partial<ProvisioningStatus> = {}): ProvisioningStatus => ({
-  forecastPages: { count: 0, expected: 2 },
-  defaultBuiltInPages: { count: 0, expected: 5 },
-  pages: { created: 0, expected: 5, missing: [] },
-  homePage: false,
-  navigation: false,
-  settings: { exists: false },
+  status: 'not_started',
+  lastRunAt: null,
+  failed: {},
   theme: { brandColors: false, ogColors: false },
+  tenantCreatedAt: null,
+  settings: {},
   ...overrides,
 })
 
 describe('needsProvisioning', () => {
-  it('returns true when nothing is provisioned', () => {
-    expect(needsProvisioning(buildStatus())).toBe(true)
+  it('returns true when provisioning has never been run', () => {
+    expect(needsProvisioning(buildStatus({ status: 'not_started' }))).toBe(true)
   })
 
-  it('returns false when all automated items are complete', () => {
-    expect(
-      needsProvisioning(
-        buildStatus({
-          forecastPages: { count: 2, expected: 2 },
-          defaultBuiltInPages: { count: 5, expected: 5 },
-          pages: { created: 5, expected: 5, missing: [] },
-          homePage: true,
-          navigation: true,
-          settings: { exists: true },
-        }),
-      ),
-    ).toBe(false)
+  it('returns false when provisioning completed', () => {
+    expect(needsProvisioning(buildStatus({ status: 'complete' }))).toBe(false)
   })
 
-  it('returns false when partially provisioned (only built-in pages missing)', () => {
+  it('returns false when provisioning completed partially', () => {
     expect(
       needsProvisioning(
-        buildStatus({
-          forecastPages: { count: 1, expected: 2 },
-          defaultBuiltInPages: { count: 2, expected: 5 },
-          pages: { created: 5, expected: 5, missing: [] },
-          homePage: true,
-          navigation: true,
-          settings: { exists: true },
-        }),
-      ),
-    ).toBe(false)
-  })
-
-  it('returns false when partially provisioned (only pages missing)', () => {
-    expect(
-      needsProvisioning(
-        buildStatus({
-          forecastPages: { count: 2, expected: 2 },
-          defaultBuiltInPages: { count: 5, expected: 5 },
-          pages: { created: 3, expected: 5, missing: ['About Us', 'Donate'] },
-          homePage: true,
-          navigation: true,
-          settings: { exists: true },
-        }),
-      ),
-    ).toBe(false)
-  })
-
-  it('returns false when partially provisioned (only home page missing)', () => {
-    expect(
-      needsProvisioning(
-        buildStatus({
-          forecastPages: { count: 2, expected: 2 },
-          defaultBuiltInPages: { count: 5, expected: 5 },
-          pages: { created: 5, expected: 5, missing: [] },
-          homePage: false,
-          navigation: true,
-          settings: { exists: true },
-        }),
-      ),
-    ).toBe(false)
-  })
-
-  it('returns false when partially provisioned (only navigation missing)', () => {
-    expect(
-      needsProvisioning(
-        buildStatus({
-          forecastPages: { count: 2, expected: 2 },
-          defaultBuiltInPages: { count: 5, expected: 5 },
-          pages: { created: 5, expected: 5, missing: [] },
-          homePage: true,
-          navigation: false,
-          settings: { exists: true },
-        }),
-      ),
-    ).toBe(false)
-  })
-
-  it('returns false when partially provisioned (only settings missing)', () => {
-    expect(
-      needsProvisioning(
-        buildStatus({
-          forecastPages: { count: 2, expected: 2 },
-          defaultBuiltInPages: { count: 5, expected: 5 },
-          pages: { created: 5, expected: 5, missing: [] },
-          homePage: true,
-          navigation: true,
-          settings: { exists: false },
-        }),
+        buildStatus({ status: 'partial', failed: { pages: { Workshops: 'err' } } }),
       ),
     ).toBe(false)
   })
 
   it('ignores theme status (manual step)', () => {
+    // Manual steps should never cause auto-provisioning to re-trigger
     expect(
       needsProvisioning(
         buildStatus({
-          forecastPages: { count: 2, expected: 2 },
-          defaultBuiltInPages: { count: 5, expected: 5 },
-          homePage: true,
-          navigation: true,
-          settings: { exists: true },
+          status: 'complete',
           theme: { brandColors: false, ogColors: false },
         }),
       ),

--- a/__tests__/client/components/needsProvisioning.client.test.ts
+++ b/__tests__/client/components/needsProvisioning.client.test.ts
@@ -28,6 +28,10 @@ describe('needsProvisioning', () => {
     ).toBe(false)
   })
 
+  it('returns false when provisioning is actively running', () => {
+    expect(needsProvisioning(buildStatus({ status: 'in_progress' }))).toBe(false)
+  })
+
   it('ignores theme status (manual step)', () => {
     // Manual steps should never cause auto-provisioning to re-trigger
     expect(

--- a/__tests__/e2e/admin/onboarding-checklist.e2e.spec.ts
+++ b/__tests__/e2e/admin/onboarding-checklist.e2e.spec.ts
@@ -58,7 +58,7 @@ test.describe('Onboarding Checklist', () => {
     await expect(checklist.getByText(/\(\d+\/\d+\)/).first()).toBeVisible({ timeout: 5000 })
 
     // Settings link should point to the tenant's settings document
-    const settingsLink = checklist.locator('a', { hasText: 'Update Brand Assets' })
+    const settingsLink = checklist.locator('a', { hasText: 'Website Settings' })
     await expect(settingsLink).toBeVisible()
     await expect(settingsLink).toHaveAttribute('href', /\/admin\/collections\/settings\/\d+/)
   })

--- a/__tests__/server/OnboardingStatusCell.server.test.tsx
+++ b/__tests__/server/OnboardingStatusCell.server.test.tsx
@@ -30,7 +30,8 @@ function isReactElement(value: unknown): value is React.ReactElement<{
 }
 
 const buildStatus = (overrides: Partial<ProvisioningStatus> = {}): ProvisioningStatus => ({
-  builtInPages: { count: 7, expected: 7 },
+  forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+  defaultBuiltInPages: { count: 5, expected: 5 },
   pages: { created: 5, expected: 5, missing: [] },
   homePage: true,
   navigation: true,

--- a/__tests__/server/OnboardingStatusCell.server.test.tsx
+++ b/__tests__/server/OnboardingStatusCell.server.test.tsx
@@ -30,7 +30,7 @@ function isReactElement(value: unknown): value is React.ReactElement<{
 }
 
 const buildStatus = (overrides: Partial<ProvisioningStatus> = {}): ProvisioningStatus => ({
-  forecastPages: { count: 2, expected: 2, zoneCount: 2 },
+  forecastPages: { count: 2, expected: 2 },
   defaultBuiltInPages: { count: 5, expected: 5 },
   pages: { created: 5, expected: 5, missing: [] },
   homePage: true,

--- a/__tests__/server/OnboardingStatusCell.server.test.tsx
+++ b/__tests__/server/OnboardingStatusCell.server.test.tsx
@@ -1,8 +1,3 @@
-import type { ProvisioningStatus } from '@/collections/Tenants/components/onboardingActions'
-import type { DefaultServerCellComponentProps } from 'payload'
-
-const mockCheckStatus = jest.fn()
-
 jest.mock('@payloadcms/ui', () => ({
   Pill: ({
     children,
@@ -15,105 +10,64 @@ jest.mock('@payloadcms/ui', () => ({
   }) => ({ type: 'Pill', props: { children, pillStyle, size } }),
 }))
 
-jest.mock('../../src/collections/Tenants/components/onboardingActions', () => ({
-  checkProvisioningStatusAction: (...args: unknown[]) => mockCheckStatus(...args),
-}))
-
 // Must import after mock setup
 import { OnboardingStatusCell } from '@/collections/Tenants/components/OnboardingStatusCell'
 
 function isReactElement(value: unknown): value is React.ReactElement<{
   children: string
   pillStyle?: string
+  size?: string
 }> {
   return value !== null && typeof value === 'object' && 'props' in value
 }
 
-const buildStatus = (overrides: Partial<ProvisioningStatus> = {}): ProvisioningStatus => ({
-  forecastPages: { count: 2, expected: 2 },
-  defaultBuiltInPages: { count: 5, expected: 5 },
-  pages: { created: 5, expected: 5, missing: [] },
-  homePage: true,
-  navigation: true,
-  settings: { exists: true, id: 1 },
-  theme: { brandColors: true, ogColors: true },
-  ...overrides,
-})
-
-const renderCell = (rowData: DefaultServerCellComponentProps['rowData']) =>
-  OnboardingStatusCell({ rowData })
+const cellFor = (status: 'complete' | 'partial' | 'in_progress' | 'not_started' | undefined) =>
+  OnboardingStatusCell({ rowData: { provisioning: { status } } })
 
 describe('OnboardingStatusCell', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
+  it('renders Complete pill for complete status', () => {
+    const result = cellFor('complete')
+
+    if (!isReactElement(result)) throw new Error('Expected ReactElement')
+    expect(result.props.children).toBe('Complete')
+    expect(result.props.pillStyle).toBe('success')
+    expect(result.props.size).toBe('small')
   })
 
-  it('returns null when rowData has no id', async () => {
-    const result = await renderCell({})
-    expect(result).toBeNull()
+  it('renders Partial pill with warning style for partial status', () => {
+    const result = cellFor('partial')
+
+    if (!isReactElement(result)) throw new Error('Expected ReactElement')
+    expect(result.props.children).toBe('Partial')
+    expect(result.props.pillStyle).toBe('warning')
   })
 
-  it('returns null when status check returns an error', async () => {
-    mockCheckStatus.mockResolvedValue({ error: 'Something went wrong' })
-    const result = await renderCell({ id: 1 })
-    expect(result).toBeNull()
+  it('renders Not started pill for not_started status', () => {
+    const result = cellFor('not_started')
+
+    if (!isReactElement(result)) throw new Error('Expected ReactElement')
+    expect(result.props.children).toBe('Not started')
   })
 
-  describe('complete', () => {
-    it('all automated and manual steps are done', async () => {
-      mockCheckStatus.mockResolvedValue({ status: buildStatus() })
-      const result = await renderCell({ id: 1 })
+  it('renders In progress pill for in_progress status', () => {
+    const result = cellFor('in_progress')
 
-      expect(result).not.toBeNull()
-      if (!isReactElement(result)) throw new Error('Expected ReactElement')
-      expect(result.props.children).toBe('Complete')
-      expect(result.props.pillStyle).toBeUndefined()
-    })
+    if (!isReactElement(result)) throw new Error('Expected ReactElement')
+    expect(result.props.children).toBe('In progress')
   })
 
-  describe('incomplete', () => {
-    it('brand colors are missing', async () => {
-      mockCheckStatus.mockResolvedValue({
-        status: buildStatus({ theme: { brandColors: false, ogColors: true } }),
-      })
-      const result = await renderCell({ id: 1 })
+  it('renders Not started pill when provisioning is missing', () => {
+    // Happens before provisioning has ever been written to the tenant
+    const result = OnboardingStatusCell({ rowData: {} })
 
-      if (!isReactElement(result)) throw new Error('Expected ReactElement')
-      expect(result.props.children).toBe('Incomplete')
-      expect(result.props.pillStyle).toBe('warning')
-    })
+    if (!isReactElement(result)) throw new Error('Expected ReactElement')
+    expect(result.props.children).toBe('Not started')
+  })
 
-    it('OG colors are missing', async () => {
-      mockCheckStatus.mockResolvedValue({
-        status: buildStatus({ theme: { brandColors: true, ogColors: false } }),
-      })
-      const result = await renderCell({ id: 1 })
+  it('renders Not started pill when provisioning.status is undefined', () => {
+    const result = OnboardingStatusCell({ rowData: { provisioning: {} } })
 
-      if (!isReactElement(result)) throw new Error('Expected ReactElement')
-      expect(result.props.children).toBe('Incomplete')
-      expect(result.props.pillStyle).toBe('warning')
-    })
-
-    it('home page is missing', async () => {
-      mockCheckStatus.mockResolvedValue({
-        status: buildStatus({ homePage: false }),
-      })
-      const result = await renderCell({ id: 1 })
-
-      if (!isReactElement(result)) throw new Error('Expected ReactElement')
-      expect(result.props.children).toBe('Incomplete')
-      expect(result.props.pillStyle).toBe('warning')
-    })
-
-    it('settings are missing', async () => {
-      mockCheckStatus.mockResolvedValue({
-        status: buildStatus({ settings: { exists: false } }),
-      })
-      const result = await renderCell({ id: 1 })
-
-      if (!isReactElement(result)) throw new Error('Expected ReactElement')
-      expect(result.props.children).toBe('Incomplete')
-      expect(result.props.pillStyle).toBe('warning')
-    })
+    if (!isReactElement(result)) throw new Error('Expected ReactElement')
+    expect(result.props.children).toBe('Not started')
   })
 })

--- a/__tests__/server/OnboardingStatusCell.server.test.tsx
+++ b/__tests__/server/OnboardingStatusCell.server.test.tsx
@@ -21,8 +21,9 @@ function isReactElement(value: unknown): value is React.ReactElement<{
   return value !== null && typeof value === 'object' && 'props' in value
 }
 
-const cellFor = (status: 'complete' | 'partial' | 'in_progress' | 'not_started' | undefined) =>
-  OnboardingStatusCell({ rowData: { provisioning: { status } } })
+const cellFor = (
+  status: 'complete' | 'partial' | 'manual' | 'in_progress' | 'not_started' | undefined,
+) => OnboardingStatusCell({ rowData: { provisioning: { status } } })
 
 describe('OnboardingStatusCell', () => {
   it('renders Complete pill for complete status', () => {
@@ -54,6 +55,14 @@ describe('OnboardingStatusCell', () => {
 
     if (!isReactElement(result)) throw new Error('Expected ReactElement')
     expect(result.props.children).toBe('In progress')
+  })
+
+  it('renders Manual actions pill for manual status', () => {
+    const result = cellFor('manual')
+
+    if (!isReactElement(result)) throw new Error('Expected ReactElement')
+    expect(result.props.children).toBe('Manual actions')
+    expect(result.props.pillStyle).toBe('warning')
   })
 
   it('renders Not started pill when provisioning is missing', () => {

--- a/__tests__/server/onboardingActions.server.test.ts
+++ b/__tests__/server/onboardingActions.server.test.ts
@@ -1,0 +1,82 @@
+// Covers the super-admin auth gate on the three provisioning server actions.
+// The downstream work (payload.findByID, provision(), etc.) is intentionally
+// not mocked because every code path here short-circuits before reaching it.
+
+jest.mock('../../src/payload.config', () => ({}))
+
+const mockAuth = jest.fn()
+const mockGetPayload = jest.fn(() => ({
+  auth: mockAuth,
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+jest.mock('payload', () => ({ getPayload: () => mockGetPayload() }))
+
+const mockHeaders = jest.fn()
+jest.mock('next/headers', () => ({ headers: () => mockHeaders() }))
+
+const mockHasSuperAdmin = jest.fn()
+jest.mock('../../src/access/hasSuperAdminPermissions', () => ({
+  hasSuperAdminPermissions: (...args: unknown[]) => mockHasSuperAdmin(...args),
+}))
+
+// Stub external dependencies the actions happen to import at module load time.
+jest.mock('../../src/app/api/[center]/og/centerColorMap', () => ({ centerColorMap: {} }))
+jest.mock('../../src/utilities/isRecord', () => ({
+  isRecord: (v: unknown) => typeof v === 'object' && v !== null,
+}))
+jest.mock('../../src/collections/Tenants/endpoints/provisionTenant', () => ({
+  provision: jest.fn(),
+  STALE_IN_PROGRESS_MS: 5 * 60 * 1000,
+}))
+
+import {
+  checkProvisioningStatusAction,
+  markProvisioningCompleteAction,
+  runProvisionAction,
+} from '@/collections/Tenants/components/onboardingActions'
+
+describe('provisioning server action auth gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockHeaders.mockReturnValue(new Headers())
+  })
+
+  const actions = [
+    { name: 'checkProvisioningStatusAction', run: () => checkProvisioningStatusAction(1) },
+    { name: 'runProvisionAction', run: () => runProvisionAction(1) },
+    { name: 'markProvisioningCompleteAction', run: () => markProvisioningCompleteAction(1) },
+  ]
+
+  describe.each(actions)('$name', ({ run }) => {
+    it('returns Unauthorized when no user is authenticated', async () => {
+      mockAuth.mockResolvedValue({ user: null })
+
+      const result = await run()
+
+      expect(result).toEqual({ error: 'Unauthorized' })
+      expect(mockHasSuperAdmin).not.toHaveBeenCalled()
+    })
+
+    it('returns Super admin access required when user lacks the role', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 42 } })
+      mockHasSuperAdmin.mockResolvedValue(false)
+
+      const result = await run()
+
+      expect(result).toEqual({ error: 'Super admin access required' })
+    })
+
+    it('proceeds past the auth gate for a super admin', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 42 } })
+      mockHasSuperAdmin.mockResolvedValue(true)
+
+      const result = await run()
+
+      // We don't assert success — the payload mock doesn't implement findByID
+      // etc. — only that the auth gate didn't short-circuit with Unauthorized
+      // or the super-admin denial.
+      expect(result).not.toEqual({ error: 'Unauthorized' })
+      expect(result).not.toEqual({ error: 'Super admin access required' })
+    })
+  })
+})

--- a/__tests__/server/resolveBuiltInPages.server.test.ts
+++ b/__tests__/server/resolveBuiltInPages.server.test.ts
@@ -1,3 +1,9 @@
+// TODO: Migrate to MSW for HTTP-level mocking. MSW v2 ships ESM which requires
+// transformIgnorePatterns changes in jest.config.mjs (next/jest overrides them).
+// See PR #969 (getAvalancheCenterPlatforms test) which uses this same jest.mock
+// pattern. Unlike that test which re-implements the function logic with mock data,
+// this test mocks at the function boundary since resolveBuiltInPages orchestrates
+// multiple NAC calls — MSW would let us test the full call chain end-to-end.
 const mockGetActiveForecastZones = jest.fn()
 const mockGetAvalancheCenterPlatforms = jest.fn()
 

--- a/__tests__/server/resolveBuiltInPages.server.test.ts
+++ b/__tests__/server/resolveBuiltInPages.server.test.ts
@@ -1,0 +1,148 @@
+const mockGetActiveForecastZones = jest.fn()
+const mockGetAvalancheCenterPlatforms = jest.fn()
+
+jest.mock('../../src/services/nac/nac', () => ({
+  getActiveForecastZones: (...args: unknown[]) => mockGetActiveForecastZones(...args),
+  getAvalancheCenterPlatforms: (...args: unknown[]) => mockGetAvalancheCenterPlatforms(...args),
+}))
+
+import { resolveBuiltInPages } from '@/collections/Tenants/endpoints/provisionTenant'
+
+// @ts-expect-error - partial mock of pino Logger; only methods used in tests are provided
+const mockLog: import('pino').Logger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}
+
+const navBuiltInPages = [
+  { title: 'All Forecasts', url: '/forecasts/avalanche' },
+  { title: 'Mountain Weather', url: '/weather/forecast' },
+  { title: 'Weather Stations', url: '/weather/stations/map' },
+  { title: 'Recent Observations', url: '/observations' },
+  { title: 'Blog', url: '/blog' },
+]
+
+function makeZone(name: string, slug: string, rank: number) {
+  return {
+    slug,
+    zone: {
+      id: Math.floor(Math.random() * 1000),
+      name,
+      url: `/forecasts/${slug}`,
+      zone_id: slug,
+      config: {
+        elevation_band_names: {
+          lower: 'Below Treeline',
+          middle: 'Near Treeline',
+          upper: 'Above Treeline',
+        },
+      },
+      status: 'active' as const,
+      rank,
+    },
+  }
+}
+
+describe('resolveBuiltInPages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAvalancheCenterPlatforms.mockResolvedValue({ weather: false })
+  })
+
+  describe('forecast pages', () => {
+    it('creates single forecast page for single-zone center', async () => {
+      mockGetActiveForecastZones.mockResolvedValue([makeZone('Olympic', 'olympic', 1)])
+
+      const { forecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+
+      expect(forecastPages).toEqual([
+        { title: 'Avalanche Forecast', url: '/forecasts/avalanche/olympic' },
+      ])
+    })
+
+    it('creates All Forecasts + per-zone pages for multi-zone center sorted by rank', async () => {
+      mockGetActiveForecastZones.mockResolvedValue([
+        makeZone('Zone B', 'zone-b', 2),
+        makeZone('Zone A', 'zone-a', 1),
+      ])
+
+      const { forecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+
+      expect(forecastPages).toEqual([
+        { title: 'All Forecasts', url: '/forecasts/avalanche' },
+        { title: 'Zone A', url: '/forecasts/avalanche/zone-a' },
+        { title: 'Zone B', url: '/forecasts/avalanche/zone-b' },
+      ])
+    })
+
+    it('creates default All Forecasts page when AFP returns no zones', async () => {
+      mockGetActiveForecastZones.mockResolvedValue([])
+
+      const { forecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+
+      expect(forecastPages).toEqual([{ title: 'All Forecasts', url: '/forecasts/avalanche' }])
+    })
+
+    it('falls back to default All Forecasts page when AFP fails', async () => {
+      mockGetActiveForecastZones.mockRejectedValue(new Error('network error'))
+
+      const { forecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+
+      expect(forecastPages).toEqual([{ title: 'All Forecasts', url: '/forecasts/avalanche' }])
+    })
+  })
+
+  describe('non-forecast pages', () => {
+    beforeEach(() => {
+      mockGetActiveForecastZones.mockResolvedValue([])
+    })
+
+    it('excludes forecast pages from non-forecast list', async () => {
+      const { nonForecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+
+      expect(nonForecastPages.find((p) => p.url.startsWith('/forecasts/avalanche'))).toBeUndefined()
+    })
+
+    it('excludes Mountain Weather when center has no weather platform', async () => {
+      mockGetAvalancheCenterPlatforms.mockResolvedValue({ weather: false })
+
+      const { nonForecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+
+      expect(nonForecastPages.find((p) => p.url === '/weather/forecast')).toBeUndefined()
+    })
+
+    it('includes Mountain Weather when center has weather platform', async () => {
+      mockGetAvalancheCenterPlatforms.mockResolvedValue({ weather: true })
+
+      const { nonForecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+
+      expect(nonForecastPages).toContainEqual({
+        title: 'Mountain Weather',
+        url: '/weather/forecast',
+      })
+    })
+
+    it('excludes Mountain Weather when NAC platforms query fails', async () => {
+      mockGetAvalancheCenterPlatforms.mockRejectedValue(new Error('network error'))
+
+      const { nonForecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+
+      expect(nonForecastPages.find((p) => p.url === '/weather/forecast')).toBeUndefined()
+    })
+
+    it('includes other DVAC nav pages unchanged', async () => {
+      const { nonForecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+
+      expect(nonForecastPages).toContainEqual({
+        title: 'Weather Stations',
+        url: '/weather/stations/map',
+      })
+      expect(nonForecastPages).toContainEqual({
+        title: 'Recent Observations',
+        url: '/observations',
+      })
+      expect(nonForecastPages).toContainEqual({ title: 'Blog', url: '/blog' })
+    })
+  })
+})

--- a/__tests__/server/resolveBuiltInPages.server.test.ts
+++ b/__tests__/server/resolveBuiltInPages.server.test.ts
@@ -1,18 +1,94 @@
-// TODO: Migrate to MSW for HTTP-level mocking. MSW v2 ships ESM which requires
-// transformIgnorePatterns changes in jest.config.mjs (next/jest overrides them).
-// See PR #969 (getAvalancheCenterPlatforms test) which uses this same jest.mock
-// pattern. Unlike that test which re-implements the function logic with mock data,
-// this test mocks at the function boundary since resolveBuiltInPages orchestrates
-// multiple NAC calls — MSW would let us test the full call chain end-to-end.
-const mockGetActiveForecastZones = jest.fn()
-const mockGetAvalancheCenterPlatforms = jest.fn()
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
 
-jest.mock('../../src/services/nac/nac', () => ({
-  getActiveForecastZones: (...args: unknown[]) => mockGetActiveForecastZones(...args),
-  getAvalancheCenterPlatforms: (...args: unknown[]) => mockGetAvalancheCenterPlatforms(...args),
+jest.mock('../../src/payload.config', () => ({}))
+
+// nac.ts internally calls getPayload({ config }) for logging. Give it a
+// stub with a logger so error-path tests don't crash on logger access.
+jest.mock('payload', () => ({
+  getPayload: jest.fn().mockResolvedValue({
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  }),
 }))
 
 import { resolveBuiltInPages } from '@/collections/Tenants/endpoints/provisionTenant'
+
+type ZoneInput = {
+  name: string
+  slug: string
+  rank?: number | null
+  id?: number
+}
+
+// Minimal but schema-compliant shape for the /v2/public/avalanche-center/:id
+// response. Every required field in avalancheCenterSchema is populated with a
+// sensible default; tests only need to pass in zones.
+function makeCenterResponse(slug: string, zones: ZoneInput[]) {
+  return {
+    id: slug.toUpperCase(),
+    name: slug.toUpperCase(),
+    url: `/${slug}`,
+    city: 'X',
+    state: 'XX',
+    timezone: 'America/Los_Angeles',
+    email: 'x@example.com',
+    phone: null,
+    center_point: null,
+    created_at: '2026-01-01T00:00:00Z',
+    wkb_geometry: null,
+    config: {
+      expires_time: null,
+      published_time: null,
+      blog: false,
+      blog_title: '',
+      weather_table: [],
+    },
+    type: 'nonprofit',
+    widget_config: {},
+    zones: zones.map((z, i) => ({
+      id: z.id ?? i + 1,
+      name: z.name,
+      url: `/forecasts/${z.slug}`,
+      zone_id: z.slug,
+      config: {
+        elevation_band_names: { lower: 'Below', middle: 'Near', upper: 'Above' },
+      },
+      status: 'active',
+      rank: z.rank ?? null,
+    })),
+    nws_zones: [],
+    nws_offices: [],
+    off_season: false,
+  }
+}
+
+// /v1/public/avalanche-centers response used by getAvalancheCenterPlatforms.
+function makeCapabilities(
+  slug: string,
+  overrides: { forecasts?: boolean; weather?: boolean } = {},
+) {
+  return {
+    centers: [
+      {
+        id: slug.toUpperCase(),
+        display_id: slug.toUpperCase(),
+        platforms: {
+          warnings: false,
+          forecasts: overrides.forecasts ?? true,
+          stations: false,
+          obs: false,
+          weather: overrides.weather ?? false,
+        },
+      },
+    ],
+  }
+}
+
+const server = setupServer()
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 // @ts-expect-error - partial mock of pino Logger; only methods used in tests are provided
 const mockLog: import('pino').Logger = {
@@ -21,38 +97,27 @@ const mockLog: import('pino').Logger = {
   error: jest.fn(),
 }
 
-function makeZone(name: string, slug: string, rank: number) {
-  return {
-    slug,
-    zone: {
-      id: Math.floor(Math.random() * 1000),
-      name,
-      url: `/forecasts/${slug}`,
-      zone_id: slug,
-      config: {
-        elevation_band_names: {
-          lower: 'Below Treeline',
-          middle: 'Near Treeline',
-          upper: 'Above Treeline',
-        },
-      },
-      status: 'active' as const,
-      rank,
-    },
-  }
-}
+const SLUG = 'test'
 
 describe('resolveBuiltInPages', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockGetAvalancheCenterPlatforms.mockResolvedValue({ weather: false })
   })
 
   describe('forecast pages', () => {
     it('creates single forecast page for single-zone center', async () => {
-      mockGetActiveForecastZones.mockResolvedValue([makeZone('Olympic', 'olympic', 1)])
+      server.use(
+        http.get('https://forecasts.avalanche.org/', () =>
+          HttpResponse.json(makeCapabilities(SLUG)),
+        ),
+        http.get(`https://api.avalanche.org/v2/public/avalanche-center/${SLUG.toUpperCase()}`, () =>
+          HttpResponse.json(
+            makeCenterResponse(SLUG, [{ name: 'Olympic', slug: 'olympic', rank: 1 }]),
+          ),
+        ),
+      )
 
-      const { forecastPages } = await resolveBuiltInPages('test', mockLog)
+      const { forecastPages } = await resolveBuiltInPages(SLUG, mockLog)
 
       expect(forecastPages).toEqual([
         { title: 'Avalanche Forecast', url: '/forecasts/avalanche/olympic' },
@@ -60,12 +125,21 @@ describe('resolveBuiltInPages', () => {
     })
 
     it('creates All Forecasts + per-zone pages for multi-zone center sorted by rank', async () => {
-      mockGetActiveForecastZones.mockResolvedValue([
-        makeZone('Zone B', 'zone-b', 2),
-        makeZone('Zone A', 'zone-a', 1),
-      ])
+      server.use(
+        http.get('https://forecasts.avalanche.org/', () =>
+          HttpResponse.json(makeCapabilities(SLUG)),
+        ),
+        http.get(`https://api.avalanche.org/v2/public/avalanche-center/${SLUG.toUpperCase()}`, () =>
+          HttpResponse.json(
+            makeCenterResponse(SLUG, [
+              { name: 'Zone B', slug: 'zone-b', rank: 2 },
+              { name: 'Zone A', slug: 'zone-a', rank: 1 },
+            ]),
+          ),
+        ),
+      )
 
-      const { forecastPages } = await resolveBuiltInPages('test', mockLog)
+      const { forecastPages } = await resolveBuiltInPages(SLUG, mockLog)
 
       expect(forecastPages).toEqual([
         { title: 'All Forecasts', url: '/forecasts/avalanche' },
@@ -75,45 +149,79 @@ describe('resolveBuiltInPages', () => {
     })
 
     it('creates default All Forecasts page when AFP returns no zones', async () => {
-      mockGetActiveForecastZones.mockResolvedValue([])
+      server.use(
+        http.get('https://forecasts.avalanche.org/', () =>
+          HttpResponse.json(makeCapabilities(SLUG)),
+        ),
+        http.get(`https://api.avalanche.org/v2/public/avalanche-center/${SLUG.toUpperCase()}`, () =>
+          HttpResponse.json(makeCenterResponse(SLUG, [])),
+        ),
+      )
 
-      const { forecastPages } = await resolveBuiltInPages('test', mockLog)
+      const { forecastPages } = await resolveBuiltInPages(SLUG, mockLog)
 
       expect(forecastPages).toEqual([{ title: 'All Forecasts', url: '/forecasts/avalanche' }])
     })
 
     it('falls back to default All Forecasts page when AFP fails', async () => {
-      mockGetActiveForecastZones.mockRejectedValue(new Error('network error'))
+      server.use(
+        http.get('https://forecasts.avalanche.org/', () =>
+          HttpResponse.json(makeCapabilities(SLUG)),
+        ),
+        http.get(
+          `https://api.avalanche.org/v2/public/avalanche-center/${SLUG.toUpperCase()}`,
+          () => new HttpResponse(null, { status: 500 }),
+        ),
+      )
 
-      const { forecastPages } = await resolveBuiltInPages('test', mockLog)
+      const { forecastPages } = await resolveBuiltInPages(SLUG, mockLog)
 
       expect(forecastPages).toEqual([{ title: 'All Forecasts', url: '/forecasts/avalanche' }])
     })
   })
 
   describe('non-forecast pages', () => {
-    beforeEach(() => {
-      mockGetActiveForecastZones.mockResolvedValue([])
-    })
-
     it('excludes forecast pages from non-forecast list', async () => {
-      const { nonForecastPages } = await resolveBuiltInPages('test', mockLog)
+      server.use(
+        http.get('https://forecasts.avalanche.org/', () =>
+          HttpResponse.json(makeCapabilities(SLUG, { weather: false })),
+        ),
+        http.get(`https://api.avalanche.org/v2/public/avalanche-center/${SLUG.toUpperCase()}`, () =>
+          HttpResponse.json(makeCenterResponse(SLUG, [])),
+        ),
+      )
+
+      const { nonForecastPages } = await resolveBuiltInPages(SLUG, mockLog)
 
       expect(nonForecastPages.find((p) => p.url.startsWith('/forecasts/avalanche'))).toBeUndefined()
     })
 
     it('excludes Mountain Weather when center has no weather platform', async () => {
-      mockGetAvalancheCenterPlatforms.mockResolvedValue({ weather: false })
+      server.use(
+        http.get('https://forecasts.avalanche.org/', () =>
+          HttpResponse.json(makeCapabilities(SLUG, { weather: false })),
+        ),
+        http.get(`https://api.avalanche.org/v2/public/avalanche-center/${SLUG.toUpperCase()}`, () =>
+          HttpResponse.json(makeCenterResponse(SLUG, [])),
+        ),
+      )
 
-      const { nonForecastPages } = await resolveBuiltInPages('test', mockLog)
+      const { nonForecastPages } = await resolveBuiltInPages(SLUG, mockLog)
 
       expect(nonForecastPages.find((p) => p.url === '/weather/forecast')).toBeUndefined()
     })
 
     it('includes Mountain Weather when center has weather platform', async () => {
-      mockGetAvalancheCenterPlatforms.mockResolvedValue({ weather: true })
+      server.use(
+        http.get('https://forecasts.avalanche.org/', () =>
+          HttpResponse.json(makeCapabilities(SLUG, { weather: true })),
+        ),
+        http.get(`https://api.avalanche.org/v2/public/avalanche-center/${SLUG.toUpperCase()}`, () =>
+          HttpResponse.json(makeCenterResponse(SLUG, [])),
+        ),
+      )
 
-      const { nonForecastPages } = await resolveBuiltInPages('test', mockLog)
+      const { nonForecastPages } = await resolveBuiltInPages(SLUG, mockLog)
 
       expect(nonForecastPages).toContainEqual({
         title: 'Mountain Weather',
@@ -122,15 +230,29 @@ describe('resolveBuiltInPages', () => {
     })
 
     it('excludes Mountain Weather when NAC platforms query fails', async () => {
-      mockGetAvalancheCenterPlatforms.mockRejectedValue(new Error('network error'))
+      server.use(
+        http.get('https://forecasts.avalanche.org/', () => new HttpResponse(null, { status: 500 })),
+        http.get(`https://api.avalanche.org/v2/public/avalanche-center/${SLUG.toUpperCase()}`, () =>
+          HttpResponse.json(makeCenterResponse(SLUG, [])),
+        ),
+      )
 
-      const { nonForecastPages } = await resolveBuiltInPages('test', mockLog)
+      const { nonForecastPages } = await resolveBuiltInPages(SLUG, mockLog)
 
       expect(nonForecastPages.find((p) => p.url === '/weather/forecast')).toBeUndefined()
     })
 
     it('includes the static BUILT_IN_PAGES list', async () => {
-      const { nonForecastPages } = await resolveBuiltInPages('test', mockLog)
+      server.use(
+        http.get('https://forecasts.avalanche.org/', () =>
+          HttpResponse.json(makeCapabilities(SLUG)),
+        ),
+        http.get(`https://api.avalanche.org/v2/public/avalanche-center/${SLUG.toUpperCase()}`, () =>
+          HttpResponse.json(makeCenterResponse(SLUG, [])),
+        ),
+      )
+
+      const { nonForecastPages } = await resolveBuiltInPages(SLUG, mockLog)
 
       expect(nonForecastPages).toContainEqual({
         title: 'Weather Stations',

--- a/__tests__/server/resolveBuiltInPages.server.test.ts
+++ b/__tests__/server/resolveBuiltInPages.server.test.ts
@@ -21,14 +21,6 @@ const mockLog: import('pino').Logger = {
   error: jest.fn(),
 }
 
-const navBuiltInPages = [
-  { title: 'All Forecasts', url: '/forecasts/avalanche' },
-  { title: 'Mountain Weather', url: '/weather/forecast' },
-  { title: 'Weather Stations', url: '/weather/stations/map' },
-  { title: 'Recent Observations', url: '/observations' },
-  { title: 'Blog', url: '/blog' },
-]
-
 function makeZone(name: string, slug: string, rank: number) {
   return {
     slug,
@@ -60,7 +52,7 @@ describe('resolveBuiltInPages', () => {
     it('creates single forecast page for single-zone center', async () => {
       mockGetActiveForecastZones.mockResolvedValue([makeZone('Olympic', 'olympic', 1)])
 
-      const { forecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+      const { forecastPages } = await resolveBuiltInPages('test', mockLog)
 
       expect(forecastPages).toEqual([
         { title: 'Avalanche Forecast', url: '/forecasts/avalanche/olympic' },
@@ -73,7 +65,7 @@ describe('resolveBuiltInPages', () => {
         makeZone('Zone A', 'zone-a', 1),
       ])
 
-      const { forecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+      const { forecastPages } = await resolveBuiltInPages('test', mockLog)
 
       expect(forecastPages).toEqual([
         { title: 'All Forecasts', url: '/forecasts/avalanche' },
@@ -85,7 +77,7 @@ describe('resolveBuiltInPages', () => {
     it('creates default All Forecasts page when AFP returns no zones', async () => {
       mockGetActiveForecastZones.mockResolvedValue([])
 
-      const { forecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+      const { forecastPages } = await resolveBuiltInPages('test', mockLog)
 
       expect(forecastPages).toEqual([{ title: 'All Forecasts', url: '/forecasts/avalanche' }])
     })
@@ -93,7 +85,7 @@ describe('resolveBuiltInPages', () => {
     it('falls back to default All Forecasts page when AFP fails', async () => {
       mockGetActiveForecastZones.mockRejectedValue(new Error('network error'))
 
-      const { forecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+      const { forecastPages } = await resolveBuiltInPages('test', mockLog)
 
       expect(forecastPages).toEqual([{ title: 'All Forecasts', url: '/forecasts/avalanche' }])
     })
@@ -105,7 +97,7 @@ describe('resolveBuiltInPages', () => {
     })
 
     it('excludes forecast pages from non-forecast list', async () => {
-      const { nonForecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+      const { nonForecastPages } = await resolveBuiltInPages('test', mockLog)
 
       expect(nonForecastPages.find((p) => p.url.startsWith('/forecasts/avalanche'))).toBeUndefined()
     })
@@ -113,7 +105,7 @@ describe('resolveBuiltInPages', () => {
     it('excludes Mountain Weather when center has no weather platform', async () => {
       mockGetAvalancheCenterPlatforms.mockResolvedValue({ weather: false })
 
-      const { nonForecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+      const { nonForecastPages } = await resolveBuiltInPages('test', mockLog)
 
       expect(nonForecastPages.find((p) => p.url === '/weather/forecast')).toBeUndefined()
     })
@@ -121,7 +113,7 @@ describe('resolveBuiltInPages', () => {
     it('includes Mountain Weather when center has weather platform', async () => {
       mockGetAvalancheCenterPlatforms.mockResolvedValue({ weather: true })
 
-      const { nonForecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+      const { nonForecastPages } = await resolveBuiltInPages('test', mockLog)
 
       expect(nonForecastPages).toContainEqual({
         title: 'Mountain Weather',
@@ -132,13 +124,13 @@ describe('resolveBuiltInPages', () => {
     it('excludes Mountain Weather when NAC platforms query fails', async () => {
       mockGetAvalancheCenterPlatforms.mockRejectedValue(new Error('network error'))
 
-      const { nonForecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+      const { nonForecastPages } = await resolveBuiltInPages('test', mockLog)
 
       expect(nonForecastPages.find((p) => p.url === '/weather/forecast')).toBeUndefined()
     })
 
-    it('includes other DVAC nav pages unchanged', async () => {
-      const { nonForecastPages } = await resolveBuiltInPages('test', navBuiltInPages, mockLog)
+    it('includes the static BUILT_IN_PAGES list', async () => {
+      const { nonForecastPages } = await resolveBuiltInPages('test', mockLog)
 
       expect(nonForecastPages).toContainEqual({
         title: 'Weather Stations',
@@ -148,7 +140,12 @@ describe('resolveBuiltInPages', () => {
         title: 'Recent Observations',
         url: '/observations',
       })
+      expect(nonForecastPages).toContainEqual({
+        title: 'Submit Observations',
+        url: '/observations/submit',
+      })
       expect(nonForecastPages).toContainEqual({ title: 'Blog', url: '/blog' })
+      expect(nonForecastPages).toContainEqual({ title: 'Events', url: '/events' })
     })
   })
 })

--- a/consistent-type-assertions.txt
+++ b/consistent-type-assertions.txt
@@ -6,6 +6,7 @@ src/app/(frontend)/[center]/blog/[slug]/page.tsx
 src/app/(frontend)/[center]/events/[slug]/page.tsx
 src/app/(frontend)/[center]/next/preview/route.ts
 src/collections/Pages/components/DuplicatePageFor/index.tsx
+src/collections/Tenants/components/onboardingActions.ts
 src/collections/Users/components/InviteUser.tsx
 src/collections/Users/components/InviteUserDrawer.tsx
 src/collections/Users/components/inviteUserAction.ts

--- a/docs/coding-guide.md
+++ b/docs/coding-guide.md
@@ -137,6 +137,10 @@ You typically don't need error boundaries for missing data - returning `null` is
 
 We have `ErrorBoundary` components available at `/src/components/ErrorBoundary/` for these cases. Next.js also provides `error.tsx` and `global-error.tsx` for route-level error handling.
 
+## Server Actions
+
+Server actions (`'use server'`) compile to POST endpoints reachable by anyone with the action ID — they are **not** automatically scoped to the caller. Always gate access at the top of every action: authenticate the user via `payload.auth({ headers: await headers() })` and apply the appropriate role/permission check (e.g. `hasSuperAdminPermissions`) before touching any data. Don't rely on the client-side admin context for authorization.
+
 ## Styling
 
 Prefer using Tailwind utility classes over adding `.(s)css` files.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -11,29 +11,25 @@ Provisioning is idempotent and can be rerun safely.
 | Step | Details |
 |------|---------|
 | Website Settings | Created with placeholder brand assets (logo, icon, banner). Replace with real assets via the checklist link. |
-| Built-in pages | Creates standard pages per the table below. |
+| Forecast pages | Queries AFP via `getActiveForecastZones()` to auto-detect single vs multi-zone. Creates zone-specific built-in pages (see table below). Falls back to a default "All Forecasts" page if AFP is unavailable. |
+| Default built-in pages | Creates non-forecast built-in pages sourced from the template (DVAC) navigation (see table below). |
 | Template pages | Copies all published pages from the template tenant (DVAC). Pages whose blocks all reference tenant-scoped data (teams, sponsors, events, forms) are copied as empty drafts. Demo pages (`blocks`, `lexical-blocks`) are skipped. Static blog/event list blocks are converted to dynamic mode. |
 | Home page | Creates a home page with welcome content and quick links to About Us and Donate. |
-| Navigation | Creates navigation menus linked to all copied pages and built-in pages. |
+| Navigation | Creates navigation menus linked to all copied pages and built-in pages. Forecasts tab is zone-aware (single zone: direct link; multi-zone: "All Forecasts" + per-zone items). |
 | Edge Config | The `updateEdgeConfigAfterChange` hook automatically adds the tenant to Vercel Edge Config. |
 
 #### Built-In Pages
 
-\* If a center has a single forecast zone, it gets an "Avalanche Forecast" page pointing to that zone. Multi-zone centers get an "All Forecasts" page plus individual zone pages.
+Forecast pages are determined by AFP zone data\*. Non-forecast pages are sourced from the template tenant's (DVAC) navigation — adding or removing a built-in page in DVAC's nav automatically changes what new tenants get.
 
-| Title | URL | For AC with single or multi zone* |
-|-------|-----|-----------------------------------|
-| All Forecasts | `/forecasts/avalanche` | multi |
-| _ZONE NAME_ | `/forecasts/avalanche/ZONE` | multi |
-| Avalanche Forecast | `/forecasts/avalanche/ZONE` | single |
-| Mountain Weather** | `/weather/forecast` | both |
-| Weather Stations | `/weather/stations/map` | both |
-| Recent Observations | `/observations` | both |
-| Submit Observations | `/observations/submit` | both |
-| Blog | `/blog` | both |
-| Events | `/events` | both |
+\* If a center has a single forecast zone, it gets an "Avalanche Forecast" page pointing to that zone. Multi-zone centers get an "All Forecasts" page plus individual zone pages. If AFP is unavailable, a default "All Forecasts" page is created.
 
-\*\* Mountain Weather is only available for centers that have a weather forecast configured.
+| Title | URL | Source |
+|-------|-----|--------|
+| All Forecasts | `/forecasts/avalanche` | AFP (multi-zone) |
+| _ZONE NAME_ | `/forecasts/avalanche/ZONE` | AFP (multi-zone) |
+| Avalanche Forecast | `/forecasts/avalanche/ZONE` | AFP (single-zone) |
+| _Non-forecast pages_ | _varies_ | DVAC navigation |
 
 ## Manual steps
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -12,7 +12,7 @@ Provisioning is idempotent and can be rerun safely.
 |------|---------|
 | Website Settings | Created with placeholder brand assets (logo, icon, banner). Replace with real assets via the checklist link. |
 | Forecast pages | Queries AFP via `getActiveForecastZones()` to auto-detect single vs multi-zone. Creates zone-specific built-in pages (see table below). Falls back to a default "All Forecasts" page if AFP is unavailable. |
-| Default built-in pages | Creates non-forecast built-in pages sourced from the template (DVAC) navigation (see table below). |
+| Default built-in pages | Creates non-forecast built-in pages sourced from the template (DVAC) navigation (see table below). Mountain Weather is only included if the center has a weather forecast configured in NAC (`platforms.weather`). |
 | Template pages | Copies all published pages from the template tenant (DVAC). Pages whose blocks all reference tenant-scoped data (teams, sponsors, events, forms) are copied as empty drafts. Demo pages (`blocks`, `lexical-blocks`) are skipped. Static blog/event list blocks are converted to dynamic mode. |
 | Home page | Creates a home page with welcome content and quick links to About Us and Donate. |
 | Navigation | Creates navigation menus linked to all copied pages and built-in pages. Forecasts tab is zone-aware (single zone: direct link; multi-zone: "All Forecasts" + per-zone items). |
@@ -29,6 +29,7 @@ Forecast pages are determined by AFP zone data\*. Non-forecast pages are sourced
 | All Forecasts | `/forecasts/avalanche` | AFP (multi-zone) |
 | _ZONE NAME_ | `/forecasts/avalanche/ZONE` | AFP (multi-zone) |
 | Avalanche Forecast | `/forecasts/avalanche/ZONE` | AFP (single-zone) |
+| Mountain Weather | `/weather/forecast` | NAC `platforms.weather` |
 | _Non-forecast pages_ | _varies_ | DVAC navigation |
 
 ## Manual steps

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -12,15 +12,15 @@ Provisioning is idempotent and can be rerun safely.
 |------|---------|
 | Website Settings | Created with placeholder brand assets (logo, icon, banner). Replace with real assets via the checklist link. |
 | Forecast pages | Queries AFP via `getActiveForecastZones()` to auto-detect single vs multi-zone. Creates zone-specific built-in pages (see table below). Falls back to a default "All Forecasts" page if AFP is unavailable. |
-| Default built-in pages | Creates non-forecast built-in pages sourced from the template (DVAC) navigation (see table below). Mountain Weather is only included if the center has a weather forecast configured in NAC (`platforms.weather`). |
-| Template pages | Copies all published pages from the template tenant (DVAC). Pages whose blocks all reference tenant-scoped data (teams, sponsors, events, forms) are copied as empty drafts. Demo pages (`blocks`, `lexical-blocks`) are skipped. Static blog/event list blocks are converted to dynamic mode. |
+| Default built-in pages | Creates non-forecast built-in pages from the static `BUILT_IN_PAGES` list in `provisionTenant.ts` (see table below). Mountain Weather is only included if the center has a weather forecast configured in NAC (`platforms.weather`). |
+| Blank pages | Creates empty pages for every slug in the static `PAGES_TO_PROVISION` list in `provisionTenant.ts`. Admins are expected to fill in the content after provisioning. |
 | Home page | Creates a home page with welcome content and quick links to About Us and Donate. |
-| Navigation | Creates navigation menus linked to all copied pages and built-in pages. Forecasts tab is zone-aware (single zone: direct link; multi-zone: "All Forecasts" + per-zone items). |
+| Navigation | Creates navigation menus linked to all provisioned pages and built-in pages. Forecasts tab is zone-aware (single zone: single-item dropdown; multi-zone: "All Forecasts" + a "Zones" accordion with per-zone items). |
 | Edge Config | The `updateEdgeConfigAfterChange` hook automatically adds the tenant to Vercel Edge Config. |
 
 #### Built-In Pages
 
-Forecast pages are determined by AFP zone data\*. Non-forecast pages are sourced from the template tenant's (DVAC) navigation — adding or removing a built-in page in DVAC's nav automatically changes what new tenants get.
+Forecast pages are determined by AFP zone data\*. Non-forecast pages come from the static `BUILT_IN_PAGES` list in `src/collections/Tenants/endpoints/provisionTenant.ts` — edit that list to change what new tenants get.
 
 \* If a center has a single forecast zone, it gets an "Avalanche Forecast" page pointing to that zone. Multi-zone centers get an "All Forecasts" page plus individual zone pages. If AFP is unavailable, a default "All Forecasts" page is created.
 
@@ -30,7 +30,7 @@ Forecast pages are determined by AFP zone data\*. Non-forecast pages are sourced
 | _ZONE NAME_ | `/forecasts/avalanche/ZONE` | AFP (multi-zone) |
 | Avalanche Forecast | `/forecasts/avalanche/ZONE` | AFP (single-zone) |
 | Mountain Weather | `/weather/forecast` | NAC `platforms.weather` |
-| _Non-forecast pages_ | _varies_ | DVAC navigation |
+| _Non-forecast pages_ | _varies_ | `BUILT_IN_PAGES` constant |
 
 ## Manual steps
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -8,6 +8,10 @@ Create the tenant in the admin panel → provisioning runs automatically via `pr
 
 Provisioning is idempotent and can be rerun safely.
 
+### Provisioning status field
+
+The outcome of each provisioning run is stored on the tenant's `provisioning` group field (`status`, `lastRunAt`, `failedPages`) directly on the Tenants collection. The onboarding checklist reads this field directly — it no longer re-derives status from live page/navigation counts, so deleting a page post-provisioning won't un-mark the tenant as complete. Re-running overwrites with the latest outcome (`complete` if everything succeeded, `partial` if some pages failed). The tenant list view renders this status as a Pill in the Provisioning column.
+
 | Step | Details |
 |------|---------|
 | Website Settings | Created with placeholder brand assets (logo, icon, banner). Replace with real assets via the checklist link. |

--- a/src/collections/Tenants/components/OnboardingChecklist.tsx
+++ b/src/collections/Tenants/components/OnboardingChecklist.tsx
@@ -4,7 +4,6 @@ import { Button, toast, useDocumentInfo, useForm } from '@payloadcms/ui'
 import { CheckCircle2, Circle, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 
-import pluralize from 'pluralize'
 import { useCallback, useEffect, useState } from 'react'
 import { needsProvisioning } from './needsProvisioning'
 import {
@@ -14,7 +13,7 @@ import {
 } from './onboardingActions'
 
 const DEFAULT_STATUS: ProvisioningStatus = {
-  forecastPages: { count: 0, expected: 0, zoneCount: 0 },
+  forecastPages: { count: 0, expected: 0 },
   defaultBuiltInPages: { count: 0, expected: 0 },
   pages: { created: 0, expected: 0, missing: [] },
   homePage: false,
@@ -174,8 +173,8 @@ export function OnboardingChecklist() {
 
       {automatedComplete && (
         <p className="mt-2 text-sm opacity-70">
-          Forecast pages are automated from NAC zones. Blank pages are created using DVACs
-          navigation structure.
+          Forecast nav is automatically based on NAC zones. <br />
+          Blank pages are created using DVACs navigation structure.
         </p>
       )}
 
@@ -184,10 +183,7 @@ export function OnboardingChecklist() {
         done={loaded && forecastPages.count >= forecastPages.expected}
         label="Forecast pages"
         details={loaded && `(${forecastPages.count}/${forecastPages.expected})`}
-      >
-        {loaded &&
-          `Center has ${forecastPages.zoneCount} ${pluralize('zone', forecastPages.zoneCount)} from NAC`}
-      </ChecklistItem>
+      />
       <ChecklistItem
         loading={isProvisioning}
         done={loaded && defaultBuiltInPages.count >= defaultBuiltInPages.expected}

--- a/src/collections/Tenants/components/OnboardingChecklist.tsx
+++ b/src/collections/Tenants/components/OnboardingChecklist.tsx
@@ -4,6 +4,7 @@ import { Button, toast, useDocumentInfo, useForm } from '@payloadcms/ui'
 import { CheckCircle2, Circle, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 
+import pluralize from 'pluralize'
 import { useCallback, useEffect, useState } from 'react'
 import { needsProvisioning } from './needsProvisioning'
 import {
@@ -13,7 +14,8 @@ import {
 } from './onboardingActions'
 
 const DEFAULT_STATUS: ProvisioningStatus = {
-  builtInPages: { count: 0, expected: 0 },
+  forecastPages: { count: 0, expected: 0, zoneCount: 0 },
+  defaultBuiltInPages: { count: 0, expected: 0 },
   pages: { created: 0, expected: 0, missing: [] },
   homePage: false,
   navigation: false,
@@ -145,10 +147,12 @@ export function OnboardingChecklist() {
     })
   }, [tenantId]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const { builtInPages, pages, homePage, navigation, settings, theme } = status
+  const { forecastPages, defaultBuiltInPages, pages, homePage, navigation, settings, theme } =
+    status
 
   const automatedComplete =
-    builtInPages.count >= builtInPages.expected &&
+    forecastPages.count >= forecastPages.expected &&
+    defaultBuiltInPages.count >= defaultBuiltInPages.expected &&
     pages.created >= pages.expected &&
     pages.expected > 0 &&
     homePage &&
@@ -170,15 +174,25 @@ export function OnboardingChecklist() {
 
       {automatedComplete && (
         <p className="mt-2 text-sm opacity-70">
-          Blank pages are created using DVACs navigation structure
+          Forecast pages are automated from NAC zones. Blank pages are created using DVACs
+          navigation structure.
         </p>
       )}
 
       <ChecklistItem
         loading={isProvisioning}
-        done={loaded && builtInPages.count >= builtInPages.expected}
-        label="Built-in pages"
-        details={loaded && `(${builtInPages.count}/${builtInPages.expected})`}
+        done={loaded && forecastPages.count >= forecastPages.expected}
+        label="Forecast pages"
+        details={loaded && `(${forecastPages.count}/${forecastPages.expected})`}
+      >
+        {loaded &&
+          `Center has ${forecastPages.zoneCount} ${pluralize('zone', forecastPages.zoneCount)} from NAC`}
+      </ChecklistItem>
+      <ChecklistItem
+        loading={isProvisioning}
+        done={loaded && defaultBuiltInPages.count >= defaultBuiltInPages.expected}
+        label="Default built-in pages"
+        details={loaded && `(${defaultBuiltInPages.count}/${defaultBuiltInPages.expected})`}
       />
       <ChecklistItem
         loading={isProvisioning}

--- a/src/collections/Tenants/components/OnboardingChecklist.tsx
+++ b/src/collections/Tenants/components/OnboardingChecklist.tsx
@@ -171,31 +171,35 @@ export function OnboardingChecklist() {
         )}
       </div>
 
-      {automatedComplete && (
-        <p className="mt-2 text-sm opacity-70">
-          Forecast nav is automatically based on NAC zones. <br />
-          Blank pages are created using DVACs navigation structure.
-        </p>
-      )}
-
       <ChecklistItem
         loading={isProvisioning}
         done={loaded && forecastPages.count >= forecastPages.expected}
-        label="Forecast pages"
+        label="Forecast Built-In pages"
         details={loaded && `(${forecastPages.count}/${forecastPages.expected})`}
-      />
+      >
+        {automatedComplete && (
+          <p className="text-sm opacity-70">
+            Forecast built-ins are automatically based on NAC zones.
+          </p>
+        )}
+      </ChecklistItem>
       <ChecklistItem
         loading={isProvisioning}
         done={loaded && defaultBuiltInPages.count >= defaultBuiltInPages.expected}
-        label="Default built-in pages"
+        label="Default Built-In pages"
         details={loaded && `(${defaultBuiltInPages.count}/${defaultBuiltInPages.expected})`}
-      />
+      ></ChecklistItem>
       <ChecklistItem
         loading={isProvisioning}
         done={pages.created >= pages.expected && pages.expected > 0}
         label="Pages"
         details={loaded && `(${pages.created}/${pages.expected})`}
       >
+        {automatedComplete && (
+          <p className="text-sm opacity-70">
+            Blank pages are created using DVACs navigation structure.
+          </p>
+        )}
         {pages.missing.length > 0 && <div>Missing: {pages.missing.join(', ')}</div>}
       </ChecklistItem>
 
@@ -212,7 +216,11 @@ export function OnboardingChecklist() {
             </Link>
           )
         }
-      />
+      >
+        {automatedComplete && (
+          <p className="text-sm opacity-70">Placeholder logo, icon and banner added.</p>
+        )}
+      </ChecklistItem>
 
       <div className="mt-3 border-0 border-t border-solid border-t-[var(--theme-border-color)] pt-3">
         <h4 className="mb-2">Needs action</h4>

--- a/src/collections/Tenants/components/OnboardingChecklist.tsx
+++ b/src/collections/Tenants/components/OnboardingChecklist.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { Button, toast, useDocumentInfo, useForm } from '@payloadcms/ui'
-import { CheckCircle2, Circle, Loader2 } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, Circle, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 
+import { formatDate } from 'date-fns/format'
 import { useCallback, useEffect, useState } from 'react'
 import { needsProvisioning } from './needsProvisioning'
 import {
@@ -13,29 +14,24 @@ import {
 } from './onboardingActions'
 
 const DEFAULT_STATUS: ProvisioningStatus = {
-  forecastPages: { count: 0, expected: 0 },
-  defaultBuiltInPages: { count: 0, expected: 0 },
-  pages: { created: 0, expected: 0, missing: [] },
-  homePage: false,
-  navigation: false,
-  settings: { exists: false, id: undefined },
+  status: 'not_started',
+  lastRunAt: null,
+  failed: {},
   theme: { brandColors: false, ogColors: false },
+  tenantCreatedAt: null,
+  settings: { id: undefined },
 }
 
 function ChecklistItem({
   loading,
   done,
   label,
-  details,
   children,
-  action,
 }: {
   loading?: boolean
   done: boolean
   label: string
-  details?: React.ReactNode
   children?: React.ReactNode
-  action?: React.ReactNode
 }) {
   const isRunning = loading && !done
 
@@ -56,9 +52,7 @@ function ChecklistItem({
             <Circle size={20} className="shrink-0 text-muted-foreground" />
           )}
           <span className={done ? 'opacity-70' : ''}>{label}</span>
-          {!isRunning && details && <span className="text-sm opacity-50">{details}</span>}
         </div>
-        {!isRunning && action && <div>{action}</div>}
       </div>
       {!isRunning && children && <div className="ml-9 mt-1 text-sm opacity-50">{children}</div>}
     </div>
@@ -70,9 +64,9 @@ export function OnboardingChecklist() {
   const { setProcessing } = useForm()
   const [status, setStatus] = useState<ProvisioningStatus>(DEFAULT_STATUS)
   const [loaded, setLoaded] = useState(false)
-  const [isProvisioning, setIsProvisioning] = useState(false)
 
   const tenantId = data?.id
+  const isProvisioning = status.status === 'in_progress'
 
   const checkStatus = useCallback(async () => {
     if (!tenantId) return null
@@ -94,29 +88,18 @@ export function OnboardingChecklist() {
   const handleProvision = useCallback(async () => {
     if (!tenantId || isProvisioning) return
 
-    setIsProvisioning(true)
+    // Optimistically mirror the in_progress state the server is about to write
+    // so the UI flips to the spinner immediately instead of waiting for the
+    // action to return.
+    setStatus((s) => ({ ...s, status: 'in_progress' }))
     setProcessing(true)
 
     toast.promise(
-      new Promise((resolve, reject) => {
-        runProvisionAction(tenantId)
-          .then(async (result) => {
-            if ('error' in result) {
-              setIsProvisioning(false)
-              setProcessing(false)
-              reject(result.error)
-              return
-            }
-            await checkStatus()
-            setIsProvisioning(false)
-            setProcessing(false)
-            resolve(result)
-          })
-          .catch((err) => {
-            setIsProvisioning(false)
-            setProcessing(false)
-            reject(err)
-          })
+      runProvisionAction(tenantId).then(async (result) => {
+        await checkStatus()
+        setProcessing(false)
+        if ('error' in result) throw new Error(result.error)
+        return result
       }),
       {
         loading: 'Building avy center...',
@@ -136,122 +119,153 @@ export function OnboardingChecklist() {
         return
       }
 
+      setStatus(result.status)
+      setLoaded(true)
+
       if (needsProvisioning(result.status)) {
-        setIsProvisioning(true)
         handleProvision()
-      } else {
-        setStatus(result.status)
-        setLoaded(true)
       }
     })
   }, [tenantId]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const { forecastPages, defaultBuiltInPages, pages, homePage, navigation, settings, theme } =
-    status
-
-  const automatedComplete =
-    forecastPages.count >= forecastPages.expected &&
-    defaultBuiltInPages.count >= defaultBuiltInPages.expected &&
-    pages.created >= pages.expected &&
-    pages.expected > 0 &&
-    homePage &&
-    navigation &&
-    settings.exists
+  const { theme } = status
+  // On the create view there's no tenant yet — skip the initial load spinner
+  // and render the placeholder checklist so users can see what will happen.
+  const showInitialLoader = Boolean(tenantId) && !loaded
+  const showChecklist = !tenantId || loaded
+  const showPlaceholders = status.status === 'not_started' || status.status === 'in_progress'
 
   return (
     <div className="rounded-lg border-solid border-[var(--theme-border-color)] p-6">
       <h3 className="mb-4">Onboarding Checklist</h3>
 
-      <div className="flex items-center justify-between mb-2">
-        <h4>Automated</h4>
-        {loaded && !automatedComplete && (
-          <Button className="m-0" onClick={handleProvision} disabled={isProvisioning} size="medium">
-            {isProvisioning ? 'Provisioning...' : 'Rerun Provisioning'}
-          </Button>
-        )}
-      </div>
+      {/* Initial load — waiting for checkProvisioningStatusAction to return */}
+      {showInitialLoader && (
+        <div className="py-4 flex items-center gap-3">
+          <Loader2
+            data-testid="spinner"
+            size={20}
+            className="shrink-0"
+            style={{ animation: 'spin 1s linear infinite', color: 'var(--theme-text)' }}
+          />
+          <span className="opacity-70">Loading...</span>
+        </div>
+      )}
 
-      <ChecklistItem
-        loading={isProvisioning}
-        done={loaded && forecastPages.count >= forecastPages.expected}
-        label="Forecast Built-In pages"
-        details={loaded && `(${forecastPages.count}/${forecastPages.expected})`}
-      >
-        {automatedComplete && (
-          <p className="text-sm opacity-70">
-            Forecast built-ins are automatically based on NAC zones.
-          </p>
-        )}
-      </ChecklistItem>
-      <ChecklistItem
-        loading={isProvisioning}
-        done={loaded && defaultBuiltInPages.count >= defaultBuiltInPages.expected}
-        label="Default Built-In pages"
-        details={loaded && `(${defaultBuiltInPages.count}/${defaultBuiltInPages.expected})`}
-      ></ChecklistItem>
-      <ChecklistItem
-        loading={isProvisioning}
-        done={pages.created >= pages.expected && pages.expected > 0}
-        label="Pages"
-        details={loaded && `(${pages.created}/${pages.expected})`}
-      >
-        {automatedComplete && (
-          <p className="text-sm opacity-70">
-            Blank pages are created using DVACs navigation structure.
-          </p>
-        )}
-        {pages.missing.length > 0 && <div>Missing: {pages.missing.join(', ')}</div>}
-      </ChecklistItem>
-
-      <ChecklistItem loading={isProvisioning} done={homePage} label="Home page" />
-      <ChecklistItem loading={isProvisioning} done={navigation} label="Navigation" />
-      <ChecklistItem
-        loading={isProvisioning}
-        done={settings.exists}
-        label="Website Settings"
-        action={
-          settings.id && (
-            <Link href={`/admin/collections/settings/${settings.id}`} className="text-sm">
-              Update Brand Assets
-            </Link>
-          )
-        }
-      >
-        {automatedComplete && (
-          <p className="text-sm opacity-70">Placeholder logo, icon and banner added.</p>
-        )}
-      </ChecklistItem>
-
-      <div className="mt-3 border-0 border-t border-solid border-t-[var(--theme-border-color)] pt-3">
-        <h4 className="mb-2">Needs action</h4>
-
-        <ChecklistItem loading={isProvisioning} done={theme.brandColors} label="Add brand colors">
-          {loaded && !theme.brandColors && (
-            <span>
-              Add slug to <code>colors.css</code> — see{' '}
-              <Link
-                href="https://github.com/NWACus/web/blob/main/docs/onboarding.md#theme"
-                target="_blank"
-              >
-                docs/onboarding.md
-              </Link>
-            </span>
+      {/* Header section — shown once provisioning has run at least once */}
+      {showChecklist && (status.status === 'complete' || status.status === 'partial') && (
+        <div className="mb-4 pb-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              {status.status === 'complete' ? (
+                <>
+                  <CheckCircle2 size={20} className="shrink-0 text-success" />
+                  <span>Complete</span>
+                </>
+              ) : (
+                <>
+                  <AlertTriangle size={20} className="shrink-0 text-warning" />
+                  <span>Failed</span>
+                </>
+              )}
+            </div>
+            <Button
+              className="m-0"
+              onClick={handleProvision}
+              disabled={isProvisioning}
+              size="medium"
+              buttonStyle="secondary"
+            >
+              Rerun
+            </Button>
+          </div>
+          {status.status === 'partial' && (
+            <div className="text-sm ml-9 mb-4 space-y-2">
+              {status.failed.timedOut && <div className="opacity-70">{status.failed.timedOut}</div>}
+              {status.failed.websiteSettings && (
+                <div className="opacity-70">Website settings failed to provision.</div>
+              )}
+              {status.failed.homePage && (
+                <div className="opacity-70">Home page failed to provision.</div>
+              )}
+              {status.failed.navigation && (
+                <div className="opacity-70">Navigation failed to provision.</div>
+              )}
+              {status.failed.pages && Object.keys(status.failed.pages).length > 0 && (
+                <div>
+                  <div className="font-semibold opacity-80">Missing pages:</div>
+                  <ul className="list-disc pl-5 opacity-70">
+                    {Object.keys(status.failed.pages).map((name) => (
+                      <li key={name}>{name}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
           )}
-        </ChecklistItem>
-        <ChecklistItem loading={isProvisioning} done={theme.ogColors} label="Add OG image colors">
-          {loaded && !theme.ogColors && (
-            <span>
-              Add slug to <code>centerColorMap</code> — see{' '}
-              <Link
-                href="https://github.com/NWACus/web/blob/main/docs/onboarding.md#theme"
-                target="_blank"
-              >
-                docs/onboarding.md
-              </Link>
-            </span>
+        </div>
+      )}
+
+      {/* Manual steps — always visible as a nag until configured */}
+      {showChecklist && (
+        <div className="mt-3 border-0 border-t border-solid border-t-[var(--theme-border-color)] pt-3">
+          <h4 className="mb-2">Needs action</h4>
+
+          {showPlaceholders && (
+            <>
+              <ChecklistItem loading={isProvisioning} done={false} label="Home page" />
+              <ChecklistItem loading={isProvisioning} done={false} label="Pages" />
+              <ChecklistItem loading={isProvisioning} done={false} label="Navigation" />
+              <ChecklistItem loading={isProvisioning} done={false} label="Website Settings" />
+            </>
           )}
-        </ChecklistItem>
-      </div>
+          {status.settings.id && (
+            <ChecklistItem
+              loading={isProvisioning}
+              done={theme.brandColors}
+              label="Update Brand Assets"
+            >
+              <div className="mt-2 text-md">
+                Change avy center logo & info in{' '}
+                <Link href={`/admin/collections/settings/${status.settings.id}`}>Settings</Link>
+              </div>
+            </ChecklistItem>
+          )}
+
+          <ChecklistItem loading={isProvisioning} done={theme.brandColors} label="Add brand colors">
+            {!theme.brandColors && (
+              <span>
+                Add slug to <code>colors.css</code> — see{' '}
+                <Link
+                  href="https://github.com/NWACus/web/blob/main/docs/onboarding.md#theme"
+                  target="_blank"
+                >
+                  docs/onboarding.md
+                </Link>
+              </span>
+            )}
+          </ChecklistItem>
+          <ChecklistItem loading={isProvisioning} done={theme.ogColors} label="Add OG image colors">
+            {!theme.ogColors && (
+              <span>
+                Add slug to <code>centerColorMap</code> — see{' '}
+                <Link
+                  href="https://github.com/NWACus/web/blob/main/docs/onboarding.md#theme"
+                  target="_blank"
+                >
+                  docs/onboarding.md
+                </Link>
+              </span>
+            )}
+          </ChecklistItem>
+          {(status.status === 'complete' || status.status === 'partial') && (
+            <div className="mt-3 border-0 border-t border-solid border-t-[var(--theme-border-color)] pt-4 text-sm opacity-70">
+              <strong>Last provisioned:</strong>&nbsp;
+              {status.lastRunAt && formatDate(status.lastRunAt, 'PPpp')}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/collections/Tenants/components/OnboardingChecklist.tsx
+++ b/src/collections/Tenants/components/OnboardingChecklist.tsx
@@ -238,25 +238,6 @@ export function OnboardingChecklist() {
               <ChecklistItem loading={isProvisioning} done={false} label="Website Settings" />
             </>
           )}
-          {status.settings.id && (
-            <ChecklistItem
-              loading={isProvisioning}
-              done={theme.brandColors}
-              label="Update Brand Assets"
-            >
-              <div className="mt-2 text-md">
-                Change avy center logo & info in{' '}
-                <Link
-                  href={`/admin/collections/settings/${status.settings.id}`}
-                  onClick={() => {
-                    setTenant({ slug: data?.slug }) // Switch selected tenant to avoid redirect
-                  }}
-                >
-                  Settings
-                </Link>
-              </div>
-            </ChecklistItem>
-          )}
 
           <ChecklistItem loading={isProvisioning} done={theme.brandColors} label="Add brand colors">
             {!theme.brandColors && (
@@ -284,6 +265,19 @@ export function OnboardingChecklist() {
               </span>
             )}
           </ChecklistItem>
+          {status.settings.id && (
+            <div className="py-2  opacity-70">
+              Update avy center brand assets & info in{' '}
+              <Link
+                href={`/admin/collections/settings/${status.settings.id}`}
+                onClick={() => {
+                  setTenant({ slug: data?.slug }) // Switch selected tenant to avoid redirect
+                }}
+              >
+                Website Settings
+              </Link>
+            </div>
+          )}
           {(status.status === 'complete' ||
             status.status === 'partial' ||
             status.status === 'manual') && (

--- a/src/collections/Tenants/components/OnboardingChecklist.tsx
+++ b/src/collections/Tenants/components/OnboardingChecklist.tsx
@@ -4,6 +4,7 @@ import { Button, toast, useDocumentInfo, useForm } from '@payloadcms/ui'
 import { AlertTriangle, CheckCircle2, Circle, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 
+import { useTenantSelection } from '@/providers/TenantSelectionProvider/index.client'
 import { formatDate } from 'date-fns/format'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { needsProvisioning } from './needsProvisioning'
@@ -62,6 +63,7 @@ function ChecklistItem({
 export function OnboardingChecklist() {
   const { data } = useDocumentInfo()
   const { setProcessing } = useForm()
+  const { setTenant } = useTenantSelection()
   const [status, setStatus] = useState<ProvisioningStatus>(DEFAULT_STATUS)
   const [loaded, setLoaded] = useState(false)
   // Refs persist across React 18 StrictMode's double-mount, so we use them to
@@ -234,7 +236,14 @@ export function OnboardingChecklist() {
             >
               <div className="mt-2 text-md">
                 Change avy center logo & info in{' '}
-                <Link href={`/admin/collections/settings/${status.settings.id}`}>Settings</Link>
+                <Link
+                  href={`/admin/collections/settings/${status.settings.id}`}
+                  onClick={() => {
+                    setTenant({ slug: data?.slug }) // Switch selected tenant to avoid redirect
+                  }}
+                >
+                  Settings
+                </Link>
               </div>
             </ChecklistItem>
           )}

--- a/src/collections/Tenants/components/OnboardingChecklist.tsx
+++ b/src/collections/Tenants/components/OnboardingChecklist.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, CheckCircle2, Circle, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 
 import { formatDate } from 'date-fns/format'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { needsProvisioning } from './needsProvisioning'
 import {
   checkProvisioningStatusAction,
@@ -64,6 +64,10 @@ export function OnboardingChecklist() {
   const { setProcessing } = useForm()
   const [status, setStatus] = useState<ProvisioningStatus>(DEFAULT_STATUS)
   const [loaded, setLoaded] = useState(false)
+  // Refs persist across React 18 StrictMode's double-mount, so we use them to
+  // ensure the auto-provision path fires at most once per tenantId even if
+  // the effect body runs twice in dev.
+  const autoProvisionAttempted = useRef<number | string | null>(null)
 
   const tenantId = data?.id
   const isProvisioning = status.status === 'in_progress'
@@ -109,7 +113,9 @@ export function OnboardingChecklist() {
     )
   }, [tenantId, isProvisioning, checkStatus, setProcessing])
 
-  // On mount: check status and auto-provision only for brand new tenants
+  // On mount: check status and auto-provision only for brand new tenants.
+  // The ref-based guard ensures the auto-provision call fires at most once
+  // per tenantId
   useEffect(() => {
     if (!tenantId) return
 
@@ -122,7 +128,8 @@ export function OnboardingChecklist() {
       setStatus(result.status)
       setLoaded(true)
 
-      if (needsProvisioning(result.status)) {
+      if (needsProvisioning(result.status) && autoProvisionAttempted.current !== tenantId) {
+        autoProvisionAttempted.current = tenantId
         handleProvision()
       }
     })

--- a/src/collections/Tenants/components/OnboardingChecklist.tsx
+++ b/src/collections/Tenants/components/OnboardingChecklist.tsx
@@ -162,58 +162,68 @@ export function OnboardingChecklist() {
       )}
 
       {/* Header section — shown once provisioning has run at least once */}
-      {showChecklist && (status.status === 'complete' || status.status === 'partial') && (
-        <div className="mb-4 pb-3">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              {status.status === 'complete' ? (
-                <>
-                  <CheckCircle2 size={20} className="shrink-0 text-success" />
-                  <span>Complete</span>
-                </>
-              ) : (
-                <>
-                  <AlertTriangle size={20} className="shrink-0 text-warning" />
-                  <span>Failed</span>
-                </>
-              )}
+      {showChecklist &&
+        (status.status === 'complete' ||
+          status.status === 'partial' ||
+          status.status === 'manual') && (
+          <div className="mb-4 pb-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                {status.status === 'complete' ? (
+                  <>
+                    <CheckCircle2 size={20} className="shrink-0 text-success" />
+                    <span>Complete</span>
+                  </>
+                ) : status.status === 'manual' ? (
+                  <>
+                    <AlertTriangle size={20} className="shrink-0 text-warning" />
+                    <span>Complete manual actions</span>
+                  </>
+                ) : (
+                  <>
+                    <AlertTriangle size={20} className="shrink-0 text-warning" />
+                    <span>Failed</span>
+                  </>
+                )}
+              </div>
+              <Button
+                className="m-0"
+                onClick={handleProvision}
+                disabled={isProvisioning}
+                size="medium"
+                buttonStyle="secondary"
+              >
+                Rerun
+              </Button>
             </div>
-            <Button
-              className="m-0"
-              onClick={handleProvision}
-              disabled={isProvisioning}
-              size="medium"
-              buttonStyle="secondary"
-            >
-              Rerun
-            </Button>
+            {status.status === 'partial' && (
+              <div className="text-sm ml-9 mb-4 space-y-2">
+                {status.failed.timedOut && (
+                  <div className="opacity-70">{status.failed.timedOut}</div>
+                )}
+                {status.failed.websiteSettings && (
+                  <div className="opacity-70">Website settings failed to provision.</div>
+                )}
+                {status.failed.homePage && (
+                  <div className="opacity-70">Home page failed to provision.</div>
+                )}
+                {status.failed.navigation && (
+                  <div className="opacity-70">Navigation failed to provision.</div>
+                )}
+                {status.failed.pages && Object.keys(status.failed.pages).length > 0 && (
+                  <div>
+                    <div className="font-semibold opacity-80">Missing pages:</div>
+                    <ul className="list-disc pl-5 opacity-70">
+                      {Object.keys(status.failed.pages).map((name) => (
+                        <li key={name}>{name}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
-          {status.status === 'partial' && (
-            <div className="text-sm ml-9 mb-4 space-y-2">
-              {status.failed.timedOut && <div className="opacity-70">{status.failed.timedOut}</div>}
-              {status.failed.websiteSettings && (
-                <div className="opacity-70">Website settings failed to provision.</div>
-              )}
-              {status.failed.homePage && (
-                <div className="opacity-70">Home page failed to provision.</div>
-              )}
-              {status.failed.navigation && (
-                <div className="opacity-70">Navigation failed to provision.</div>
-              )}
-              {status.failed.pages && Object.keys(status.failed.pages).length > 0 && (
-                <div>
-                  <div className="font-semibold opacity-80">Missing pages:</div>
-                  <ul className="list-disc pl-5 opacity-70">
-                    {Object.keys(status.failed.pages).map((name) => (
-                      <li key={name}>{name}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      )}
+        )}
 
       {/* Manual steps — always visible as a nag until configured */}
       {showChecklist && (
@@ -274,7 +284,9 @@ export function OnboardingChecklist() {
               </span>
             )}
           </ChecklistItem>
-          {(status.status === 'complete' || status.status === 'partial') && (
+          {(status.status === 'complete' ||
+            status.status === 'partial' ||
+            status.status === 'manual') && (
             <div className="mt-3 border-0 border-t border-solid border-t-[var(--theme-border-color)] pt-4 text-sm opacity-70">
               <strong>Last provisioned:</strong>&nbsp;
               {status.lastRunAt && formatDate(status.lastRunAt, 'PPpp')}

--- a/src/collections/Tenants/components/OnboardingChecklist.tsx
+++ b/src/collections/Tenants/components/OnboardingChecklist.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, CheckCircle2, Circle, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 
 import { useTenantSelection } from '@/providers/TenantSelectionProvider/index.client'
+import { Label } from '@radix-ui/react-label'
 import { formatDate } from 'date-fns/format'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { needsProvisioning } from './needsProvisioning'
@@ -145,149 +146,163 @@ export function OnboardingChecklist() {
   const showPlaceholders = status.status === 'not_started' || status.status === 'in_progress'
 
   return (
-    <div className="rounded-lg border-solid border-[var(--theme-border-color)] p-6">
-      <h3 className="mb-4">Onboarding Checklist</h3>
+    <>
+      <div className="rounded-lg border-solid border-[var(--theme-border-color)] p-6">
+        <h3 className="mb-4">Onboarding Checklist</h3>
 
-      {/* Initial load — waiting for checkProvisioningStatusAction to return */}
-      {showInitialLoader && (
-        <div className="py-4 flex items-center gap-3">
-          <Loader2
-            data-testid="spinner"
-            size={20}
-            className="shrink-0"
-            style={{ animation: 'spin 1s linear infinite', color: 'var(--theme-text)' }}
-          />
-          <span className="opacity-70">Loading...</span>
-        </div>
-      )}
+        {showInitialLoader && (
+          <div className="py-4 flex items-center gap-3">
+            <Loader2
+              data-testid="spinner"
+              size={20}
+              className="shrink-0"
+              style={{ animation: 'spin 1s linear infinite', color: 'var(--theme-text)' }}
+            />
+            <span className="opacity-70">Loading...</span>
+          </div>
+        )}
 
-      {/* Header section — shown once provisioning has run at least once */}
-      {showChecklist &&
-        (status.status === 'complete' ||
-          status.status === 'partial' ||
-          status.status === 'manual') && (
-          <div className="mb-4 pb-3">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                {status.status === 'complete' ? (
-                  <>
-                    <CheckCircle2 size={20} className="shrink-0 text-success" />
-                    <span>Complete</span>
-                  </>
-                ) : status.status === 'manual' ? (
-                  <>
-                    <AlertTriangle size={20} className="shrink-0 text-warning" />
-                    <span>Complete manual actions</span>
-                  </>
-                ) : (
-                  <>
-                    <AlertTriangle size={20} className="shrink-0 text-warning" />
-                    <span>Failed</span>
-                  </>
-                )}
+        {/* Header section — shown once provisioning has run at least once */}
+        {showChecklist &&
+          (status.status === 'complete' ||
+            status.status === 'partial' ||
+            status.status === 'manual') && (
+            <div className="mb-4 pb-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  {status.status === 'complete' ? (
+                    <>
+                      <CheckCircle2 size={20} className="shrink-0 text-success" />
+                      <span>Complete</span>
+                    </>
+                  ) : status.status === 'manual' ? (
+                    <>
+                      <CheckCircle2 size={20} className="shrink-0 text-success" />
+                      <span>Complete — manual actions remaining</span>
+                    </>
+                  ) : (
+                    <>
+                      <AlertTriangle size={20} className="shrink-0 text-warning" />
+                      <span>Failed</span>
+                    </>
+                  )}
+                </div>
               </div>
-              <Button
-                className="m-0"
-                onClick={handleProvision}
-                disabled={isProvisioning}
-                size="medium"
-                buttonStyle="secondary"
-              >
-                Rerun
-              </Button>
+              {status.status === 'partial' && (
+                <div className="text-sm ml-9 mb-4 space-y-2">
+                  {status.failed.timedOut && (
+                    <div className="opacity-70">{status.failed.timedOut}</div>
+                  )}
+                  {status.failed.websiteSettings && (
+                    <div className="opacity-70">Website settings failed to provision.</div>
+                  )}
+                  {status.failed.homePage && (
+                    <div className="opacity-70">Home page failed to provision.</div>
+                  )}
+                  {status.failed.navigation && (
+                    <div className="opacity-70">Navigation failed to provision.</div>
+                  )}
+                  {status.failed.pages && Object.keys(status.failed.pages).length > 0 && (
+                    <div>
+                      <div className="font-semibold opacity-80">Missing pages:</div>
+                      <ul className="list-disc pl-5 opacity-70">
+                        {Object.keys(status.failed.pages).map((name) => (
+                          <li key={name}>{name}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
-            {status.status === 'partial' && (
-              <div className="text-sm ml-9 mb-4 space-y-2">
-                {status.failed.timedOut && (
-                  <div className="opacity-70">{status.failed.timedOut}</div>
-                )}
-                {status.failed.websiteSettings && (
-                  <div className="opacity-70">Website settings failed to provision.</div>
-                )}
-                {status.failed.homePage && (
-                  <div className="opacity-70">Home page failed to provision.</div>
-                )}
-                {status.failed.navigation && (
-                  <div className="opacity-70">Navigation failed to provision.</div>
-                )}
-                {status.failed.pages && Object.keys(status.failed.pages).length > 0 && (
-                  <div>
-                    <div className="font-semibold opacity-80">Missing pages:</div>
-                    <ul className="list-disc pl-5 opacity-70">
-                      {Object.keys(status.failed.pages).map((name) => (
-                        <li key={name}>{name}</li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
+          )}
+
+        {/* Manual steps — always visible as a nag until configured */}
+        {showChecklist && (
+          <div className="mt-3 border-0 border-t border-solid border-t-[var(--theme-border-color)] pt-3">
+            <h4 className="mb-2">Needs action</h4>
+
+            {showPlaceholders && (
+              <>
+                <ChecklistItem loading={isProvisioning} done={false} label="Home page" />
+                <ChecklistItem loading={isProvisioning} done={false} label="Pages" />
+                <ChecklistItem loading={isProvisioning} done={false} label="Navigation" />
+                <ChecklistItem loading={isProvisioning} done={false} label="Website Settings" />
+              </>
+            )}
+
+            <ChecklistItem
+              loading={isProvisioning}
+              done={theme.brandColors}
+              label="Add brand colors"
+            >
+              {!theme.brandColors && (
+                <span>
+                  Add slug to <code>colors.css</code> — see{' '}
+                  <Link
+                    href="https://github.com/NWACus/web/blob/main/docs/onboarding.md#theme"
+                    target="_blank"
+                  >
+                    docs/onboarding.md
+                  </Link>
+                </span>
+              )}
+            </ChecklistItem>
+            <ChecklistItem
+              loading={isProvisioning}
+              done={theme.ogColors}
+              label="Add OG image colors"
+            >
+              {!theme.ogColors && (
+                <span>
+                  Add slug to <code>centerColorMap</code> — see{' '}
+                  <Link
+                    href="https://github.com/NWACus/web/blob/main/docs/onboarding.md#theme"
+                    target="_blank"
+                  >
+                    docs/onboarding.md
+                  </Link>
+                </span>
+              )}
+            </ChecklistItem>
+            {status.settings.id && (
+              <div className="py-2  opacity-70">
+                Update avy center brand assets & info in{' '}
+                <Link
+                  href={`/admin/collections/settings/${status.settings.id}`}
+                  onClick={() => {
+                    setTenant({ slug: data?.slug }) // Switch selected tenant to avoid redirect
+                  }}
+                >
+                  Website Settings
+                </Link>
+              </div>
+            )}
+            {(status.status === 'complete' ||
+              status.status === 'partial' ||
+              status.status === 'manual') && (
+              <div className="mt-3 border-0 border-t border-solid border-t-[var(--theme-border-color)] pt-4 text-sm opacity-70">
+                <strong>Last provisioned:</strong>&nbsp;
+                {status.lastRunAt && formatDate(status.lastRunAt, 'PPpp')}
               </div>
             )}
           </div>
         )}
-
-      {/* Manual steps — always visible as a nag until configured */}
-      {showChecklist && (
-        <div className="mt-3 border-0 border-t border-solid border-t-[var(--theme-border-color)] pt-3">
-          <h4 className="mb-2">Needs action</h4>
-
-          {showPlaceholders && (
-            <>
-              <ChecklistItem loading={isProvisioning} done={false} label="Home page" />
-              <ChecklistItem loading={isProvisioning} done={false} label="Pages" />
-              <ChecklistItem loading={isProvisioning} done={false} label="Navigation" />
-              <ChecklistItem loading={isProvisioning} done={false} label="Website Settings" />
-            </>
-          )}
-
-          <ChecklistItem loading={isProvisioning} done={theme.brandColors} label="Add brand colors">
-            {!theme.brandColors && (
-              <span>
-                Add slug to <code>colors.css</code> — see{' '}
-                <Link
-                  href="https://github.com/NWACus/web/blob/main/docs/onboarding.md#theme"
-                  target="_blank"
-                >
-                  docs/onboarding.md
-                </Link>
-              </span>
-            )}
-          </ChecklistItem>
-          <ChecklistItem loading={isProvisioning} done={theme.ogColors} label="Add OG image colors">
-            {!theme.ogColors && (
-              <span>
-                Add slug to <code>centerColorMap</code> — see{' '}
-                <Link
-                  href="https://github.com/NWACus/web/blob/main/docs/onboarding.md#theme"
-                  target="_blank"
-                >
-                  docs/onboarding.md
-                </Link>
-              </span>
-            )}
-          </ChecklistItem>
-          {status.settings.id && (
-            <div className="py-2  opacity-70">
-              Update avy center brand assets & info in{' '}
-              <Link
-                href={`/admin/collections/settings/${status.settings.id}`}
-                onClick={() => {
-                  setTenant({ slug: data?.slug }) // Switch selected tenant to avoid redirect
-                }}
-              >
-                Website Settings
-              </Link>
-            </div>
-          )}
-          {(status.status === 'complete' ||
-            status.status === 'partial' ||
-            status.status === 'manual') && (
-            <div className="mt-3 border-0 border-t border-solid border-t-[var(--theme-border-color)] pt-4 text-sm opacity-70">
-              <strong>Last provisioned:</strong>&nbsp;
-              {status.lastRunAt && formatDate(status.lastRunAt, 'PPpp')}
-            </div>
-          )}
+      </div>
+      {showChecklist && status.status !== 'in_progress' && status.status !== 'not_started' && (
+        <div className="flex items-center justify-between mt-5">
+          <Label>Something not right?</Label>
+          <Button
+            className="m-0"
+            onClick={handleProvision}
+            disabled={isProvisioning}
+            size="medium"
+            buttonStyle="secondary"
+          >
+            Rerun provisioning
+          </Button>
         </div>
       )}
-    </div>
+    </>
   )
 }

--- a/src/collections/Tenants/components/OnboardingStatusCell.tsx
+++ b/src/collections/Tenants/components/OnboardingStatusCell.tsx
@@ -16,10 +16,12 @@ export async function OnboardingStatusCell({
     return null
   }
 
-  const { builtInPages, pages, homePage, navigation, settings } = result.status
+  const { forecastPages, defaultBuiltInPages, pages, homePage, navigation, settings } =
+    result.status
 
   const allComplete =
-    builtInPages.count >= builtInPages.expected &&
+    forecastPages.count >= forecastPages.expected &&
+    defaultBuiltInPages.count >= defaultBuiltInPages.expected &&
     pages.created >= pages.expected &&
     pages.expected > 0 &&
     homePage &&

--- a/src/collections/Tenants/components/OnboardingStatusCell.tsx
+++ b/src/collections/Tenants/components/OnboardingStatusCell.tsx
@@ -1,40 +1,22 @@
 import { Pill } from '@payloadcms/ui'
 import type { DefaultServerCellComponentProps } from 'payload'
 
-import { checkProvisioningStatusAction } from './onboardingActions'
-
-export async function OnboardingStatusCell({
+export function OnboardingStatusCell({
   rowData,
 }: Pick<DefaultServerCellComponentProps, 'rowData'>) {
-  if (!rowData?.id) {
-    return null
-  }
-
-  const result = await checkProvisioningStatusAction(rowData.id)
-
-  if ('error' in result) {
-    return null
-  }
-
-  const { forecastPages, defaultBuiltInPages, pages, homePage, navigation, settings } =
-    result.status
-
-  const allComplete =
-    forecastPages.count >= forecastPages.expected &&
-    defaultBuiltInPages.count >= defaultBuiltInPages.expected &&
-    pages.created >= pages.expected &&
-    pages.expected > 0 &&
-    homePage &&
-    navigation &&
-    settings.exists &&
-    result.status.theme.brandColors &&
-    result.status.theme.ogColors
-
-  return allComplete ? (
-    <Pill size="small">Complete</Pill>
-  ) : (
-    <Pill size="small" pillStyle="warning">
-      Incomplete
-    </Pill>
-  )
+  const status = rowData?.provisioning?.status
+  if (status === 'complete')
+    return (
+      <Pill size="small" pillStyle="success">
+        Complete
+      </Pill>
+    )
+  if (status === 'partial')
+    return (
+      <Pill size="small" pillStyle="warning">
+        Partial
+      </Pill>
+    )
+  if (status === 'in_progress') return <Pill size="small">In progress</Pill>
+  return <Pill size="small">Not started</Pill>
 }

--- a/src/collections/Tenants/components/OnboardingStatusCell.tsx
+++ b/src/collections/Tenants/components/OnboardingStatusCell.tsx
@@ -17,6 +17,12 @@ export function OnboardingStatusCell({
         Partial
       </Pill>
     )
+  if (status === 'manual')
+    return (
+      <Pill size="small" pillStyle="warning">
+        Manual actions
+      </Pill>
+    )
   if (status === 'in_progress') return <Pill size="small">In progress</Pill>
   return <Pill size="small">Not started</Pill>
 }

--- a/src/collections/Tenants/components/needsProvisioning.ts
+++ b/src/collections/Tenants/components/needsProvisioning.ts
@@ -5,8 +5,13 @@ import type { ProvisioningStatus } from './onboardingActions'
  * Used to auto-provision on creation without auto-triggering on existing incomplete tenants.
  */
 export function needsProvisioning(status: ProvisioningStatus): boolean {
-  const { builtInPages, pages, homePage, navigation, settings } = status
+  const { forecastPages, defaultBuiltInPages, pages, homePage, navigation, settings } = status
   return (
-    builtInPages.count === 0 && pages.created === 0 && !homePage && !navigation && !settings.exists
+    forecastPages.count === 0 &&
+    defaultBuiltInPages.count === 0 &&
+    pages.created === 0 &&
+    !homePage &&
+    !navigation &&
+    !settings.exists
   )
 }

--- a/src/collections/Tenants/components/needsProvisioning.ts
+++ b/src/collections/Tenants/components/needsProvisioning.ts
@@ -1,17 +1,13 @@
 import type { ProvisioningStatus } from './onboardingActions'
 
 /**
- * Returns true only when no provisioning has ever been done (brand new tenant).
- * Used to auto-provision on creation without auto-triggering on existing incomplete tenants.
+ * Returns true only when provisioning has never been run (brand new tenant).
+ * Used to auto-provision on creation without auto-triggering on tenants whose
+ * provisioning already completed or partially ran.
+ *
+ * Kept in its own file (not in onboardingActions.ts) so tests can import it
+ * without pulling in the 'use server' module's Payload-config chain.
  */
 export function needsProvisioning(status: ProvisioningStatus): boolean {
-  const { forecastPages, defaultBuiltInPages, pages, homePage, navigation, settings } = status
-  return (
-    forecastPages.count === 0 &&
-    defaultBuiltInPages.count === 0 &&
-    pages.created === 0 &&
-    !homePage &&
-    !navigation &&
-    !settings.exists
-  )
+  return status.status === 'not_started'
 }

--- a/src/collections/Tenants/components/onboardingActions.ts
+++ b/src/collections/Tenants/components/onboardingActions.ts
@@ -12,7 +12,7 @@ import path from 'path'
 import { getPayload } from 'payload'
 
 export type ProvisioningStatus = {
-  forecastPages: { count: number; expected: number; zoneCount: number }
+  forecastPages: { count: number; expected: number }
   defaultBuiltInPages: { count: number; expected: number }
   pages: { created: number; expected: number; missing: string[] }
   homePage: boolean
@@ -120,11 +120,8 @@ export async function checkProvisioningStatusAction(
       templatePageSlugs = templatePages.docs.map((p) => ({ slug: p.slug, title: p.title }))
     }
 
-    const {
-      forecastPages: expectedForecastPages,
-      nonForecastPages: expectedNonForecastPages,
-      zoneCount,
-    } = await resolveBuiltInPages(tenant.slug, navBuiltInPages, payload.logger)
+    const { forecastPages: expectedForecastPages, nonForecastPages: expectedNonForecastPages } =
+      await resolveBuiltInPages(tenant.slug, navBuiltInPages, payload.logger)
 
     const tenantForecastPageCount = builtInPages.docs.filter((p) =>
       p.url.startsWith('/forecasts/avalanche'),
@@ -142,7 +139,6 @@ export async function checkProvisioningStatusAction(
         forecastPages: {
           count: tenantForecastPageCount,
           expected: expectedForecastPages.length,
-          zoneCount,
         },
         defaultBuiltInPages: {
           count: tenantDefaultPageCount,

--- a/src/collections/Tenants/components/onboardingActions.ts
+++ b/src/collections/Tenants/components/onboardingActions.ts
@@ -1,11 +1,7 @@
 'use server'
 
 import { centerColorMap } from '@/app/api/[center]/og/centerColorMap'
-import {
-  BUILT_IN_PAGES,
-  extractNavReferences,
-  provision,
-} from '@/collections/Tenants/endpoints/provisionTenant'
+import { extractNavReferences, provision } from '@/collections/Tenants/endpoints/provisionTenant'
 import config from '@payload-config'
 import fs from 'fs/promises'
 import path from 'path'
@@ -99,7 +95,6 @@ export async function checkProvisioningStatusAction(
         })
         .then((res) => res.docs[0])
 
-      // TODO: Use builtInPageUrls to filter expected built-in page count #999
       const { pageSlugs: navPageSlugs } = extractNavReferences(templateNav ?? {})
 
       const templatePages = await payload.find({
@@ -115,14 +110,15 @@ export async function checkProvisioningStatusAction(
       templatePageSlugs = templatePages.docs.map((p) => ({ slug: p.slug, title: p.title }))
     }
 
+    // TODO: Use builtInPageUrls to filter expected built-in page count #999
+
     const tenantPagesBySlug = new Map(pages.docs.map((p) => [p.slug, p]))
     const createdPages = templatePageSlugs.filter((p) => tenantPagesBySlug.has(p.slug))
     const missing = templatePageSlugs.filter((p) => !tenantPagesBySlug.has(p.slug))
 
     return {
       status: {
-        // TODO: Filter expected count to navigation-referenced built-in pages #999
-        builtInPages: { count: builtInPages.totalDocs, expected: BUILT_IN_PAGES.length },
+        builtInPages: { count: builtInPages.totalDocs, expected: builtInPages.totalDocs },
         pages: {
           created: createdPages.length,
           expected: templatePageSlugs.length,

--- a/src/collections/Tenants/components/onboardingActions.ts
+++ b/src/collections/Tenants/components/onboardingActions.ts
@@ -12,7 +12,8 @@ import path from 'path'
 import { getPayload } from 'payload'
 
 export type ProvisioningStatus = {
-  builtInPages: { count: number; expected: number }
+  forecastPages: { count: number; expected: number; zoneCount: number }
+  defaultBuiltInPages: { count: number; expected: number }
   pages: { created: number; expected: number; missing: string[] }
   homePage: boolean
   navigation: boolean
@@ -42,7 +43,8 @@ export async function checkProvisioningStatusAction(
       payload.find({
         collection: 'builtInPages',
         where: { tenant: { equals: tenantId } },
-        limit: 0,
+        limit: 100,
+        select: { url: true },
       }),
       payload.find({
         collection: 'pages',
@@ -118,12 +120,18 @@ export async function checkProvisioningStatusAction(
       templatePageSlugs = templatePages.docs.map((p) => ({ slug: p.slug, title: p.title }))
     }
 
-    const { forecastPages, nonForecastPages } = await resolveBuiltInPages(
-      tenant.slug,
-      navBuiltInPages,
-      payload.logger,
-    )
-    const expectedBuiltInPages = [...forecastPages, ...nonForecastPages]
+    const {
+      forecastPages: expectedForecastPages,
+      nonForecastPages: expectedNonForecastPages,
+      zoneCount,
+    } = await resolveBuiltInPages(tenant.slug, navBuiltInPages, payload.logger)
+
+    const tenantForecastPageCount = builtInPages.docs.filter((p) =>
+      p.url.startsWith('/forecasts/avalanche'),
+    ).length
+    const tenantDefaultPageCount = builtInPages.docs.filter(
+      (p) => !p.url.startsWith('/forecasts/avalanche'),
+    ).length
 
     const tenantPagesBySlug = new Map(pages.docs.map((p) => [p.slug, p]))
     const createdPages = templatePageSlugs.filter((p) => tenantPagesBySlug.has(p.slug))
@@ -131,7 +139,15 @@ export async function checkProvisioningStatusAction(
 
     return {
       status: {
-        builtInPages: { count: builtInPages.totalDocs, expected: expectedBuiltInPages.length },
+        forecastPages: {
+          count: tenantForecastPageCount,
+          expected: expectedForecastPages.length,
+          zoneCount,
+        },
+        defaultBuiltInPages: {
+          count: tenantDefaultPageCount,
+          expected: expectedNonForecastPages.length,
+        },
         pages: {
           created: createdPages.length,
           expected: templatePageSlugs.length,

--- a/src/collections/Tenants/components/onboardingActions.ts
+++ b/src/collections/Tenants/components/onboardingActions.ts
@@ -1,7 +1,11 @@
 'use server'
 
 import { centerColorMap } from '@/app/api/[center]/og/centerColorMap'
-import { extractNavReferences, provision } from '@/collections/Tenants/endpoints/provisionTenant'
+import {
+  extractNavReferences,
+  provision,
+  resolveBuiltInPages,
+} from '@/collections/Tenants/endpoints/provisionTenant'
 import config from '@payload-config'
 import fs from 'fs/promises'
 import path from 'path'
@@ -84,6 +88,8 @@ export async function checkProvisioningStatusAction(
     const templateTenant = templateTenantResult.docs[0]
 
     let templatePageSlugs: { slug: string; title: string }[] = []
+    let navPageSlugs = new Set<string>()
+    let navBuiltInPages: Array<{ title: string; url: string }> = []
     if (templateTenant) {
       // Get page slugs from template navigation (same logic as provisioning)
       const templateNav = await payload
@@ -95,7 +101,9 @@ export async function checkProvisioningStatusAction(
         })
         .then((res) => res.docs[0])
 
-      const { pageSlugs: navPageSlugs } = extractNavReferences(templateNav ?? {})
+      const refs = extractNavReferences(templateNav ?? {})
+      navPageSlugs = refs.pageSlugs
+      navBuiltInPages = refs.builtInPages
 
       const templatePages = await payload.find({
         collection: 'pages',
@@ -110,7 +118,12 @@ export async function checkProvisioningStatusAction(
       templatePageSlugs = templatePages.docs.map((p) => ({ slug: p.slug, title: p.title }))
     }
 
-    // TODO: Use builtInPageUrls to filter expected built-in page count #999
+    const { forecastPages, nonForecastPages } = await resolveBuiltInPages(
+      tenant.slug,
+      navBuiltInPages,
+      payload.logger,
+    )
+    const expectedBuiltInPages = [...forecastPages, ...nonForecastPages]
 
     const tenantPagesBySlug = new Map(pages.docs.map((p) => [p.slug, p]))
     const createdPages = templatePageSlugs.filter((p) => tenantPagesBySlug.has(p.slug))
@@ -118,7 +131,7 @@ export async function checkProvisioningStatusAction(
 
     return {
       status: {
-        builtInPages: { count: builtInPages.totalDocs, expected: builtInPages.totalDocs },
+        builtInPages: { count: builtInPages.totalDocs, expected: expectedBuiltInPages.length },
         pages: {
           created: createdPages.length,
           expected: templatePageSlugs.length,

--- a/src/collections/Tenants/components/onboardingActions.ts
+++ b/src/collections/Tenants/components/onboardingActions.ts
@@ -115,8 +115,8 @@ export async function checkProvisioningStatusAction(
         failed,
         theme,
         tenantCreatedAt: tenant.createdAt ?? null,
-        // Settings is only fetched for the id (used to build the "Update Brand
-        // Assets" link in the checklist UI)
+        // Settings id is used to build the "Edit settings" link in the
+        // checklist UI.
         settings: { id: settings.docs[0]?.id },
       },
     }

--- a/src/collections/Tenants/components/onboardingActions.ts
+++ b/src/collections/Tenants/components/onboardingActions.ts
@@ -28,7 +28,7 @@ async function authorize(): Promise<{ payload: Payload } | { error: string }> {
 }
 
 export type ProvisioningStatus = {
-  status: 'not_started' | 'in_progress' | 'complete' | 'partial'
+  status: 'not_started' | 'in_progress' | 'complete' | 'partial' | 'manual'
   lastRunAt: string | null
   failed: ProvisioningFailed
   theme: { brandColors: boolean; ogColors: boolean }
@@ -68,7 +68,7 @@ export async function checkProvisioningStatusAction(
     // Recover from crashed runs: if we've been "in_progress" longer than the
     // grace window, treat it as a failed run so the UI shows a re-provision
     // button instead of a spinner that never stops.
-    let status = provisioning?.status ?? 'not_started'
+    let status: ProvisioningStatus['status'] = provisioning?.status ?? 'not_started'
     let failed: ProvisioningFailed = isRecord(provisioning?.failed) ? provisioning.failed : {}
     if (status === 'in_progress' && provisioning?.lastRunAt) {
       const age = Date.now() - new Date(provisioning.lastRunAt).getTime()
@@ -78,17 +78,42 @@ export async function checkProvisioningStatusAction(
       }
     }
 
+    const theme = {
+      // Check if a CSS class matching the tenant slug exists in colors.css (e.g. ".dvac {")
+      brandColors: brandColors.includes(`.${tenant.slug} {`),
+      // Check if the tenant slug exists as a key in centerColorMap in the OG route
+      ogColors: tenant.slug in centerColorMap,
+    }
+    const themeComplete = theme.brandColors && theme.ogColors
+
+    // Manual code-level items (brand colors in colors.css, OG colors in
+    // centerColorMap) live outside the DB. Flip between 'complete' and
+    // 'manual' based on the theme check, and persist it so the list-view
+    // cell can render the same state without re-reading colors.css per row.
+    let nextStatus: typeof status | undefined
+    if (status === 'complete' && !themeComplete) nextStatus = 'manual'
+    else if (status === 'manual' && themeComplete) nextStatus = 'complete'
+    if (nextStatus) {
+      await payload
+        .update({
+          collection: 'tenants',
+          id: tenantId,
+          data: { provisioning: { status: nextStatus } },
+        })
+        .catch((err) => {
+          payload.logger.warn(
+            `Failed to sync derived provisioning status for tenant ${tenantId}: ${err instanceof Error ? err.message : err}`,
+          )
+        })
+      status = nextStatus
+    }
+
     return {
       status: {
         status,
         lastRunAt: provisioning?.lastRunAt ?? null,
         failed,
-        theme: {
-          // Check if a CSS class matching the tenant slug exists in colors.css (e.g. ".dvac {")
-          brandColors: brandColors.includes(`.${tenant.slug} {`),
-          // Check if the tenant slug exists as a key in centerColorMap in the OG route
-          ogColors: tenant.slug in centerColorMap,
-        },
+        theme,
         tenantCreatedAt: tenant.createdAt ?? null,
         // Settings is only fetched for the id (used to build the "Update Brand
         // Assets" link in the checklist UI)

--- a/src/collections/Tenants/components/onboardingActions.ts
+++ b/src/collections/Tenants/components/onboardingActions.ts
@@ -1,12 +1,27 @@
 'use server'
 
+import { hasSuperAdminPermissions } from '@/access/hasSuperAdminPermissions'
 import { centerColorMap } from '@/app/api/[center]/og/centerColorMap'
 import { provision, type ProvisioningFailed } from '@/collections/Tenants/endpoints/provisionTenant'
 import { isRecord } from '@/utilities/isRecord'
 import config from '@payload-config'
 import fs from 'fs/promises'
+import { headers } from 'next/headers'
 import path from 'path'
-import { getPayload } from 'payload'
+import { getPayload, type Payload, type PayloadRequest } from 'payload'
+
+// Server actions are POST endpoints reachable by anyone with the action ID —
+// gate every action behind a super-admin check before touching tenant data.
+async function authorize(): Promise<{ payload: Payload } | { error: string }> {
+  const payload = await getPayload({ config })
+  const { user } = await payload.auth({ headers: await headers() })
+  if (!user) return { error: 'Unauthorized' }
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const mockedReq = { user, payload } as PayloadRequest
+  const isSuperAdmin = await hasSuperAdminPermissions({ req: mockedReq })
+  if (!isSuperAdmin) return { error: 'Super admin access required' }
+  return { payload }
+}
 
 export type ProvisioningStatus = {
   status: 'not_started' | 'in_progress' | 'complete' | 'partial'
@@ -24,9 +39,10 @@ const STALE_IN_PROGRESS_MS = 10 * 60 * 1000
 export async function checkProvisioningStatusAction(
   tenantId: number | string,
 ): Promise<{ status: ProvisioningStatus } | { error: string }> {
+  const auth = await authorize()
+  if ('error' in auth) return auth
+  const { payload } = auth
   try {
-    const payload = await getPayload({ config })
-
     const [tenant, settings, brandColors] = await Promise.all([
       payload.findByID({
         collection: 'tenants',
@@ -88,7 +104,9 @@ export async function checkProvisioningStatusAction(
 export async function runProvisionAction(
   tenantId: number | string,
 ): Promise<{ success: true; failedPages: string[] } | { error: string }> {
-  const payload = await getPayload({ config })
+  const auth = await authorize()
+  if ('error' in auth) return auth
+  const { payload } = auth
   try {
     const tenant = await payload.findByID({
       collection: 'tenants',
@@ -113,7 +131,9 @@ export async function runProvisionAction(
 export async function markProvisioningCompleteAction(
   tenantId: number | string,
 ): Promise<{ success: true } | { error: string }> {
-  const payload = await getPayload({ config })
+  const auth = await authorize()
+  if ('error' in auth) return auth
+  const { payload } = auth
   try {
     await payload.update({
       collection: 'tenants',

--- a/src/collections/Tenants/components/onboardingActions.ts
+++ b/src/collections/Tenants/components/onboardingActions.ts
@@ -1,25 +1,25 @@
 'use server'
 
 import { centerColorMap } from '@/app/api/[center]/og/centerColorMap'
-import {
-  PAGES_TO_PROVISION,
-  provision,
-  resolveBuiltInPages,
-} from '@/collections/Tenants/endpoints/provisionTenant'
+import { provision, type ProvisioningFailed } from '@/collections/Tenants/endpoints/provisionTenant'
+import { isRecord } from '@/utilities/isRecord'
 import config from '@payload-config'
 import fs from 'fs/promises'
 import path from 'path'
 import { getPayload } from 'payload'
 
 export type ProvisioningStatus = {
-  forecastPages: { count: number; expected: number }
-  defaultBuiltInPages: { count: number; expected: number }
-  pages: { created: number; expected: number; missing: string[] }
-  homePage: boolean
-  navigation: boolean
-  settings: { exists: boolean; id?: number | string }
+  status: 'not_started' | 'in_progress' | 'complete' | 'partial'
+  lastRunAt: string | null
+  failed: ProvisioningFailed
   theme: { brandColors: boolean; ogColors: boolean }
+  tenantCreatedAt: string | null
+  settings: { id?: number | string }
 }
+
+// Provisioning is synchronous on the server, so anything longer than this is
+// almost certainly a crashed run we should recover from rather than wait on.
+const STALE_IN_PROGRESS_MS = 10 * 60 * 1000
 
 export async function checkProvisioningStatusAction(
   tenantId: number | string,
@@ -27,91 +27,57 @@ export async function checkProvisioningStatusAction(
   try {
     const payload = await getPayload({ config })
 
-    const [builtInPages, pages, homePages, navigations, settings, tenant, brandColors] =
-      await Promise.all([
-        payload.find({
-          collection: 'builtInPages',
-          where: { tenant: { equals: tenantId } },
-          limit: 100,
-          select: { url: true },
+    const [tenant, settings, brandColors] = await Promise.all([
+      payload.findByID({
+        collection: 'tenants',
+        id: tenantId,
+      }),
+      payload.find({
+        collection: 'settings',
+        where: { tenant: { equals: tenantId } },
+        limit: 1,
+        select: {},
+      }),
+      fs
+        .readFile(path.join(process.cwd(), 'src/app/(frontend)/colors.css'), 'utf-8')
+        .catch((err) => {
+          payload.logger.warn(
+            `Failed to read colors.css: ${err instanceof Error ? err.message : err}`,
+          )
+          return ''
         }),
-        payload.find({
-          collection: 'pages',
-          where: { tenant: { equals: tenantId } },
-          limit: 500,
-          select: { slug: true, title: true, _status: true },
-        }),
-        payload.find({
-          collection: 'homePages',
-          where: { tenant: { equals: tenantId } },
-          limit: 0,
-        }),
-        payload.find({
-          collection: 'navigations',
-          where: { tenant: { equals: tenantId } },
-          limit: 0,
-        }),
-        payload.find({
-          collection: 'settings',
-          where: { tenant: { equals: tenantId } },
-          limit: 1,
-          select: {},
-        }),
-        payload.findByID({
-          collection: 'tenants',
-          id: tenantId,
-        }),
-        fs
-          .readFile(path.join(process.cwd(), 'src/app/(frontend)/colors.css'), 'utf-8')
-          .catch((err) => {
-            payload.logger.warn(
-              `Failed to read colors.css: ${err instanceof Error ? err.message : err}`,
-            )
-            return ''
-          }),
-      ])
+    ])
 
-    const { forecastPages: expectedForecastPages, nonForecastPages: expectedNonForecastPages } =
-      await resolveBuiltInPages(tenant.slug, payload.logger)
+    const provisioning = tenant.provisioning
 
-    const tenantForecastPageCount = builtInPages.docs.filter((p) =>
-      p.url.startsWith('/forecasts/avalanche'),
-    ).length
-    const tenantDefaultPageCount = builtInPages.docs.filter(
-      (p) => !p.url.startsWith('/forecasts/avalanche'),
-    ).length
-
-    const tenantPagesBySlug = new Map(pages.docs.map((p) => [p.slug, p]))
-    const createdPages = PAGES_TO_PROVISION.filter((p) => tenantPagesBySlug.has(p.slug))
-    const missing = PAGES_TO_PROVISION.filter((p) => !tenantPagesBySlug.has(p.slug))
+    // Recover from crashed runs: if we've been "in_progress" longer than the
+    // grace window, treat it as a failed run so the UI shows a re-provision
+    // button instead of a spinner that never stops.
+    let status = provisioning?.status ?? 'not_started'
+    let failed: ProvisioningFailed = isRecord(provisioning?.failed) ? provisioning.failed : {}
+    if (status === 'in_progress' && provisioning?.lastRunAt) {
+      const age = Date.now() - new Date(provisioning.lastRunAt).getTime()
+      if (age > STALE_IN_PROGRESS_MS) {
+        status = 'partial'
+        failed = { ...failed, timedOut: 'Provisioning timed out. It may still be running.' }
+      }
+    }
 
     return {
       status: {
-        forecastPages: {
-          count: tenantForecastPageCount,
-          expected: expectedForecastPages.length,
-        },
-        defaultBuiltInPages: {
-          count: tenantDefaultPageCount,
-          expected: expectedNonForecastPages.length,
-        },
-        pages: {
-          created: createdPages.length,
-          expected: PAGES_TO_PROVISION.length,
-          missing: missing.map((p) => p.title),
-        },
-        homePage: homePages.totalDocs > 0,
-        navigation: navigations.totalDocs > 0,
-        settings: {
-          exists: settings.totalDocs > 0,
-          id: settings.docs[0]?.id,
-        },
+        status,
+        lastRunAt: provisioning?.lastRunAt ?? null,
+        failed,
         theme: {
           // Check if a CSS class matching the tenant slug exists in colors.css (e.g. ".dvac {")
           brandColors: brandColors.includes(`.${tenant.slug} {`),
           // Check if the tenant slug exists as a key in centerColorMap in the OG route
           ogColors: tenant.slug in centerColorMap,
         },
+        tenantCreatedAt: tenant.createdAt ?? null,
+        // Settings is only fetched for the id (used to build the "Update Brand
+        // Assets" link in the checklist UI)
+        settings: { id: settings.docs[0]?.id },
       },
     }
   } catch (err) {
@@ -135,5 +101,33 @@ export async function runProvisionAction(
   } catch (err) {
     payload.logger.error({ err }, 'Provisioning failed')
     return { error: err instanceof Error ? err.message : 'Failed to run provisioning' }
+  }
+}
+
+/**
+ * Manually mark a tenant's provisioning as complete. Used when an admin has
+ * fixed the items that failed during provisioning without re-running it.
+ * Clears `failed` but leaves `lastRunAt` unchanged (that still reflects the
+ * actual last provision run).
+ */
+export async function markProvisioningCompleteAction(
+  tenantId: number | string,
+): Promise<{ success: true } | { error: string }> {
+  const payload = await getPayload({ config })
+  try {
+    await payload.update({
+      collection: 'tenants',
+      id: tenantId,
+      data: {
+        provisioning: {
+          status: 'complete',
+          failed: undefined,
+        },
+      },
+    })
+    return { success: true }
+  } catch (err) {
+    payload.logger.error({ err }, 'Failed to mark provisioning complete')
+    return { error: err instanceof Error ? err.message : 'Failed to mark provisioning complete' }
   }
 }

--- a/src/collections/Tenants/components/onboardingActions.ts
+++ b/src/collections/Tenants/components/onboardingActions.ts
@@ -2,7 +2,7 @@
 
 import { centerColorMap } from '@/app/api/[center]/og/centerColorMap'
 import {
-  extractNavReferences,
+  PAGES_TO_PROVISION,
   provision,
   resolveBuiltInPages,
 } from '@/collections/Tenants/endpoints/provisionTenant'
@@ -27,101 +27,52 @@ export async function checkProvisioningStatusAction(
   try {
     const payload = await getPayload({ config })
 
-    // Template tenant slug must match TEMPLATE_TENANT_SLUG in provisionTenant.ts
-    const templateTenantSlug = 'dvac'
-
-    const [
-      builtInPages,
-      pages,
-      homePages,
-      navigations,
-      settings,
-      tenant,
-      brandColors,
-      templateTenantResult,
-    ] = await Promise.all([
-      payload.find({
-        collection: 'builtInPages',
-        where: { tenant: { equals: tenantId } },
-        limit: 100,
-        select: { url: true },
-      }),
-      payload.find({
-        collection: 'pages',
-        where: { tenant: { equals: tenantId } },
-        limit: 500,
-        select: { slug: true, title: true, _status: true },
-      }),
-      payload.find({
-        collection: 'homePages',
-        where: { tenant: { equals: tenantId } },
-        limit: 0,
-      }),
-      payload.find({
-        collection: 'navigations',
-        where: { tenant: { equals: tenantId } },
-        limit: 0,
-      }),
-      payload.find({
-        collection: 'settings',
-        where: { tenant: { equals: tenantId } },
-        limit: 1,
-        select: {},
-      }),
-      payload.findByID({
-        collection: 'tenants',
-        id: tenantId,
-      }),
-      fs
-        .readFile(path.join(process.cwd(), 'src/app/(frontend)/colors.css'), 'utf-8')
-        .catch((err) => {
-          payload.logger.warn(
-            `Failed to read colors.css: ${err instanceof Error ? err.message : err}`,
-          )
-          return ''
+    const [builtInPages, pages, homePages, navigations, settings, tenant, brandColors] =
+      await Promise.all([
+        payload.find({
+          collection: 'builtInPages',
+          where: { tenant: { equals: tenantId } },
+          limit: 100,
+          select: { url: true },
         }),
-      payload.find({
-        collection: 'tenants',
-        where: { slug: { equals: templateTenantSlug } },
-        limit: 1,
-      }),
-    ])
-
-    const templateTenant = templateTenantResult.docs[0]
-
-    let templatePageSlugs: { slug: string; title: string }[] = []
-    let navPageSlugs = new Set<string>()
-    let navBuiltInPages: Array<{ title: string; url: string }> = []
-    if (templateTenant) {
-      // Get page slugs from template navigation (same logic as provisioning)
-      const templateNav = await payload
-        .find({
+        payload.find({
+          collection: 'pages',
+          where: { tenant: { equals: tenantId } },
+          limit: 500,
+          select: { slug: true, title: true, _status: true },
+        }),
+        payload.find({
+          collection: 'homePages',
+          where: { tenant: { equals: tenantId } },
+          limit: 0,
+        }),
+        payload.find({
           collection: 'navigations',
-          where: { tenant: { equals: templateTenant.id } },
+          where: { tenant: { equals: tenantId } },
+          limit: 0,
+        }),
+        payload.find({
+          collection: 'settings',
+          where: { tenant: { equals: tenantId } },
           limit: 1,
-          depth: 1,
-        })
-        .then((res) => res.docs[0])
-
-      const refs = extractNavReferences(templateNav ?? {})
-      navPageSlugs = refs.pageSlugs
-      navBuiltInPages = refs.builtInPages
-
-      const templatePages = await payload.find({
-        collection: 'pages',
-        where: {
-          tenant: { equals: templateTenant.id },
-          _status: { equals: 'published' },
-          slug: { in: [...navPageSlugs].join(',') },
-        },
-        limit: 500,
-        select: { slug: true, title: true },
-      })
-      templatePageSlugs = templatePages.docs.map((p) => ({ slug: p.slug, title: p.title }))
-    }
+          select: {},
+        }),
+        payload.findByID({
+          collection: 'tenants',
+          id: tenantId,
+        }),
+        fs
+          .readFile(path.join(process.cwd(), 'src/app/(frontend)/colors.css'), 'utf-8')
+          .catch((err) => {
+            payload.logger.warn(
+              `Failed to read colors.css: ${err instanceof Error ? err.message : err}`,
+            )
+            return ''
+          }),
+      ])
 
     const { forecastPages: expectedForecastPages, nonForecastPages: expectedNonForecastPages } =
-      await resolveBuiltInPages(tenant.slug, navBuiltInPages, payload.logger)
+      await resolveBuiltInPages(tenant.slug, payload.logger)
 
     const tenantForecastPageCount = builtInPages.docs.filter((p) =>
       p.url.startsWith('/forecasts/avalanche'),
@@ -131,8 +82,8 @@ export async function checkProvisioningStatusAction(
     ).length
 
     const tenantPagesBySlug = new Map(pages.docs.map((p) => [p.slug, p]))
-    const createdPages = templatePageSlugs.filter((p) => tenantPagesBySlug.has(p.slug))
-    const missing = templatePageSlugs.filter((p) => !tenantPagesBySlug.has(p.slug))
+    const createdPages = PAGES_TO_PROVISION.filter((p) => tenantPagesBySlug.has(p.slug))
+    const missing = PAGES_TO_PROVISION.filter((p) => !tenantPagesBySlug.has(p.slug))
 
     return {
       status: {
@@ -146,7 +97,7 @@ export async function checkProvisioningStatusAction(
         },
         pages: {
           created: createdPages.length,
-          expected: templatePageSlugs.length,
+          expected: PAGES_TO_PROVISION.length,
           missing: missing.map((p) => p.title),
         },
         homePage: homePages.totalDocs > 0,

--- a/src/collections/Tenants/components/onboardingActions.ts
+++ b/src/collections/Tenants/components/onboardingActions.ts
@@ -14,8 +14,6 @@ import { headers } from 'next/headers'
 import path from 'path'
 import { getPayload, type Payload, type PayloadRequest } from 'payload'
 
-// Server actions are POST endpoints reachable by anyone with the action ID —
-// gate every action behind a super-admin check before touching tenant data.
 async function authorize(): Promise<{ payload: Payload } | { error: string }> {
   const payload = await getPayload({ config })
   const { user } = await payload.auth({ headers: await headers() })

--- a/src/collections/Tenants/components/onboardingActions.ts
+++ b/src/collections/Tenants/components/onboardingActions.ts
@@ -52,7 +52,6 @@ export async function checkProvisioningStatusAction(
         collection: 'settings',
         where: { tenant: { equals: tenantId } },
         limit: 1,
-        select: {},
       }),
       fs
         .readFile(path.join(process.cwd(), 'src/app/(frontend)/colors.css'), 'utf-8')

--- a/src/collections/Tenants/components/onboardingActions.ts
+++ b/src/collections/Tenants/components/onboardingActions.ts
@@ -2,7 +2,11 @@
 
 import { hasSuperAdminPermissions } from '@/access/hasSuperAdminPermissions'
 import { centerColorMap } from '@/app/api/[center]/og/centerColorMap'
-import { provision, type ProvisioningFailed } from '@/collections/Tenants/endpoints/provisionTenant'
+import {
+  provision,
+  STALE_IN_PROGRESS_MS,
+  type ProvisioningFailed,
+} from '@/collections/Tenants/endpoints/provisionTenant'
 import { isRecord } from '@/utilities/isRecord'
 import config from '@payload-config'
 import fs from 'fs/promises'
@@ -31,10 +35,6 @@ export type ProvisioningStatus = {
   tenantCreatedAt: string | null
   settings: { id?: number | string }
 }
-
-// Provisioning is synchronous on the server, so anything longer than this is
-// almost certainly a crashed run we should recover from rather than wait on.
-const STALE_IN_PROGRESS_MS = 10 * 60 * 1000
 
 export async function checkProvisioningStatusAction(
   tenantId: number | string,

--- a/src/collections/Tenants/endpoints/provisionTenant.ts
+++ b/src/collections/Tenants/endpoints/provisionTenant.ts
@@ -1,7 +1,11 @@
 import { hasSuperAdminPermissions } from '@/access/hasSuperAdminPermissions'
 import { getSeedImageByFilename, simpleContent } from '@/endpoints/seed/utilities'
 import type { BuiltInPage, Navigation, Page, Tenant } from '@/payload-types'
-import { getActiveForecastZones, type ActiveForecastZoneWithSlug } from '@/services/nac/nac'
+import {
+  getActiveForecastZones,
+  getAvalancheCenterPlatforms,
+  type ActiveForecastZoneWithSlug,
+} from '@/services/nac/nac'
 import { isValidRelationship } from '@/utilities/relationships'
 import type { Payload, PayloadHandler } from 'payload'
 import type { Logger } from 'pino'
@@ -57,7 +61,20 @@ export async function resolveBuiltInPages(
           })),
         ]
 
-  const nonForecastPages = navBuiltInPages.filter((p) => !p.url.startsWith('/forecasts/avalanche'))
+  // Non-forecast pages from DVAC nav, excluding Mountain Weather (determined by NAC)
+  const nonForecastPages = navBuiltInPages.filter(
+    (p) => !p.url.startsWith('/forecasts/avalanche') && p.url !== '/weather/forecast',
+  )
+
+  // Add Mountain Weather only if center has weather forecasts in NAC
+  try {
+    const { weather } = await getAvalancheCenterPlatforms(tenantSlug)
+    if (weather) {
+      nonForecastPages.push({ title: 'Mountain Weather', url: '/weather/forecast' })
+    }
+  } catch {
+    log.warn(`[${tenantSlug}] Failed to query NAC platforms. Excluding Mountain Weather.`)
+  }
 
   return { forecastPages, nonForecastPages }
 }

--- a/src/collections/Tenants/endpoints/provisionTenant.ts
+++ b/src/collections/Tenants/endpoints/provisionTenant.ts
@@ -19,6 +19,7 @@ export async function resolveBuiltInPages(
 ): Promise<{
   forecastPages: Array<{ title: string; url: string }>
   nonForecastPages: Array<{ title: string; url: string }>
+  zoneCount: number
 }> {
   let forecastZones: ActiveForecastZoneWithSlug[] = []
   try {
@@ -59,7 +60,7 @@ export async function resolveBuiltInPages(
 
   const nonForecastPages = navBuiltInPages.filter((p) => !p.url.startsWith('/forecasts/avalanche'))
 
-  return { forecastPages, nonForecastPages }
+  return { forecastPages, nonForecastPages, zoneCount: forecastZones.length }
 }
 
 /**

--- a/src/collections/Tenants/endpoints/provisionTenant.ts
+++ b/src/collections/Tenants/endpoints/provisionTenant.ts
@@ -4,44 +4,62 @@ import type { BuiltInPage, Navigation, Page, Tenant } from '@/payload-types'
 import { getActiveForecastZones, type ActiveForecastZoneWithSlug } from '@/services/nac/nac'
 import { isValidRelationship } from '@/utilities/relationships'
 import type { Payload, PayloadHandler } from 'payload'
+import type { Logger } from 'pino'
 
 const TEMPLATE_TENANT_SLUG = 'dvac'
 
-export const NON_FORECAST_BUILT_IN_PAGES: Array<{ title: string; url: string }> = [
-  { title: 'Mountain Weather', url: '/weather/forecast' },
-  { title: 'Weather Stations', url: '/weather/stations/map' },
-  { title: 'Recent Observations', url: '/observations' },
-  { title: 'Submit Observations', url: '/observations/submit' },
-  { title: 'Blog', url: '/blog' },
-  { title: 'Events', url: '/events' },
-]
-
 /**
- * Builds the list of built-in pages based on forecast zones from AFP data.
- * Forecast pages are always included (determined by AFP, not template nav).
- * Non-forecast pages are filtered to those referenced in the template navigation.
+ * Queries AFP for forecast zones and splits template nav built-in pages into
+ * zone-aware forecast pages (sorted by rank) and non-forecast pages.
  */
-export function buildBuiltInPages(
-  zones: ActiveForecastZoneWithSlug[],
-  navBuiltInPageUrls?: Set<string>,
-): Array<{ title: string; url: string }> {
+export async function resolveBuiltInPages(
+  tenantSlug: string,
+  navBuiltInPages: Array<{ title: string; url: string }>,
+  log: Logger,
+): Promise<{
+  forecastPages: Array<{ title: string; url: string }>
+  nonForecastPages: Array<{ title: string; url: string }>
+}> {
+  let forecastZones: ActiveForecastZoneWithSlug[] = []
+  try {
+    forecastZones = await getActiveForecastZones(tenantSlug)
+    if (forecastZones.length === 0) {
+      log.warn(
+        `[${tenantSlug}] No forecast zones found from AFP. Creating default "All Forecasts" page.`,
+      )
+    } else {
+      log.info(`[${tenantSlug}] Found ${forecastZones.length} forecast zone(s) from AFP`)
+    }
+  } catch (err) {
+    log.warn(
+      `[${tenantSlug}] Failed to query AFP for forecast zones: ${err instanceof Error ? err.message : 'Unknown error'}. Creating default "All Forecasts" page.`,
+    )
+  }
+
+  // Sort by rank so consumers can iterate in display order
+  const sorted = [...forecastZones].sort(
+    (a, b) => (a.zone.rank ?? Infinity) - (b.zone.rank ?? Infinity),
+  )
+
   const forecastPages =
-    zones.length === 1
-      ? [{ title: 'Avalanche Forecast', url: `/forecasts/avalanche/${zones[0].slug}` }]
+    sorted.length === 1
+      ? [
+          {
+            title: 'Avalanche Forecast',
+            url: `/forecasts/avalanche/${sorted[0].slug}`,
+          },
+        ]
       : [
           { title: 'All Forecasts', url: '/forecasts/avalanche' },
-          ...zones.map(({ zone, slug }) => ({
+          ...sorted.map(({ zone, slug }) => ({
             title: zone.name,
             url: `/forecasts/avalanche/${slug}`,
           })),
         ]
 
-  // Filter non-forecast pages to those referenced in template navigation
-  const nonForecastPages = navBuiltInPageUrls
-    ? NON_FORECAST_BUILT_IN_PAGES.filter((p) => navBuiltInPageUrls.has(p.url))
-    : NON_FORECAST_BUILT_IN_PAGES
+  const nonForecastPages = navBuiltInPages.filter((p) => !p.url.startsWith('/forecasts/avalanche'))
 
-  return [...forecastPages, ...nonForecastPages]
+  return { forecastPages, nonForecastPages }
 }
 
 /**
@@ -123,22 +141,23 @@ export const provisionTenant: PayloadHandler = async (req) => {
  */
 export type NavReferences = {
   pageSlugs: Set<string>
-  builtInPageUrls: Set<string>
+  builtInPages: Array<{ title: string; url: string }>
 }
 
 export function extractNavReferences(nav: Navigation): NavReferences {
   const pageSlugs = new Set<string>()
-  const builtInPageUrls = new Set<string>()
+  const builtInPages: Array<{ title: string; url: string }> = []
+  const seenUrls = new Set<string>()
 
   for (const tab of Object.values(nav)) {
     if (typeof tab === 'object' && tab !== null) {
       // Tab with items array (forecasts, weather, education, etc.)
       if ('items' in tab && Array.isArray(tab.items)) {
         for (const item of tab.items) {
-          buildNavReference(item.link, pageSlugs, builtInPageUrls)
+          buildNavReference(item.link, pageSlugs, builtInPages, seenUrls)
           if (Array.isArray(item.items)) {
             for (const subItem of item.items) {
-              buildNavReference(subItem.link, pageSlugs, builtInPageUrls)
+              buildNavReference(subItem.link, pageSlugs, builtInPages, seenUrls)
             }
           }
         }
@@ -146,12 +165,12 @@ export function extractNavReferences(nav: Navigation): NavReferences {
 
       // Tab with a direct link (donate)
       if ('link' in tab) {
-        buildNavReference(tab.link, pageSlugs, builtInPageUrls)
+        buildNavReference(tab.link, pageSlugs, builtInPages, seenUrls)
       }
     }
   }
 
-  return { pageSlugs, builtInPageUrls }
+  return { pageSlugs, builtInPages }
 }
 
 function buildNavReference(
@@ -160,15 +179,20 @@ function buildNavReference(
     | null
     | undefined,
   pageSlugs: Set<string>,
-  builtInPageUrls: Set<string>,
+  builtInPages: Array<{ title: string; url: string }>,
+  seenUrls: Set<string>,
 ): void {
   const ref = link?.reference
   if (!ref || !isValidRelationship(ref.value)) return
 
   if (ref.relationTo === 'pages' && 'slug' in ref.value) {
     pageSlugs.add(String(ref.value.slug))
-  } else if (ref.relationTo === 'builtInPages' && 'url' in ref.value) {
-    builtInPageUrls.add(String(ref.value.url))
+  } else if (ref.relationTo === 'builtInPages' && 'url' in ref.value && 'title' in ref.value) {
+    const url = String(ref.value.url)
+    if (!seenUrls.has(url)) {
+      seenUrls.add(url)
+      builtInPages.push({ title: String(ref.value.title), url })
+    }
   }
 }
 
@@ -236,7 +260,7 @@ export async function provision(payload: Payload, tenant: Tenant) {
     .then((res) => res.docs[0])
 
   let navPageSlugs = new Set<string>()
-  let navBuiltInPageUrls = new Set<string>()
+  let navBuiltInPages: Array<{ title: string; url: string }> = []
 
   if (templateTenant) {
     const templateNav = await payload
@@ -250,37 +274,21 @@ export async function provision(payload: Payload, tenant: Tenant) {
 
     const refs = extractNavReferences(templateNav ?? {})
     navPageSlugs = refs.pageSlugs
-    navBuiltInPageUrls = refs.builtInPageUrls
+    navBuiltInPages = refs.builtInPages
     log.info(
-      `[${tenant.slug}] Found ${navPageSlugs.size} page slugs and ${navBuiltInPageUrls.size} built-in page URLs in template navigation`,
+      `[${tenant.slug}] Found ${navPageSlugs.size} page slugs and ${navBuiltInPages.length} built-in pages in template navigation`,
     )
   } else {
     log.warn(`Template tenant "${TEMPLATE_TENANT_SLUG}" not found. Using default built-in pages.`)
   }
 
-  // 3. Query AFP for forecast zones
-  log.info(`[${tenant.slug}] Querying AFP for forecast zones...`)
-  let forecastZones: ActiveForecastZoneWithSlug[] = []
-  try {
-    forecastZones = await getActiveForecastZones(tenant.slug)
-    if (forecastZones.length === 0) {
-      log.warn(
-        `[${tenant.slug}] No forecast zones found from AFP. Creating default "All Forecasts" page.`,
-      )
-    } else {
-      log.info(`[${tenant.slug}] Found ${forecastZones.length} forecast zone(s) from AFP`)
-    }
-  } catch (err) {
-    log.warn(
-      `[${tenant.slug}] Failed to query AFP for forecast zones: ${err instanceof Error ? err.message : 'Unknown error'}. Creating default "All Forecasts" page.`,
-    )
-  }
-
-  // 4. Create Built-In Pages (zone-aware, filtered to nav-referenced)
-  const builtInPagesToCreate = buildBuiltInPages(
-    forecastZones,
-    navBuiltInPageUrls.size > 0 ? navBuiltInPageUrls : undefined,
+  // 3–4. Query AFP for forecast zones and resolve built-in pages
+  const { forecastPages, nonForecastPages } = await resolveBuiltInPages(
+    tenant.slug,
+    navBuiltInPages,
+    log,
   )
+  const builtInPagesToCreate = [...forecastPages, ...nonForecastPages]
   log.info(`[${tenant.slug}] Creating ${builtInPagesToCreate.length} built-in pages...`)
   const existingBuiltInPages = await payload.find({
     collection: 'builtInPages',
@@ -510,22 +518,17 @@ export async function provision(payload: Payload, tenant: Tenant) {
         data: {
           tenant: tenant.id,
           forecasts:
-            forecastZones.length === 1
+            forecastPages.length === 1
               ? {
-                  link: navBuiltInPageItem(
-                    `/forecasts/avalanche/${forecastZones[0].slug}`,
-                    'Avalanche Forecast',
-                  )?.link,
+                  link: navBuiltInPageItem(forecastPages[0].url, forecastPages[0].title)?.link,
                   items: [],
                 }
               : {
                   link: navBuiltInPageItem('/forecasts/avalanche', 'All Forecasts')?.link,
                   items: filterNulls(
-                    forecastZones
-                      .sort((a, b) => (a.zone.rank ?? Infinity) - (b.zone.rank ?? Infinity))
-                      .map(({ zone, slug }) =>
-                        navBuiltInPageItem(`/forecasts/avalanche/${slug}`, zone.name),
-                      ),
+                    forecastPages
+                      .filter((p) => p.url !== '/forecasts/avalanche')
+                      .map((p) => navBuiltInPageItem(p.url, p.title)),
                   ),
                 },
           observations: {

--- a/src/collections/Tenants/endpoints/provisionTenant.ts
+++ b/src/collections/Tenants/endpoints/provisionTenant.ts
@@ -19,7 +19,6 @@ export async function resolveBuiltInPages(
 ): Promise<{
   forecastPages: Array<{ title: string; url: string }>
   nonForecastPages: Array<{ title: string; url: string }>
-  zoneCount: number
 }> {
   let forecastZones: ActiveForecastZoneWithSlug[] = []
   try {
@@ -60,7 +59,7 @@ export async function resolveBuiltInPages(
 
   const nonForecastPages = navBuiltInPages.filter((p) => !p.url.startsWith('/forecasts/avalanche'))
 
-  return { forecastPages, nonForecastPages, zoneCount: forecastZones.length }
+  return { forecastPages, nonForecastPages }
 }
 
 /**

--- a/src/collections/Tenants/endpoints/provisionTenant.ts
+++ b/src/collections/Tenants/endpoints/provisionTenant.ts
@@ -1,24 +1,66 @@
 import { hasSuperAdminPermissions } from '@/access/hasSuperAdminPermissions'
 import { getSeedImageByFilename, simpleContent } from '@/endpoints/seed/utilities'
-import type { BuiltInPage, Navigation, Page, Tenant } from '@/payload-types'
+import type { BuiltInPage, Page, Tenant } from '@/payload-types'
 import {
   getActiveForecastZones,
   getAvalancheCenterPlatforms,
   type ActiveForecastZoneWithSlug,
 } from '@/services/nac/nac'
-import { isValidRelationship } from '@/utilities/relationships'
 import type { Payload, PayloadHandler } from 'payload'
 import type { Logger } from 'pino'
 
-const TEMPLATE_TENANT_SLUG = 'dvac'
+/**
+ * Non-forecast built-in pages every tenant gets. Mountain Weather is not
+ * listed here — it's conditionally added based on whether NAC reports the
+ * center has a weather platform.
+ */
+export const BUILT_IN_PAGES: ReadonlyArray<{ title: string; url: string }> = [
+  { title: 'Weather Stations', url: '/weather/stations/map' },
+  { title: 'Recent Observations', url: '/observations' },
+  { title: 'Submit Observations', url: '/observations/submit' },
+  { title: 'Blog', url: '/blog' },
+  { title: 'Events', url: '/events' },
+]
 
 /**
- * Queries AFP for forecast zones and splits template nav built-in pages into
- * zone-aware forecast pages (sorted by rank) and non-forecast pages.
+ * Blank pages every tenant gets. Titles are placeholders that the tenant
+ * admin is expected to edit; slugs are referenced by the default navigation.
+ */
+export const PAGES_TO_PROVISION: ReadonlyArray<{ slug: string; title: string }> = [
+  { slug: 'weather-tools', title: 'Weather Tools' },
+  { slug: 'learn', title: 'Learn' },
+  { slug: 'field-classes', title: 'Field Classes' },
+  { slug: 'avalanche-awareness-classes', title: 'Avalanche Awareness Classes' },
+  { slug: 'courses-by-external-providers', title: 'Courses by External Providers' },
+  { slug: 'workshops', title: 'Workshops' },
+  { slug: 'request-a-class', title: 'Request a Class' },
+  { slug: 'scholarships', title: 'Scholarships' },
+  { slug: 'mentorship', title: 'Mentorship' },
+  { slug: 'beacon-parks', title: 'Beacon Parks' },
+  { slug: 'about-us', title: 'About Us' },
+  { slug: 'agency-partners', title: 'Agency Partners' },
+  { slug: 'who-we-are', title: 'Who We Are' },
+  { slug: 'annual-report-minutes', title: 'Annual Reports & Minutes' },
+  { slug: 'employment', title: 'Employment' },
+  { slug: 'donate-membership', title: 'Donate / Membership' },
+  { slug: 'workplace-giving', title: 'Workplace Giving' },
+  { slug: 'other-ways-to-give', title: 'Other Ways to Give' },
+  { slug: 'corporate-sponsorship', title: 'Corporate Sponsorship' },
+  { slug: 'volunteer', title: 'Volunteer' },
+  { slug: 'local-accident-reports', title: 'Local Accident Reports' },
+  { slug: 'avalanche-accident-statistics', title: 'Avalanche Accident Statistics' },
+  { slug: 'us-avalanche-accidents', title: 'US Avalanche Accidents' },
+  { slug: 'grief-and-loss-resources', title: 'Grief and Loss Resources' },
+  { slug: 'avalanche-accident-map', title: 'Avalanche Accident Map' },
+]
+
+/**
+ * Queries AFP for forecast zones and returns zone-aware forecast built-in
+ * pages plus the static non-forecast list (with Mountain Weather conditionally
+ * included based on NAC platforms).
  */
 export async function resolveBuiltInPages(
   tenantSlug: string,
-  navBuiltInPages: Array<{ title: string; url: string }>,
   log: Logger,
 ): Promise<{
   forecastPages: Array<{ title: string; url: string }>
@@ -61,10 +103,7 @@ export async function resolveBuiltInPages(
           })),
         ]
 
-  // Non-forecast pages from DVAC nav, excluding Mountain Weather (determined by NAC)
-  const nonForecastPages = navBuiltInPages.filter(
-    (p) => !p.url.startsWith('/forecasts/avalanche') && p.url !== '/weather/forecast',
-  )
+  const nonForecastPages: Array<{ title: string; url: string }> = [...BUILT_IN_PAGES]
 
   // Add Mountain Weather only if center has weather forecasts in NAC
   try {
@@ -142,77 +181,15 @@ export const provisionTenant: PayloadHandler = async (req) => {
 /**
  * Provisions a tenant with all default data:
  * 1. Website Settings with placeholder brand assets (logo, icon, banner)
- * 2. Look up template tenant (DVAC) navigation to determine which pages to create
- * 3. Query AFP for forecast zones (single vs multi-zone detection)
- * 4. Built-in pages (zone-aware, filtered to those referenced in template navigation)
- * 5. Blank pages matching the template tenant's page structure
- * 6. Home page with default content
- * 7. Navigation linked to the new pages and built-in pages (zone-aware forecasts)
+ * 2. Query AFP for forecast zones (single vs multi-zone detection)
+ * 3. Built-in pages (zone-aware forecasts + static non-forecast list + optional
+ *    Mountain Weather based on NAC platforms)
+ * 4. Blank pages for every entry in PAGES_TO_PROVISION
+ * 5. Home page with default content
+ * 6. Navigation linked to the new pages and built-in pages (zone-aware forecasts)
  *
  * Idempotent - checks for existing data before creating.
  */
-/**
- * Extracts page slugs from a resolved navigation document.
- * Walks all DVAC nav tabs' items (and sub-items) and collects slugs
- * from internal page references.
- */
-export type NavReferences = {
-  pageSlugs: Set<string>
-  builtInPages: Array<{ title: string; url: string }>
-}
-
-export function extractNavReferences(nav: Navigation): NavReferences {
-  const pageSlugs = new Set<string>()
-  const builtInPages: Array<{ title: string; url: string }> = []
-  const seenUrls = new Set<string>()
-
-  for (const tab of Object.values(nav)) {
-    if (typeof tab === 'object' && tab !== null) {
-      // Tab with items array (forecasts, weather, education, etc.)
-      if ('items' in tab && Array.isArray(tab.items)) {
-        for (const item of tab.items) {
-          buildNavReference(item.link, pageSlugs, builtInPages, seenUrls)
-          if (Array.isArray(item.items)) {
-            for (const subItem of item.items) {
-              buildNavReference(subItem.link, pageSlugs, builtInPages, seenUrls)
-            }
-          }
-        }
-      }
-
-      // Tab with a direct link (donate)
-      if ('link' in tab) {
-        buildNavReference(tab.link, pageSlugs, builtInPages, seenUrls)
-      }
-    }
-  }
-
-  return { pageSlugs, builtInPages }
-}
-
-function buildNavReference(
-  link:
-    | { reference?: { relationTo: string; value: number | { id: string | number } } | null }
-    | null
-    | undefined,
-  pageSlugs: Set<string>,
-  builtInPages: Array<{ title: string; url: string }>,
-  seenUrls: Set<string>,
-): void {
-  const ref = link?.reference
-  if (!ref || !isValidRelationship(ref.value)) return
-
-  if (ref.relationTo === 'pages' && 'slug' in ref.value) {
-    pageSlugs.add(String(ref.value.slug))
-  } else if (ref.relationTo === 'builtInPages' && 'url' in ref.value && 'title' in ref.value) {
-    const url = String(ref.value.url)
-    if (!seenUrls.has(url)) {
-      seenUrls.add(url)
-      builtInPages.push({ title: String(ref.value.title), url })
-    }
-  }
-}
-
 export async function provision(payload: Payload, tenant: Tenant) {
   const log = payload.logger
 
@@ -266,45 +243,8 @@ export async function provision(payload: Payload, tenant: Tenant) {
     log.info(`[${tenant.slug}] Website settings already exist, skipping`)
   }
 
-  // 2. Look up template tenant navigation to determine which pages to create
-  log.info(`[${tenant.slug}] Looking up template tenant (${TEMPLATE_TENANT_SLUG}) navigation...`)
-  const templateTenant = await payload
-    .find({
-      collection: 'tenants',
-      where: { slug: { equals: TEMPLATE_TENANT_SLUG } },
-      limit: 1,
-    })
-    .then((res) => res.docs[0])
-
-  let navPageSlugs = new Set<string>()
-  let navBuiltInPages: Array<{ title: string; url: string }> = []
-
-  if (templateTenant) {
-    const templateNav = await payload
-      .find({
-        collection: 'navigations',
-        where: { tenant: { equals: templateTenant.id } },
-        limit: 1,
-        depth: 1,
-      })
-      .then((res) => res.docs[0])
-
-    const refs = extractNavReferences(templateNav ?? {})
-    navPageSlugs = refs.pageSlugs
-    navBuiltInPages = refs.builtInPages
-    log.info(
-      `[${tenant.slug}] Found ${navPageSlugs.size} page slugs and ${navBuiltInPages.length} built-in pages in template navigation`,
-    )
-  } else {
-    log.warn(`Template tenant "${TEMPLATE_TENANT_SLUG}" not found. Using default built-in pages.`)
-  }
-
-  // 3–4. Query AFP for forecast zones and resolve built-in pages
-  const { forecastPages, nonForecastPages } = await resolveBuiltInPages(
-    tenant.slug,
-    navBuiltInPages,
-    log,
-  )
+  // 2. Query AFP for forecast zones and resolve built-in pages
+  const { forecastPages, nonForecastPages } = await resolveBuiltInPages(tenant.slug, log)
   const builtInPagesToCreate = [...forecastPages, ...nonForecastPages]
   log.info(`[${tenant.slug}] Creating ${builtInPagesToCreate.length} built-in pages...`)
   const existingBuiltInPages = await payload.find({
@@ -337,79 +277,65 @@ export async function provision(payload: Payload, tenant: Tenant) {
     builtInPagesByUrl[bip.url] = bip
   }
 
-  // 5. Create blank pages for pages referenced in template navigation
+  // 3. Create blank pages for every entry in PAGES_TO_PROVISION
   const createdPages: Page[] = []
   const failedPages: string[] = []
   const pagesBySlug: Record<string, Page> = {}
 
-  if (templateTenant) {
-    // Query the template pages that are referenced in navigation
-    const templatePages = await payload.find({
-      collection: 'pages',
-      where: {
-        tenant: { equals: templateTenant.id },
-        _status: { equals: 'published' },
-        slug: { in: [...navPageSlugs].join(',') },
-      },
-      limit: 500,
-      depth: 0,
-    })
+  const existingPages = await payload.find({
+    collection: 'pages',
+    where: { tenant: { equals: tenant.id } },
+    limit: 500,
+    depth: 0,
+  })
+  const existingPagesBySlug = new Map(existingPages.docs.map((p) => [p.slug, p]))
 
-    // Check which pages already exist for this tenant (full objects for nav linking)
-    const existingPages = await payload.find({
-      collection: 'pages',
-      where: { tenant: { equals: tenant.id } },
-      limit: 500,
-      depth: 0,
-    })
-    const existingPagesBySlug = new Map(existingPages.docs.map((p) => [p.slug, p]))
-
-    for (const templatePage of templatePages.docs) {
-      const existing = existingPagesBySlug.get(templatePage.slug)
-      if (existing) {
-        log.info(`[${tenant.slug}] Page "${templatePage.title}" already exists, skipping`)
-        pagesBySlug[existing.slug] = existing
-        continue
-      }
-
-      try {
-        const newPage = await payload.create({
-          collection: 'pages',
-          data: {
-            layout: [
-              {
-                blockType: 'content',
-                backgroundColor: 'transparent',
-                layout: '1_1',
-                columns: [{ richText: simpleContent('') }],
-              },
-            ],
-            tenant: tenant.id,
-            title: templatePage.title,
-            slug: templatePage.slug,
-            _status: 'published',
-            publishedAt: new Date().toISOString(),
-          },
-        })
-        createdPages.push(newPage)
-        pagesBySlug[newPage.slug] = newPage
-      } catch (err) {
-        log.error(
-          `[${tenant.slug}] Failed to create page "${templatePage.title}" (slug: ${templatePage.slug}): ${err instanceof Error ? err.message : 'Unknown error'}`,
-        )
-        failedPages.push(templatePage.title)
-      }
+  for (const { slug, title } of PAGES_TO_PROVISION) {
+    const existing = existingPagesBySlug.get(slug)
+    if (existing) {
+      log.info(`[${tenant.slug}] Page "${title}" already exists, skipping`)
+      pagesBySlug[slug] = existing
+      continue
     }
 
-    // Also index any pre-existing pages we didn't create (from the initial query)
-    for (const p of existingPages.docs) {
-      if (!pagesBySlug[p.slug]) {
-        pagesBySlug[p.slug] = p
-      }
+    try {
+      const newPage = await payload.create({
+        collection: 'pages',
+        data: {
+          layout: [
+            {
+              blockType: 'content',
+              backgroundColor: 'transparent',
+              layout: '1_1',
+              columns: [{ richText: simpleContent('') }],
+            },
+          ],
+          tenant: tenant.id,
+          title,
+          slug,
+          _status: 'published',
+          publishedAt: new Date().toISOString(),
+        },
+      })
+      createdPages.push(newPage)
+      pagesBySlug[slug] = newPage
+    } catch (err) {
+      log.error(
+        `[${tenant.slug}] Failed to create page "${title}" (slug: ${slug}): ${err instanceof Error ? err.message : 'Unknown error'}`,
+      )
+      failedPages.push(title)
     }
   }
 
-  // 6. Create Home Page
+  // Also index any pre-existing pages not in PAGES_TO_PROVISION (so the nav
+  // builder can still reference them if present)
+  for (const p of existingPages.docs) {
+    if (!pagesBySlug[p.slug]) {
+      pagesBySlug[p.slug] = p
+    }
+  }
+
+  // 4. Create Home Page
   log.info(`[${tenant.slug}] Creating home page...`)
   const existingHomePage = await payload.find({
     collection: 'homePages',
@@ -485,7 +411,7 @@ export async function provision(payload: Payload, tenant: Tenant) {
     log.info(`[${tenant.slug}] Home page already exists, skipping`)
   }
 
-  // 7. Create Navigation
+  // 5. Create Navigation
   log.info(`[${tenant.slug}] Creating navigation...`)
   const existingNavigation = await payload.find({
     collection: 'navigations',
@@ -537,18 +463,27 @@ export async function provision(payload: Payload, tenant: Tenant) {
           forecasts:
             forecastPages.length === 1
               ? {
-                  link: navBuiltInPageItem(forecastPages[0].url, forecastPages[0].title)?.link,
-                  items: [],
+                  options: { displayMode: 'dropdown' },
+                  items: filterNulls([
+                    navBuiltInPageItem(forecastPages[0].url, forecastPages[0].title),
+                  ]),
                 }
               : {
-                  link: navBuiltInPageItem('/forecasts/avalanche', 'All Forecasts')?.link,
-                  items: filterNulls(
-                    forecastPages
-                      .filter((p) => p.url !== '/forecasts/avalanche')
-                      .map((p) => navBuiltInPageItem(p.url, p.title)),
-                  ),
+                  options: { displayMode: 'dropdown' },
+                  items: [
+                    ...filterNulls([navBuiltInPageItem('/forecasts/avalanche', 'All Forecasts')]),
+                    {
+                      label: 'Zones',
+                      items: filterNulls(
+                        forecastPages
+                          .filter((p) => p.url !== '/forecasts/avalanche')
+                          .map((p) => navBuiltInPageItem(p.url, p.title)),
+                      ),
+                    },
+                  ],
                 },
           observations: {
+            options: { displayMode: 'dropdown' },
             items: filterNulls([
               navBuiltInPageItem('/observations', 'Recent Observations'),
               navBuiltInPageItem('/observations/submit', 'Submit Observations'),
@@ -613,12 +548,12 @@ export async function provision(payload: Payload, tenant: Tenant) {
             ]),
           },
           blog: {
+            options: { displayMode: 'link', enabled: true },
             link: navBuiltInPageItem('/blog', 'Blog')?.link,
-            options: { enabled: true },
           },
           events: {
+            options: { displayMode: 'link', enabled: true },
             link: navBuiltInPageItem('/events', 'Events')?.link,
-            options: { enabled: true },
           },
           donate: {
             options: { displayMode: 'button' },

--- a/src/collections/Tenants/endpoints/provisionTenant.ts
+++ b/src/collections/Tenants/endpoints/provisionTenant.ts
@@ -1,11 +1,10 @@
 import { hasSuperAdminPermissions } from '@/access/hasSuperAdminPermissions'
 import { getSeedImageByFilename, simpleContent } from '@/endpoints/seed/utilities'
 import type { BuiltInPage, Page, Tenant } from '@/payload-types'
-import {
-  getActiveForecastZones,
-  getAvalancheCenterPlatforms,
-  type ActiveForecastZoneWithSlug,
-} from '@/services/nac/nac'
+// nac.ts imports @payload-config, which imports this collection — lazy-load
+// the value imports inside function bodies to break the circular dependency.
+// Type imports are erased at runtime and don't contribute to the cycle.
+import type { ActiveForecastZoneWithSlug } from '@/services/nac/nac'
 import type { Payload, PayloadHandler } from 'payload'
 import type { Logger } from 'pino'
 
@@ -66,6 +65,9 @@ export async function resolveBuiltInPages(
   forecastPages: Array<{ title: string; url: string }>
   nonForecastPages: Array<{ title: string; url: string }>
 }> {
+  // Lazy-loaded to break the circular import with @payload-config
+  const { getActiveForecastZones, getAvalancheCenterPlatforms } = await import('@/services/nac/nac')
+
   let forecastZones: ActiveForecastZoneWithSlug[] = []
   try {
     forecastZones = await getActiveForecastZones(tenantSlug)
@@ -153,12 +155,17 @@ export const provisionTenant: PayloadHandler = async (req) => {
   }
 
   try {
-    // Create the tenant
+    // Create the tenant. Initial provisioning is 'not_started'; the provision()
+    // call below overwrites with the actual outcome when it completes.
     const tenant = await payload.create({
       collection: 'tenants',
       data: {
         name: body.name,
         slug: body.slug,
+        provisioning: {
+          status: 'not_started',
+          lastRunAt: new Date().toISOString(),
+        },
       },
     })
 
@@ -190,10 +197,38 @@ export const provisionTenant: PayloadHandler = async (req) => {
  *
  * Idempotent - checks for existing data before creating.
  */
+
+export type ProvisioningFailed = NonNullable<NonNullable<Tenant['provisioning']>['failed']>
+
+const errorMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : 'Unknown error'
+
 export async function provision(payload: Payload, tenant: Tenant) {
   const log = payload.logger
 
   log.info(`Provisioning tenant: ${tenant.name} (${tenant.slug})`)
+
+  // Mark in_progress upfront so concurrent page loads / reloads see the
+  // active provisioning run and don't trigger a second one.
+  try {
+    await payload.update({
+      collection: 'tenants',
+      id: tenant.id,
+      data: {
+        provisioning: {
+          status: 'in_progress',
+          lastRunAt: new Date().toISOString(),
+          failed: undefined,
+        },
+      },
+    })
+  } catch (err) {
+    log.error(
+      `[${tenant.slug}] Failed to mark provisioning in_progress: ${err instanceof Error ? err.message : 'Unknown error'}`,
+    )
+  }
+
+  const failed: ProvisioningFailed = {}
 
   // 1. Create Website Settings with placeholder brand assets
   log.info(`[${tenant.slug}] Creating website settings...`)
@@ -204,41 +239,47 @@ export async function provision(payload: Payload, tenant: Tenant) {
   })
   let settingsCreated = false
   if (existingSettings.docs.length === 0) {
-    const [logoFile, iconFile, bannerFile] = await Promise.all([
-      getSeedImageByFilename('placeholder-logo.png', log),
-      getSeedImageByFilename('placeholder-icon.png', log),
-      getSeedImageByFilename('placeholder-banner.png', log),
-    ])
-    const [logo, icon, banner] = await Promise.all([
-      payload.create({
-        collection: 'media',
-        data: { tenant: tenant.id, alt: 'logo' },
-        file: logoFile,
-      }),
-      payload.create({
-        collection: 'media',
-        data: { tenant: tenant.id, alt: 'icon' },
-        file: iconFile,
-      }),
-      payload.create({
-        collection: 'media',
-        data: { tenant: tenant.id, alt: 'banner' },
-        file: bannerFile,
-      }),
-    ])
-    await payload.create({
-      collection: 'settings',
-      data: {
-        tenant: tenant.id,
-        description: tenant.name,
-        footerForm: { type: 'none' },
-        socialMedia: {},
-        logo: logo.id,
-        icon: icon.id,
-        banner: banner.id,
-      },
-    })
-    settingsCreated = true
+    try {
+      const [logoFile, iconFile, bannerFile] = await Promise.all([
+        getSeedImageByFilename('placeholder-logo.png', log),
+        getSeedImageByFilename('placeholder-icon.png', log),
+        getSeedImageByFilename('placeholder-banner.png', log),
+      ])
+      const [logo, icon, banner] = await Promise.all([
+        payload.create({
+          collection: 'media',
+          data: { tenant: tenant.id, alt: 'logo' },
+          file: logoFile,
+        }),
+        payload.create({
+          collection: 'media',
+          data: { tenant: tenant.id, alt: 'icon' },
+          file: iconFile,
+        }),
+        payload.create({
+          collection: 'media',
+          data: { tenant: tenant.id, alt: 'banner' },
+          file: bannerFile,
+        }),
+      ])
+      await payload.create({
+        collection: 'settings',
+        data: {
+          tenant: tenant.id,
+          description: tenant.name,
+          footerForm: { type: 'none' },
+          socialMedia: {},
+          logo: logo.id,
+          icon: icon.id,
+          banner: banner.id,
+        },
+      })
+      settingsCreated = true
+    } catch (err) {
+      const message = errorMessage(err)
+      log.error(`[${tenant.slug}] Failed to create website settings: ${message}`)
+      failed.websiteSettings = message
+    }
   } else {
     log.info(`[${tenant.slug}] Website settings already exist, skipping`)
   }
@@ -279,7 +320,6 @@ export async function provision(payload: Payload, tenant: Tenant) {
 
   // 3. Create blank pages for every entry in PAGES_TO_PROVISION
   const createdPages: Page[] = []
-  const failedPages: string[] = []
   const pagesBySlug: Record<string, Page> = {}
 
   const existingPages = await payload.find({
@@ -320,10 +360,10 @@ export async function provision(payload: Payload, tenant: Tenant) {
       createdPages.push(newPage)
       pagesBySlug[slug] = newPage
     } catch (err) {
-      log.error(
-        `[${tenant.slug}] Failed to create page "${title}" (slug: ${slug}): ${err instanceof Error ? err.message : 'Unknown error'}`,
-      )
-      failedPages.push(title)
+      const message = errorMessage(err)
+      log.error(`[${tenant.slug}] Failed to create page "${title}" (slug: ${slug}): ${message}`)
+      if (!failed.pages) failed.pages = {}
+      failed.pages[title] = message
     }
   }
 
@@ -403,9 +443,9 @@ export async function provision(payload: Payload, tenant: Tenant) {
       })
       homePageCreated = true
     } catch (err) {
-      log.error(
-        `[${tenant.slug}] Failed to create home page: ${err instanceof Error ? err.message : 'Unknown error'}`,
-      )
+      const message = errorMessage(err)
+      log.error(`[${tenant.slug}] Failed to create home page: ${message}`)
+      failed.homePage = message
     }
   } else {
     log.info(`[${tenant.slug}] Home page already exists, skipping`)
@@ -564,12 +604,37 @@ export async function provision(payload: Payload, tenant: Tenant) {
       })
       navigationCreated = true
     } catch (err) {
-      log.error(
-        `[${tenant.slug}] Failed to create navigation: ${err instanceof Error ? err.message : 'Unknown error'}`,
-      )
+      const message = errorMessage(err)
+      log.error(`[${tenant.slug}] Failed to create navigation: ${message}`)
+      failed.navigation = message
     }
   } else {
     log.info(`[${tenant.slug}] Navigation already exists, skipping`)
+  }
+
+  // Record the outcome on the tenant itself so the onboarding checklist can
+  // read a single source of truth instead of re-deriving status from live
+  // data. Partial = at least one step failed; Complete = everything succeeded.
+  // Lives on tenants (not settings) because it's lifecycle state, not
+  // configuration.
+  const hasFailures = Object.keys(failed).length > 0
+  const provisioningStatus: 'complete' | 'partial' = hasFailures ? 'partial' : 'complete'
+  try {
+    await payload.update({
+      collection: 'tenants',
+      id: tenant.id,
+      data: {
+        provisioning: {
+          status: provisioningStatus,
+          lastRunAt: new Date().toISOString(),
+          failed: hasFailures ? failed : undefined,
+        },
+      },
+    })
+  } catch (err) {
+    log.error(
+      `[${tenant.slug}] Failed to record provisioning status: ${err instanceof Error ? err.message : 'Unknown error'}`,
+    )
   }
 
   const summary = {
@@ -577,9 +642,10 @@ export async function provision(payload: Payload, tenant: Tenant) {
     settingsCreated,
     builtInPagesCreated: createdBuiltInPages.length - existingBuiltInPages.docs.length,
     pagesCreated: createdPages.length,
-    failedPages,
+    failedPages: Object.keys(failed.pages ?? {}),
     homePageCreated,
     navigationCreated,
+    provisioningStatus,
     // TODO: Theme creation (colors.css, centerColorMap in generateOGImage.tsx) requires manual steps.
   }
 

--- a/src/collections/Tenants/endpoints/provisionTenant.ts
+++ b/src/collections/Tenants/endpoints/provisionTenant.ts
@@ -1,13 +1,13 @@
 import { hasSuperAdminPermissions } from '@/access/hasSuperAdminPermissions'
 import { getSeedImageByFilename, simpleContent } from '@/endpoints/seed/utilities'
 import type { BuiltInPage, Navigation, Page, Tenant } from '@/payload-types'
+import { getActiveForecastZones, type ActiveForecastZoneWithSlug } from '@/services/nac/nac'
 import { isValidRelationship } from '@/utilities/relationships'
 import type { Payload, PayloadHandler } from 'payload'
 
 const TEMPLATE_TENANT_SLUG = 'dvac'
 
-export const BUILT_IN_PAGES: Array<{ title: string; url: string }> = [
-  { title: 'All Forecasts', url: '/forecasts/avalanche' },
+export const NON_FORECAST_BUILT_IN_PAGES: Array<{ title: string; url: string }> = [
   { title: 'Mountain Weather', url: '/weather/forecast' },
   { title: 'Weather Stations', url: '/weather/stations/map' },
   { title: 'Recent Observations', url: '/observations' },
@@ -15,6 +15,34 @@ export const BUILT_IN_PAGES: Array<{ title: string; url: string }> = [
   { title: 'Blog', url: '/blog' },
   { title: 'Events', url: '/events' },
 ]
+
+/**
+ * Builds the list of built-in pages based on forecast zones from AFP data.
+ * Forecast pages are always included (determined by AFP, not template nav).
+ * Non-forecast pages are filtered to those referenced in the template navigation.
+ */
+export function buildBuiltInPages(
+  zones: ActiveForecastZoneWithSlug[],
+  navBuiltInPageUrls?: Set<string>,
+): Array<{ title: string; url: string }> {
+  const forecastPages =
+    zones.length === 1
+      ? [{ title: 'Avalanche Forecast', url: `/forecasts/avalanche/${zones[0].slug}` }]
+      : [
+          { title: 'All Forecasts', url: '/forecasts/avalanche' },
+          ...zones.map(({ zone, slug }) => ({
+            title: zone.name,
+            url: `/forecasts/avalanche/${slug}`,
+          })),
+        ]
+
+  // Filter non-forecast pages to those referenced in template navigation
+  const nonForecastPages = navBuiltInPageUrls
+    ? NON_FORECAST_BUILT_IN_PAGES.filter((p) => navBuiltInPageUrls.has(p.url))
+    : NON_FORECAST_BUILT_IN_PAGES
+
+  return [...forecastPages, ...nonForecastPages]
+}
 
 /**
  * Creates a new tenant and provisions it with all default data.
@@ -80,10 +108,11 @@ export const provisionTenant: PayloadHandler = async (req) => {
  * Provisions a tenant with all default data:
  * 1. Website Settings with placeholder brand assets (logo, icon, banner)
  * 2. Look up template tenant (DVAC) navigation to determine which pages to create
- * 3. Built-in pages (filtered to those referenced in template navigation)
- * 4. Blank pages matching the template tenant's page structure
- * 5. Home page with default content
- * 6. Navigation linked to the new pages and built-in pages
+ * 3. Query AFP for forecast zones (single vs multi-zone detection)
+ * 4. Built-in pages (zone-aware, filtered to those referenced in template navigation)
+ * 5. Blank pages matching the template tenant's page structure
+ * 6. Home page with default content
+ * 7. Navigation linked to the new pages and built-in pages (zone-aware forecasts)
  *
  * Idempotent - checks for existing data before creating.
  */
@@ -229,9 +258,30 @@ export async function provision(payload: Payload, tenant: Tenant) {
     log.warn(`Template tenant "${TEMPLATE_TENANT_SLUG}" not found. Using default built-in pages.`)
   }
 
-  // 3. Create Built-In Pages
-  // TODO: Filter to only navigation-referenced built-in pages #999
-  log.info(`[${tenant.slug}] Creating built-in pages...`)
+  // 3. Query AFP for forecast zones
+  log.info(`[${tenant.slug}] Querying AFP for forecast zones...`)
+  let forecastZones: ActiveForecastZoneWithSlug[] = []
+  try {
+    forecastZones = await getActiveForecastZones(tenant.slug)
+    if (forecastZones.length === 0) {
+      log.warn(
+        `[${tenant.slug}] No forecast zones found from AFP. Creating default "All Forecasts" page.`,
+      )
+    } else {
+      log.info(`[${tenant.slug}] Found ${forecastZones.length} forecast zone(s) from AFP`)
+    }
+  } catch (err) {
+    log.warn(
+      `[${tenant.slug}] Failed to query AFP for forecast zones: ${err instanceof Error ? err.message : 'Unknown error'}. Creating default "All Forecasts" page.`,
+    )
+  }
+
+  // 4. Create Built-In Pages (zone-aware, filtered to nav-referenced)
+  const builtInPagesToCreate = buildBuiltInPages(
+    forecastZones,
+    navBuiltInPageUrls.size > 0 ? navBuiltInPageUrls : undefined,
+  )
+  log.info(`[${tenant.slug}] Creating ${builtInPagesToCreate.length} built-in pages...`)
   const existingBuiltInPages = await payload.find({
     collection: 'builtInPages',
     where: { tenant: { equals: tenant.id } },
@@ -240,7 +290,7 @@ export async function provision(payload: Payload, tenant: Tenant) {
   const existingBuiltInPageUrls = new Set(existingBuiltInPages.docs.map((p) => p.url))
 
   const createdBuiltInPages: BuiltInPage[] = [...existingBuiltInPages.docs]
-  for (const { title, url } of BUILT_IN_PAGES) {
+  for (const { title, url } of builtInPagesToCreate) {
     if (existingBuiltInPageUrls.has(url)) {
       log.info(`[${tenant.slug}] Built-in page "${title}" already exists, skipping`)
       continue
@@ -262,7 +312,7 @@ export async function provision(payload: Payload, tenant: Tenant) {
     builtInPagesByUrl[bip.url] = bip
   }
 
-  // 4. Create blank pages for pages referenced in template navigation
+  // 5. Create blank pages for pages referenced in template navigation
   const createdPages: Page[] = []
   const failedPages: string[] = []
   const pagesBySlug: Record<string, Page> = {}
@@ -334,7 +384,7 @@ export async function provision(payload: Payload, tenant: Tenant) {
     }
   }
 
-  // 5. Create Home Page
+  // 6. Create Home Page
   log.info(`[${tenant.slug}] Creating home page...`)
   const existingHomePage = await payload.find({
     collection: 'homePages',
@@ -410,7 +460,7 @@ export async function provision(payload: Payload, tenant: Tenant) {
     log.info(`[${tenant.slug}] Home page already exists, skipping`)
   }
 
-  // 6. Create Navigation
+  // 7. Create Navigation
   log.info(`[${tenant.slug}] Creating navigation...`)
   const existingNavigation = await payload.find({
     collection: 'navigations',
@@ -459,8 +509,31 @@ export async function provision(payload: Payload, tenant: Tenant) {
         collection: 'navigations',
         data: {
           tenant: tenant.id,
-          forecasts: { options: { displayMode: 'dropdown' }, items: [] },
-          observations: { options: { displayMode: 'dropdown' }, items: [] },
+          forecasts:
+            forecastZones.length === 1
+              ? {
+                  link: navBuiltInPageItem(
+                    `/forecasts/avalanche/${forecastZones[0].slug}`,
+                    'Avalanche Forecast',
+                  )?.link,
+                  items: [],
+                }
+              : {
+                  link: navBuiltInPageItem('/forecasts/avalanche', 'All Forecasts')?.link,
+                  items: filterNulls(
+                    forecastZones
+                      .sort((a, b) => (a.zone.rank ?? Infinity) - (b.zone.rank ?? Infinity))
+                      .map(({ zone, slug }) =>
+                        navBuiltInPageItem(`/forecasts/avalanche/${slug}`, zone.name),
+                      ),
+                  ),
+                },
+          observations: {
+            items: filterNulls([
+              navBuiltInPageItem('/observations', 'Recent Observations'),
+              navBuiltInPageItem('/observations/submit', 'Submit Observations'),
+            ]),
+          },
           weather: {
             options: { displayMode: 'dropdown' },
             items: filterNulls([

--- a/src/collections/Tenants/endpoints/provisionTenant.ts
+++ b/src/collections/Tenants/endpoints/provisionTenant.ts
@@ -596,6 +596,14 @@ export async function provision(payload: Payload, tenant: Tenant) {
               navPageItem('avalanche-accident-map'),
             ]),
           },
+          blog: {
+            link: navBuiltInPageItem('/blog', 'Blog')?.link,
+            options: { enabled: true },
+          },
+          events: {
+            link: navBuiltInPageItem('/events', 'Events')?.link,
+            options: { enabled: true },
+          },
           donate: {
             options: { displayMode: 'button' },
             link: navPageItem('donate-membership', 'Donate')?.link,

--- a/src/collections/Tenants/endpoints/provisionTenant.ts
+++ b/src/collections/Tenants/endpoints/provisionTenant.ts
@@ -200,6 +200,10 @@ export const provisionTenant: PayloadHandler = async (req) => {
 
 export type ProvisioningFailed = NonNullable<NonNullable<Tenant['provisioning']>['failed']>
 
+// A run that's been in_progress longer than this is treated as crashed; the
+// next caller is allowed to take over.
+export const STALE_IN_PROGRESS_MS = 5 * 60 * 1000
+
 const errorMessage = (err: unknown): string =>
   err instanceof Error ? err.message : 'Unknown error'
 
@@ -208,24 +212,34 @@ export async function provision(payload: Payload, tenant: Tenant) {
 
   log.info(`Provisioning tenant: ${tenant.name} (${tenant.slug})`)
 
-  // Mark in_progress upfront so concurrent page loads / reloads see the
-  // active provisioning run and don't trigger a second one.
-  try {
-    await payload.update({
-      collection: 'tenants',
-      id: tenant.id,
-      data: {
-        provisioning: {
-          status: 'in_progress',
-          lastRunAt: new Date().toISOString(),
-          failed: undefined,
+  // Acquire a per-tenant lock; take over stale runs to recover from crashes.
+  const now = new Date()
+  const staleCutoff = new Date(now.getTime() - STALE_IN_PROGRESS_MS).toISOString()
+  const lockResult = await payload.update({
+    collection: 'tenants',
+    where: {
+      and: [
+        { id: { equals: tenant.id } },
+        {
+          or: [
+            { 'provisioning.status': { not_equals: 'in_progress' } },
+            { 'provisioning.lastRunAt': { less_than: staleCutoff } },
+          ],
         },
+      ],
+    },
+    data: {
+      provisioning: {
+        status: 'in_progress',
+        lastRunAt: now.toISOString(),
+        failed: undefined,
       },
-    })
-  } catch (err) {
-    log.error(
-      `[${tenant.slug}] Failed to mark provisioning in_progress: ${err instanceof Error ? err.message : 'Unknown error'}`,
-    )
+    },
+  })
+
+  if (lockResult.docs.length === 0) {
+    log.warn(`[${tenant.slug}] Skipping provision — another run is already active`)
+    throw new Error(`Provisioning is already in progress for ${tenant.slug}`)
   }
 
   const failed: ProvisioningFailed = {}

--- a/src/collections/Tenants/index.ts
+++ b/src/collections/Tenants/index.ts
@@ -93,7 +93,7 @@ export const Tenants: CollectionConfig = {
             { label: 'In progress', value: 'in_progress' },
             { label: 'Complete', value: 'complete' },
             { label: 'Partial', value: 'partial' },
-            { label: 'Complete manual actions', value: 'manual' },
+            { label: 'Complete — manual actions remaining', value: 'manual' },
           ],
         },
         { name: 'lastRunAt', type: 'date' },

--- a/src/collections/Tenants/index.ts
+++ b/src/collections/Tenants/index.ts
@@ -93,6 +93,7 @@ export const Tenants: CollectionConfig = {
             { label: 'In progress', value: 'in_progress' },
             { label: 'Complete', value: 'complete' },
             { label: 'Partial', value: 'partial' },
+            { label: 'Complete manual actions', value: 'manual' },
           ],
         },
         { name: 'lastRunAt', type: 'date' },

--- a/src/collections/Tenants/index.ts
+++ b/src/collections/Tenants/index.ts
@@ -76,6 +76,60 @@ export const Tenants: CollectionConfig = {
     },
     contentHashField(),
     {
+      name: 'provisioning',
+      type: 'group',
+      label: 'Provisioning',
+      admin: {
+        hidden: true,
+      },
+      fields: [
+        {
+          name: 'status',
+          type: 'select',
+          defaultValue: 'not_started',
+          required: true,
+          options: [
+            { label: 'Not started', value: 'not_started' },
+            { label: 'In progress', value: 'in_progress' },
+            { label: 'Complete', value: 'complete' },
+            { label: 'Partial', value: 'partial' },
+          ],
+        },
+        { name: 'lastRunAt', type: 'date' },
+        {
+          name: 'failed',
+          type: 'json',
+          admin: {
+            description:
+              'What failed during the last provisioning run. Empty when everything succeeded.',
+          },
+          jsonSchema: {
+            uri: 'a://b/tenant-provisioning-failed.json',
+            fileMatch: ['a://b/tenant-provisioning-failed.json'],
+            // Presence of a key means that step failed; the value is the
+            // error message (stored for debugging, not shown in admin UI).
+            // `pages` is page-name → error message.
+            schema: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                pages: {
+                  type: 'object',
+                  additionalProperties: { type: 'string' },
+                },
+                homePage: { type: 'string' },
+                navigation: { type: 'string' },
+                websiteSettings: { type: 'string' },
+                // Set synthetically on read when an in_progress run has gone
+                // past the staleness window — see checkProvisioningStatusAction.
+                timedOut: { type: 'string' },
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
       type: 'ui',
       name: 'onboardingChecklist',
       label: 'Onboarding Status',

--- a/src/endpoints/bootstrap/index.ts
+++ b/src/endpoints/bootstrap/index.ts
@@ -59,22 +59,31 @@ export const bootstrap = async ({
 
   payload.logger.info(`— Seeding tenants...`)
 
+  const bootstrappedProvisioning = {
+    status: 'complete' as const,
+    lastRunAt: new Date().toISOString(),
+    failed: undefined,
+  }
   const tenantData: RequiredDataFromCollectionSlug<'tenants'>[] = [
     {
       name: 'Death Valley Avalanche Center',
       slug: 'dvac',
+      provisioning: bootstrappedProvisioning,
     },
     {
       name: 'Northwest Avalanche Center',
       slug: 'nwac',
+      provisioning: bootstrappedProvisioning,
     },
     {
       name: 'Sierra Avalanche Center',
       slug: 'sac',
+      provisioning: bootstrappedProvisioning,
     },
     {
       name: 'Sawtooth Avalanche Center',
       slug: 'snfac',
+      provisioning: bootstrappedProvisioning,
     },
   ]
   for (const data of tenantData) {

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -201,22 +201,34 @@ export const seed = async ({
       },
     })
 
+    // Seed tenants with provisioning status already 'complete' so the
+    // onboarding checklist shows Complete without requiring a manual re-run.
+    const seededAt = new Date().toISOString()
+    const seededProvisioning = {
+      status: 'complete' as const,
+      lastRunAt: seededAt,
+      failed: undefined,
+    }
     const tenants = await upsertGlobals('tenants', payload, incremental, (obj) => obj.slug, [
       {
         name: 'Death Valley Avalanche Center',
         slug: 'dvac',
+        provisioning: seededProvisioning,
       },
       {
         name: 'Northwest Avalanche Center',
         slug: 'nwac',
+        provisioning: seededProvisioning,
       },
       {
         name: 'Sierra Avalanche Center',
         slug: 'sac',
+        provisioning: seededProvisioning,
       },
       {
         name: 'Sawtooth Avalanche Center',
         slug: 'snfac',
+        provisioning: seededProvisioning,
       },
     ])
     const tenantsById: Record<number, Tenant> = {}

--- a/src/migrations/20260421_181446_add_tenant_provisioning_field.json
+++ b/src/migrations/20260421_181446_add_tenant_provisioning_field.json
@@ -1,0 +1,25063 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "home_pages_quick_links": {
+      "name": "home_pages_quick_links",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "new_tab": {
+          "name": "new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_quick_links_order_idx": {
+          "name": "home_pages_quick_links_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_quick_links_parent_id_idx": {
+          "name": "home_pages_quick_links_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_quick_links_parent_id_fk": {
+          "name": "home_pages_quick_links_parent_id_fk",
+          "tableFrom": "home_pages_quick_links",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_highlighted_content_columns": {
+      "name": "home_pages_highlighted_content_columns",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_highlighted_content_columns_order_idx": {
+          "name": "home_pages_highlighted_content_columns_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_highlighted_content_columns_parent_id_idx": {
+          "name": "home_pages_highlighted_content_columns_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_highlighted_content_columns_parent_id_fk": {
+          "name": "home_pages_highlighted_content_columns_parent_id_fk",
+          "tableFrom": "home_pages_highlighted_content_columns",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_blog_list": {
+      "name": "home_pages_blocks_blog_list",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "below_heading_content": {
+          "name": "below_heading_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "post_options": {
+          "name": "post_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dynamic'"
+        },
+        "dynamic_options_sort_by": {
+          "name": "dynamic_options_sort_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'-publishedAt'"
+        },
+        "dynamic_options_max_posts": {
+          "name": "dynamic_options_max_posts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_blog_list_order_idx": {
+          "name": "home_pages_blocks_blog_list_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_blog_list_parent_id_idx": {
+          "name": "home_pages_blocks_blog_list_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_blog_list_path_idx": {
+          "name": "home_pages_blocks_blog_list_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_blog_list_parent_id_fk": {
+          "name": "home_pages_blocks_blog_list_parent_id_fk",
+          "tableFrom": "home_pages_blocks_blog_list",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_content_columns": {
+      "name": "home_pages_blocks_content_columns",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{\"root\":{\"type\":\"root\",\"format\":\"\",\"indent\":0,\"version\":1,\"children\":[{\"type\":\"paragraph\",\"format\":\"\",\"indent\":0,\"version\":1,\"children\":[],\"direction\":\"ltr\",\"textStyle\":\"\",\"textFormat\":0}],\"direction\":\"ltr\"}}'"
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_content_columns_order_idx": {
+          "name": "home_pages_blocks_content_columns_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_content_columns_parent_id_idx": {
+          "name": "home_pages_blocks_content_columns_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_content_columns_parent_id_fk": {
+          "name": "home_pages_blocks_content_columns_parent_id_fk",
+          "tableFrom": "home_pages_blocks_content_columns",
+          "tableTo": "home_pages_blocks_content",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_content": {
+      "name": "home_pages_blocks_content",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'1_1'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_content_order_idx": {
+          "name": "home_pages_blocks_content_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_content_parent_id_idx": {
+          "name": "home_pages_blocks_content_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_content_path_idx": {
+          "name": "home_pages_blocks_content_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_content_parent_id_fk": {
+          "name": "home_pages_blocks_content_parent_id_fk",
+          "tableFrom": "home_pages_blocks_content",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_document_block": {
+      "name": "home_pages_blocks_document_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_document_block_order_idx": {
+          "name": "home_pages_blocks_document_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_document_block_parent_id_idx": {
+          "name": "home_pages_blocks_document_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_document_block_path_idx": {
+          "name": "home_pages_blocks_document_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "home_pages_blocks_document_block_document_idx": {
+          "name": "home_pages_blocks_document_block_document_idx",
+          "columns": ["document_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_document_block_document_id_documents_id_fk": {
+          "name": "home_pages_blocks_document_block_document_id_documents_id_fk",
+          "tableFrom": "home_pages_blocks_document_block",
+          "tableTo": "documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_pages_blocks_document_block_parent_id_fk": {
+          "name": "home_pages_blocks_document_block_parent_id_fk",
+          "tableFrom": "home_pages_blocks_document_block",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_event_list_dynamic_opts_by_types": {
+      "name": "home_pages_blocks_event_list_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_event_list_dynamic_opts_by_types_order_idx": {
+          "name": "home_pages_blocks_event_list_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_event_list_dynamic_opts_by_types_parent_idx": {
+          "name": "home_pages_blocks_event_list_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_event_list_dynamic_opts_by_types_parent_fk": {
+          "name": "home_pages_blocks_event_list_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "home_pages_blocks_event_list_dynamic_opts_by_types",
+          "tableTo": "home_pages_blocks_event_list",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_event_list": {
+      "name": "home_pages_blocks_event_list",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "below_heading_content": {
+          "name": "below_heading_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_options": {
+          "name": "event_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dynamic'"
+        },
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_event_list_order_idx": {
+          "name": "home_pages_blocks_event_list_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_event_list_parent_id_idx": {
+          "name": "home_pages_blocks_event_list_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_event_list_path_idx": {
+          "name": "home_pages_blocks_event_list_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_event_list_parent_id_fk": {
+          "name": "home_pages_blocks_event_list_parent_id_fk",
+          "tableFrom": "home_pages_blocks_event_list",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_event_table_dynamic_opts_by_types": {
+      "name": "home_pages_blocks_event_table_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_event_table_dynamic_opts_by_types_order_idx": {
+          "name": "home_pages_blocks_event_table_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_event_table_dynamic_opts_by_types_parent_idx": {
+          "name": "home_pages_blocks_event_table_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_event_table_dynamic_opts_by_types_parent_fk": {
+          "name": "home_pages_blocks_event_table_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "home_pages_blocks_event_table_dynamic_opts_by_types",
+          "tableTo": "home_pages_blocks_event_table",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_event_table": {
+      "name": "home_pages_blocks_event_table",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "below_heading_content": {
+          "name": "below_heading_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_options": {
+          "name": "event_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dynamic'"
+        },
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_event_table_order_idx": {
+          "name": "home_pages_blocks_event_table_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_event_table_parent_id_idx": {
+          "name": "home_pages_blocks_event_table_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_event_table_path_idx": {
+          "name": "home_pages_blocks_event_table_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_event_table_parent_id_fk": {
+          "name": "home_pages_blocks_event_table_parent_id_fk",
+          "tableFrom": "home_pages_blocks_event_table",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_form_block": {
+      "name": "home_pages_blocks_form_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_intro": {
+          "name": "enable_intro",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intro_content": {
+          "name": "intro_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_form_block_order_idx": {
+          "name": "home_pages_blocks_form_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_form_block_parent_id_idx": {
+          "name": "home_pages_blocks_form_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_form_block_path_idx": {
+          "name": "home_pages_blocks_form_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "home_pages_blocks_form_block_form_idx": {
+          "name": "home_pages_blocks_form_block_form_idx",
+          "columns": ["form_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_form_block_form_id_forms_id_fk": {
+          "name": "home_pages_blocks_form_block_form_id_forms_id_fk",
+          "tableFrom": "home_pages_blocks_form_block",
+          "tableTo": "forms",
+          "columnsFrom": ["form_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_pages_blocks_form_block_parent_id_fk": {
+          "name": "home_pages_blocks_form_block_parent_id_fk",
+          "tableFrom": "home_pages_blocks_form_block",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_generic_embed": {
+      "name": "home_pages_blocks_generic_embed",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "align_content": {
+          "name": "align_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_generic_embed_order_idx": {
+          "name": "home_pages_blocks_generic_embed_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_generic_embed_parent_id_idx": {
+          "name": "home_pages_blocks_generic_embed_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_generic_embed_path_idx": {
+          "name": "home_pages_blocks_generic_embed_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_generic_embed_parent_id_fk": {
+          "name": "home_pages_blocks_generic_embed_parent_id_fk",
+          "tableFrom": "home_pages_blocks_generic_embed",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_header_block": {
+      "name": "home_pages_blocks_header_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "full_width_color": {
+          "name": "full_width_color",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_header_block_order_idx": {
+          "name": "home_pages_blocks_header_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_header_block_parent_id_idx": {
+          "name": "home_pages_blocks_header_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_header_block_path_idx": {
+          "name": "home_pages_blocks_header_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_header_block_parent_id_fk": {
+          "name": "home_pages_blocks_header_block_parent_id_fk",
+          "tableFrom": "home_pages_blocks_header_block",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_image_link_grid_columns": {
+      "name": "home_pages_blocks_image_link_grid_columns",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_image_link_grid_columns_order_idx": {
+          "name": "home_pages_blocks_image_link_grid_columns_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_image_link_grid_columns_parent_id_idx": {
+          "name": "home_pages_blocks_image_link_grid_columns_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_image_link_grid_columns_image_idx": {
+          "name": "home_pages_blocks_image_link_grid_columns_image_idx",
+          "columns": ["image_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_image_link_grid_columns_image_id_media_id_fk": {
+          "name": "home_pages_blocks_image_link_grid_columns_image_id_media_id_fk",
+          "tableFrom": "home_pages_blocks_image_link_grid_columns",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_pages_blocks_image_link_grid_columns_parent_id_fk": {
+          "name": "home_pages_blocks_image_link_grid_columns_parent_id_fk",
+          "tableFrom": "home_pages_blocks_image_link_grid_columns",
+          "tableTo": "home_pages_blocks_image_link_grid",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_image_link_grid": {
+      "name": "home_pages_blocks_image_link_grid",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_image_link_grid_order_idx": {
+          "name": "home_pages_blocks_image_link_grid_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_image_link_grid_parent_id_idx": {
+          "name": "home_pages_blocks_image_link_grid_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_image_link_grid_path_idx": {
+          "name": "home_pages_blocks_image_link_grid_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_image_link_grid_parent_id_fk": {
+          "name": "home_pages_blocks_image_link_grid_parent_id_fk",
+          "tableFrom": "home_pages_blocks_image_link_grid",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_image_text": {
+      "name": "home_pages_blocks_image_text",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "image_layout": {
+          "name": "image_layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_wrap": {
+          "name": "text_wrap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_image_text_order_idx": {
+          "name": "home_pages_blocks_image_text_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_image_text_parent_id_idx": {
+          "name": "home_pages_blocks_image_text_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_image_text_path_idx": {
+          "name": "home_pages_blocks_image_text_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "home_pages_blocks_image_text_image_idx": {
+          "name": "home_pages_blocks_image_text_image_idx",
+          "columns": ["image_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_image_text_image_id_media_id_fk": {
+          "name": "home_pages_blocks_image_text_image_id_media_id_fk",
+          "tableFrom": "home_pages_blocks_image_text",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_pages_blocks_image_text_parent_id_fk": {
+          "name": "home_pages_blocks_image_text_parent_id_fk",
+          "tableFrom": "home_pages_blocks_image_text",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_link_preview_cards": {
+      "name": "home_pages_blocks_link_preview_cards",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_type": {
+          "name": "button_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "button_new_tab": {
+          "name": "button_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_url": {
+          "name": "button_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_label": {
+          "name": "button_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_variant": {
+          "name": "button_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'default'"
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_link_preview_cards_order_idx": {
+          "name": "home_pages_blocks_link_preview_cards_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_link_preview_cards_parent_id_idx": {
+          "name": "home_pages_blocks_link_preview_cards_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_link_preview_cards_image_idx": {
+          "name": "home_pages_blocks_link_preview_cards_image_idx",
+          "columns": ["image_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_link_preview_cards_image_id_media_id_fk": {
+          "name": "home_pages_blocks_link_preview_cards_image_id_media_id_fk",
+          "tableFrom": "home_pages_blocks_link_preview_cards",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_pages_blocks_link_preview_cards_parent_id_fk": {
+          "name": "home_pages_blocks_link_preview_cards_parent_id_fk",
+          "tableFrom": "home_pages_blocks_link_preview_cards",
+          "tableTo": "home_pages_blocks_link_preview",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_link_preview": {
+      "name": "home_pages_blocks_link_preview",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_link_preview_order_idx": {
+          "name": "home_pages_blocks_link_preview_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_link_preview_parent_id_idx": {
+          "name": "home_pages_blocks_link_preview_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_link_preview_path_idx": {
+          "name": "home_pages_blocks_link_preview_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_link_preview_parent_id_fk": {
+          "name": "home_pages_blocks_link_preview_parent_id_fk",
+          "tableFrom": "home_pages_blocks_link_preview",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_media_block": {
+      "name": "home_pages_blocks_media_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "align_content": {
+          "name": "align_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "image_size": {
+          "name": "image_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'original'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_media_block_order_idx": {
+          "name": "home_pages_blocks_media_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_media_block_parent_id_idx": {
+          "name": "home_pages_blocks_media_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_media_block_path_idx": {
+          "name": "home_pages_blocks_media_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "home_pages_blocks_media_block_media_idx": {
+          "name": "home_pages_blocks_media_block_media_idx",
+          "columns": ["media_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_media_block_media_id_media_id_fk": {
+          "name": "home_pages_blocks_media_block_media_id_media_id_fk",
+          "tableFrom": "home_pages_blocks_media_block",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_pages_blocks_media_block_parent_id_fk": {
+          "name": "home_pages_blocks_media_block_parent_id_fk",
+          "tableFrom": "home_pages_blocks_media_block",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_nac_media_block": {
+      "name": "home_pages_blocks_nac_media_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'carousel'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_nac_media_block_order_idx": {
+          "name": "home_pages_blocks_nac_media_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_nac_media_block_parent_id_idx": {
+          "name": "home_pages_blocks_nac_media_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_nac_media_block_path_idx": {
+          "name": "home_pages_blocks_nac_media_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_nac_media_block_parent_id_fk": {
+          "name": "home_pages_blocks_nac_media_block_parent_id_fk",
+          "tableFrom": "home_pages_blocks_nac_media_block",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_single_blog_post": {
+      "name": "home_pages_blocks_single_blog_post",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_single_blog_post_order_idx": {
+          "name": "home_pages_blocks_single_blog_post_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_single_blog_post_parent_id_idx": {
+          "name": "home_pages_blocks_single_blog_post_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_single_blog_post_path_idx": {
+          "name": "home_pages_blocks_single_blog_post_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "home_pages_blocks_single_blog_post_post_idx": {
+          "name": "home_pages_blocks_single_blog_post_post_idx",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_single_blog_post_post_id_posts_id_fk": {
+          "name": "home_pages_blocks_single_blog_post_post_id_posts_id_fk",
+          "tableFrom": "home_pages_blocks_single_blog_post",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_pages_blocks_single_blog_post_parent_id_fk": {
+          "name": "home_pages_blocks_single_blog_post_parent_id_fk",
+          "tableFrom": "home_pages_blocks_single_blog_post",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_single_event": {
+      "name": "home_pages_blocks_single_event",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_single_event_order_idx": {
+          "name": "home_pages_blocks_single_event_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_single_event_parent_id_idx": {
+          "name": "home_pages_blocks_single_event_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_single_event_path_idx": {
+          "name": "home_pages_blocks_single_event_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "home_pages_blocks_single_event_event_idx": {
+          "name": "home_pages_blocks_single_event_event_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_single_event_event_id_events_id_fk": {
+          "name": "home_pages_blocks_single_event_event_id_events_id_fk",
+          "tableFrom": "home_pages_blocks_single_event",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_pages_blocks_single_event_parent_id_fk": {
+          "name": "home_pages_blocks_single_event_parent_id_fk",
+          "tableFrom": "home_pages_blocks_single_event",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_sponsors_block": {
+      "name": "home_pages_blocks_sponsors_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "sponsors_layout": {
+          "name": "sponsors_layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'static'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_sponsors_block_order_idx": {
+          "name": "home_pages_blocks_sponsors_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_sponsors_block_parent_id_idx": {
+          "name": "home_pages_blocks_sponsors_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_sponsors_block_path_idx": {
+          "name": "home_pages_blocks_sponsors_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_sponsors_block_parent_id_fk": {
+          "name": "home_pages_blocks_sponsors_block_parent_id_fk",
+          "tableFrom": "home_pages_blocks_sponsors_block",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_team": {
+      "name": "home_pages_blocks_team",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_team_order_idx": {
+          "name": "home_pages_blocks_team_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_team_parent_id_idx": {
+          "name": "home_pages_blocks_team_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "home_pages_blocks_team_path_idx": {
+          "name": "home_pages_blocks_team_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "home_pages_blocks_team_team_idx": {
+          "name": "home_pages_blocks_team_team_idx",
+          "columns": ["team_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_team_team_id_teams_id_fk": {
+          "name": "home_pages_blocks_team_team_id_teams_id_fk",
+          "tableFrom": "home_pages_blocks_team",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "home_pages_blocks_team_parent_id_fk": {
+          "name": "home_pages_blocks_team_parent_id_fk",
+          "tableFrom": "home_pages_blocks_team",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_blocks_in_highlighted_content": {
+      "name": "home_pages_blocks_in_highlighted_content",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "block_type": {
+          "name": "block_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_blocks_in_highlighted_content_order_idx": {
+          "name": "home_pages_blocks_in_highlighted_content_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_blocks_in_highlighted_content_parent_id_idx": {
+          "name": "home_pages_blocks_in_highlighted_content_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_blocks_in_highlighted_content_parent_id_fk": {
+          "name": "home_pages_blocks_in_highlighted_content_parent_id_fk",
+          "tableFrom": "home_pages_blocks_in_highlighted_content",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_document_references": {
+      "name": "home_pages_document_references",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instances": {
+          "name": "instances",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_document_references_order_idx": {
+          "name": "home_pages_document_references_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "home_pages_document_references_parent_id_idx": {
+          "name": "home_pages_document_references_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_document_references_parent_id_fk": {
+          "name": "home_pages_document_references_parent_id_fk",
+          "tableFrom": "home_pages_document_references",
+          "tableTo": "home_pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages": {
+      "name": "home_pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "highlighted_content_enabled": {
+          "name": "highlighted_content_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "highlighted_content_heading": {
+          "name": "highlighted_content_heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "highlighted_content_background_color": {
+          "name": "highlighted_content_background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "home_pages_tenant_idx": {
+          "name": "home_pages_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": true
+        },
+        "home_pages_updated_at_idx": {
+          "name": "home_pages_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "home_pages_created_at_idx": {
+          "name": "home_pages_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "home_pages__status_idx": {
+          "name": "home_pages__status_idx",
+          "columns": ["_status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_tenant_id_tenants_id_fk": {
+          "name": "home_pages_tenant_id_tenants_id_fk",
+          "tableFrom": "home_pages",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "home_pages_rels": {
+      "name": "home_pages_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "built_in_pages_id": {
+          "name": "built_in_pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posts_id": {
+          "name": "posts_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_groups_id": {
+          "name": "event_groups_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_tags_id": {
+          "name": "event_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events_id": {
+          "name": "events_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sponsors_id": {
+          "name": "sponsors_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "home_pages_rels_order_idx": {
+          "name": "home_pages_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "home_pages_rels_parent_idx": {
+          "name": "home_pages_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "home_pages_rels_path_idx": {
+          "name": "home_pages_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "home_pages_rels_pages_id_idx": {
+          "name": "home_pages_rels_pages_id_idx",
+          "columns": ["pages_id"],
+          "isUnique": false
+        },
+        "home_pages_rels_built_in_pages_id_idx": {
+          "name": "home_pages_rels_built_in_pages_id_idx",
+          "columns": ["built_in_pages_id"],
+          "isUnique": false
+        },
+        "home_pages_rels_posts_id_idx": {
+          "name": "home_pages_rels_posts_id_idx",
+          "columns": ["posts_id"],
+          "isUnique": false
+        },
+        "home_pages_rels_tags_id_idx": {
+          "name": "home_pages_rels_tags_id_idx",
+          "columns": ["tags_id"],
+          "isUnique": false
+        },
+        "home_pages_rels_event_groups_id_idx": {
+          "name": "home_pages_rels_event_groups_id_idx",
+          "columns": ["event_groups_id"],
+          "isUnique": false
+        },
+        "home_pages_rels_event_tags_id_idx": {
+          "name": "home_pages_rels_event_tags_id_idx",
+          "columns": ["event_tags_id"],
+          "isUnique": false
+        },
+        "home_pages_rels_events_id_idx": {
+          "name": "home_pages_rels_events_id_idx",
+          "columns": ["events_id"],
+          "isUnique": false
+        },
+        "home_pages_rels_sponsors_id_idx": {
+          "name": "home_pages_rels_sponsors_id_idx",
+          "columns": ["sponsors_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "home_pages_rels_parent_fk": {
+          "name": "home_pages_rels_parent_fk",
+          "tableFrom": "home_pages_rels",
+          "tableTo": "home_pages",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "home_pages_rels_pages_fk": {
+          "name": "home_pages_rels_pages_fk",
+          "tableFrom": "home_pages_rels",
+          "tableTo": "pages",
+          "columnsFrom": ["pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "home_pages_rels_built_in_pages_fk": {
+          "name": "home_pages_rels_built_in_pages_fk",
+          "tableFrom": "home_pages_rels",
+          "tableTo": "built_in_pages",
+          "columnsFrom": ["built_in_pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "home_pages_rels_posts_fk": {
+          "name": "home_pages_rels_posts_fk",
+          "tableFrom": "home_pages_rels",
+          "tableTo": "posts",
+          "columnsFrom": ["posts_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "home_pages_rels_tags_fk": {
+          "name": "home_pages_rels_tags_fk",
+          "tableFrom": "home_pages_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "home_pages_rels_event_groups_fk": {
+          "name": "home_pages_rels_event_groups_fk",
+          "tableFrom": "home_pages_rels",
+          "tableTo": "event_groups",
+          "columnsFrom": ["event_groups_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "home_pages_rels_event_tags_fk": {
+          "name": "home_pages_rels_event_tags_fk",
+          "tableFrom": "home_pages_rels",
+          "tableTo": "event_tags",
+          "columnsFrom": ["event_tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "home_pages_rels_events_fk": {
+          "name": "home_pages_rels_events_fk",
+          "tableFrom": "home_pages_rels",
+          "tableTo": "events",
+          "columnsFrom": ["events_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "home_pages_rels_sponsors_fk": {
+          "name": "home_pages_rels_sponsors_fk",
+          "tableFrom": "home_pages_rels",
+          "tableTo": "sponsors",
+          "columnsFrom": ["sponsors_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_version_quick_links": {
+      "name": "_home_pages_v_version_quick_links",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "new_tab": {
+          "name": "new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_version_quick_links_order_idx": {
+          "name": "_home_pages_v_version_quick_links_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_version_quick_links_parent_id_idx": {
+          "name": "_home_pages_v_version_quick_links_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_version_quick_links_parent_id_fk": {
+          "name": "_home_pages_v_version_quick_links_parent_id_fk",
+          "tableFrom": "_home_pages_v_version_quick_links",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_version_highlighted_content_columns": {
+      "name": "_home_pages_v_version_highlighted_content_columns",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_version_highlighted_content_columns_order_idx": {
+          "name": "_home_pages_v_version_highlighted_content_columns_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_version_highlighted_content_columns_parent_id_idx": {
+          "name": "_home_pages_v_version_highlighted_content_columns_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_version_highlighted_content_columns_parent_id_fk": {
+          "name": "_home_pages_v_version_highlighted_content_columns_parent_id_fk",
+          "tableFrom": "_home_pages_v_version_highlighted_content_columns",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_blog_list": {
+      "name": "_home_pages_v_blocks_blog_list",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "below_heading_content": {
+          "name": "below_heading_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "post_options": {
+          "name": "post_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dynamic'"
+        },
+        "dynamic_options_sort_by": {
+          "name": "dynamic_options_sort_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'-publishedAt'"
+        },
+        "dynamic_options_max_posts": {
+          "name": "dynamic_options_max_posts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_blog_list_order_idx": {
+          "name": "_home_pages_v_blocks_blog_list_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_blog_list_parent_id_idx": {
+          "name": "_home_pages_v_blocks_blog_list_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_blog_list_path_idx": {
+          "name": "_home_pages_v_blocks_blog_list_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_blog_list_parent_id_fk": {
+          "name": "_home_pages_v_blocks_blog_list_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_blog_list",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_content_columns": {
+      "name": "_home_pages_v_blocks_content_columns",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{\"root\":{\"type\":\"root\",\"format\":\"\",\"indent\":0,\"version\":1,\"children\":[{\"type\":\"paragraph\",\"format\":\"\",\"indent\":0,\"version\":1,\"children\":[],\"direction\":\"ltr\",\"textStyle\":\"\",\"textFormat\":0}],\"direction\":\"ltr\"}}'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_content_columns_order_idx": {
+          "name": "_home_pages_v_blocks_content_columns_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_content_columns_parent_id_idx": {
+          "name": "_home_pages_v_blocks_content_columns_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_content_columns_parent_id_fk": {
+          "name": "_home_pages_v_blocks_content_columns_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_content_columns",
+          "tableTo": "_home_pages_v_blocks_content",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_content": {
+      "name": "_home_pages_v_blocks_content",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'1_1'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_content_order_idx": {
+          "name": "_home_pages_v_blocks_content_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_content_parent_id_idx": {
+          "name": "_home_pages_v_blocks_content_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_content_path_idx": {
+          "name": "_home_pages_v_blocks_content_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_content_parent_id_fk": {
+          "name": "_home_pages_v_blocks_content_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_content",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_document_block": {
+      "name": "_home_pages_v_blocks_document_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_document_block_order_idx": {
+          "name": "_home_pages_v_blocks_document_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_document_block_parent_id_idx": {
+          "name": "_home_pages_v_blocks_document_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_document_block_path_idx": {
+          "name": "_home_pages_v_blocks_document_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_document_block_document_idx": {
+          "name": "_home_pages_v_blocks_document_block_document_idx",
+          "columns": ["document_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_document_block_document_id_documents_id_fk": {
+          "name": "_home_pages_v_blocks_document_block_document_id_documents_id_fk",
+          "tableFrom": "_home_pages_v_blocks_document_block",
+          "tableTo": "documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_blocks_document_block_parent_id_fk": {
+          "name": "_home_pages_v_blocks_document_block_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_document_block",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_event_list_dynamic_opts_by_types": {
+      "name": "_home_pages_v_blocks_event_list_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_event_list_dynamic_opts_by_types_order_idx": {
+          "name": "_home_pages_v_blocks_event_list_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_event_list_dynamic_opts_by_types_parent_idx": {
+          "name": "_home_pages_v_blocks_event_list_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_event_list_dynamic_opts_by_types_parent_fk": {
+          "name": "_home_pages_v_blocks_event_list_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "_home_pages_v_blocks_event_list_dynamic_opts_by_types",
+          "tableTo": "_home_pages_v_blocks_event_list",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_event_list": {
+      "name": "_home_pages_v_blocks_event_list",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "below_heading_content": {
+          "name": "below_heading_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_options": {
+          "name": "event_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dynamic'"
+        },
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_event_list_order_idx": {
+          "name": "_home_pages_v_blocks_event_list_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_event_list_parent_id_idx": {
+          "name": "_home_pages_v_blocks_event_list_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_event_list_path_idx": {
+          "name": "_home_pages_v_blocks_event_list_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_event_list_parent_id_fk": {
+          "name": "_home_pages_v_blocks_event_list_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_event_list",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_event_table_dynamic_opts_by_types": {
+      "name": "_home_pages_v_blocks_event_table_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_event_table_dynamic_opts_by_types_order_idx": {
+          "name": "_home_pages_v_blocks_event_table_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_event_table_dynamic_opts_by_types_parent_idx": {
+          "name": "_home_pages_v_blocks_event_table_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_event_table_dynamic_opts_by_types_parent_fk": {
+          "name": "_home_pages_v_blocks_event_table_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "_home_pages_v_blocks_event_table_dynamic_opts_by_types",
+          "tableTo": "_home_pages_v_blocks_event_table",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_event_table": {
+      "name": "_home_pages_v_blocks_event_table",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "below_heading_content": {
+          "name": "below_heading_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_options": {
+          "name": "event_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dynamic'"
+        },
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_event_table_order_idx": {
+          "name": "_home_pages_v_blocks_event_table_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_event_table_parent_id_idx": {
+          "name": "_home_pages_v_blocks_event_table_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_event_table_path_idx": {
+          "name": "_home_pages_v_blocks_event_table_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_event_table_parent_id_fk": {
+          "name": "_home_pages_v_blocks_event_table_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_event_table",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_form_block": {
+      "name": "_home_pages_v_blocks_form_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_intro": {
+          "name": "enable_intro",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intro_content": {
+          "name": "intro_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_form_block_order_idx": {
+          "name": "_home_pages_v_blocks_form_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_form_block_parent_id_idx": {
+          "name": "_home_pages_v_blocks_form_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_form_block_path_idx": {
+          "name": "_home_pages_v_blocks_form_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_form_block_form_idx": {
+          "name": "_home_pages_v_blocks_form_block_form_idx",
+          "columns": ["form_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_form_block_form_id_forms_id_fk": {
+          "name": "_home_pages_v_blocks_form_block_form_id_forms_id_fk",
+          "tableFrom": "_home_pages_v_blocks_form_block",
+          "tableTo": "forms",
+          "columnsFrom": ["form_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_blocks_form_block_parent_id_fk": {
+          "name": "_home_pages_v_blocks_form_block_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_form_block",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_generic_embed": {
+      "name": "_home_pages_v_blocks_generic_embed",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "align_content": {
+          "name": "align_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_generic_embed_order_idx": {
+          "name": "_home_pages_v_blocks_generic_embed_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_generic_embed_parent_id_idx": {
+          "name": "_home_pages_v_blocks_generic_embed_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_generic_embed_path_idx": {
+          "name": "_home_pages_v_blocks_generic_embed_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_generic_embed_parent_id_fk": {
+          "name": "_home_pages_v_blocks_generic_embed_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_generic_embed",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_header_block": {
+      "name": "_home_pages_v_blocks_header_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "full_width_color": {
+          "name": "full_width_color",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_header_block_order_idx": {
+          "name": "_home_pages_v_blocks_header_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_header_block_parent_id_idx": {
+          "name": "_home_pages_v_blocks_header_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_header_block_path_idx": {
+          "name": "_home_pages_v_blocks_header_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_header_block_parent_id_fk": {
+          "name": "_home_pages_v_blocks_header_block_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_header_block",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_image_link_grid_columns": {
+      "name": "_home_pages_v_blocks_image_link_grid_columns",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_image_link_grid_columns_order_idx": {
+          "name": "_home_pages_v_blocks_image_link_grid_columns_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_image_link_grid_columns_parent_id_idx": {
+          "name": "_home_pages_v_blocks_image_link_grid_columns_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_image_link_grid_columns_image_idx": {
+          "name": "_home_pages_v_blocks_image_link_grid_columns_image_idx",
+          "columns": ["image_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_image_link_grid_columns_image_id_media_id_fk": {
+          "name": "_home_pages_v_blocks_image_link_grid_columns_image_id_media_id_fk",
+          "tableFrom": "_home_pages_v_blocks_image_link_grid_columns",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_blocks_image_link_grid_columns_parent_id_fk": {
+          "name": "_home_pages_v_blocks_image_link_grid_columns_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_image_link_grid_columns",
+          "tableTo": "_home_pages_v_blocks_image_link_grid",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_image_link_grid": {
+      "name": "_home_pages_v_blocks_image_link_grid",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_image_link_grid_order_idx": {
+          "name": "_home_pages_v_blocks_image_link_grid_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_image_link_grid_parent_id_idx": {
+          "name": "_home_pages_v_blocks_image_link_grid_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_image_link_grid_path_idx": {
+          "name": "_home_pages_v_blocks_image_link_grid_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_image_link_grid_parent_id_fk": {
+          "name": "_home_pages_v_blocks_image_link_grid_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_image_link_grid",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_image_text": {
+      "name": "_home_pages_v_blocks_image_text",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "image_layout": {
+          "name": "image_layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_wrap": {
+          "name": "text_wrap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_image_text_order_idx": {
+          "name": "_home_pages_v_blocks_image_text_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_image_text_parent_id_idx": {
+          "name": "_home_pages_v_blocks_image_text_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_image_text_path_idx": {
+          "name": "_home_pages_v_blocks_image_text_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_image_text_image_idx": {
+          "name": "_home_pages_v_blocks_image_text_image_idx",
+          "columns": ["image_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_image_text_image_id_media_id_fk": {
+          "name": "_home_pages_v_blocks_image_text_image_id_media_id_fk",
+          "tableFrom": "_home_pages_v_blocks_image_text",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_blocks_image_text_parent_id_fk": {
+          "name": "_home_pages_v_blocks_image_text_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_image_text",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_link_preview_cards": {
+      "name": "_home_pages_v_blocks_link_preview_cards",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_type": {
+          "name": "button_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "button_new_tab": {
+          "name": "button_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_url": {
+          "name": "button_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_label": {
+          "name": "button_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_variant": {
+          "name": "button_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_link_preview_cards_order_idx": {
+          "name": "_home_pages_v_blocks_link_preview_cards_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_link_preview_cards_parent_id_idx": {
+          "name": "_home_pages_v_blocks_link_preview_cards_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_link_preview_cards_image_idx": {
+          "name": "_home_pages_v_blocks_link_preview_cards_image_idx",
+          "columns": ["image_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_link_preview_cards_image_id_media_id_fk": {
+          "name": "_home_pages_v_blocks_link_preview_cards_image_id_media_id_fk",
+          "tableFrom": "_home_pages_v_blocks_link_preview_cards",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_blocks_link_preview_cards_parent_id_fk": {
+          "name": "_home_pages_v_blocks_link_preview_cards_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_link_preview_cards",
+          "tableTo": "_home_pages_v_blocks_link_preview",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_link_preview": {
+      "name": "_home_pages_v_blocks_link_preview",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_link_preview_order_idx": {
+          "name": "_home_pages_v_blocks_link_preview_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_link_preview_parent_id_idx": {
+          "name": "_home_pages_v_blocks_link_preview_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_link_preview_path_idx": {
+          "name": "_home_pages_v_blocks_link_preview_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_link_preview_parent_id_fk": {
+          "name": "_home_pages_v_blocks_link_preview_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_link_preview",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_media_block": {
+      "name": "_home_pages_v_blocks_media_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "align_content": {
+          "name": "align_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "image_size": {
+          "name": "image_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'original'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_media_block_order_idx": {
+          "name": "_home_pages_v_blocks_media_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_media_block_parent_id_idx": {
+          "name": "_home_pages_v_blocks_media_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_media_block_path_idx": {
+          "name": "_home_pages_v_blocks_media_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_media_block_media_idx": {
+          "name": "_home_pages_v_blocks_media_block_media_idx",
+          "columns": ["media_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_media_block_media_id_media_id_fk": {
+          "name": "_home_pages_v_blocks_media_block_media_id_media_id_fk",
+          "tableFrom": "_home_pages_v_blocks_media_block",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_blocks_media_block_parent_id_fk": {
+          "name": "_home_pages_v_blocks_media_block_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_media_block",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_nac_media_block": {
+      "name": "_home_pages_v_blocks_nac_media_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'carousel'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_nac_media_block_order_idx": {
+          "name": "_home_pages_v_blocks_nac_media_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_nac_media_block_parent_id_idx": {
+          "name": "_home_pages_v_blocks_nac_media_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_nac_media_block_path_idx": {
+          "name": "_home_pages_v_blocks_nac_media_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_nac_media_block_parent_id_fk": {
+          "name": "_home_pages_v_blocks_nac_media_block_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_nac_media_block",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_single_blog_post": {
+      "name": "_home_pages_v_blocks_single_blog_post",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_single_blog_post_order_idx": {
+          "name": "_home_pages_v_blocks_single_blog_post_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_single_blog_post_parent_id_idx": {
+          "name": "_home_pages_v_blocks_single_blog_post_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_single_blog_post_path_idx": {
+          "name": "_home_pages_v_blocks_single_blog_post_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_single_blog_post_post_idx": {
+          "name": "_home_pages_v_blocks_single_blog_post_post_idx",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_single_blog_post_post_id_posts_id_fk": {
+          "name": "_home_pages_v_blocks_single_blog_post_post_id_posts_id_fk",
+          "tableFrom": "_home_pages_v_blocks_single_blog_post",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_blocks_single_blog_post_parent_id_fk": {
+          "name": "_home_pages_v_blocks_single_blog_post_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_single_blog_post",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_single_event": {
+      "name": "_home_pages_v_blocks_single_event",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_single_event_order_idx": {
+          "name": "_home_pages_v_blocks_single_event_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_single_event_parent_id_idx": {
+          "name": "_home_pages_v_blocks_single_event_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_single_event_path_idx": {
+          "name": "_home_pages_v_blocks_single_event_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_single_event_event_idx": {
+          "name": "_home_pages_v_blocks_single_event_event_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_single_event_event_id_events_id_fk": {
+          "name": "_home_pages_v_blocks_single_event_event_id_events_id_fk",
+          "tableFrom": "_home_pages_v_blocks_single_event",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_blocks_single_event_parent_id_fk": {
+          "name": "_home_pages_v_blocks_single_event_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_single_event",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_sponsors_block": {
+      "name": "_home_pages_v_blocks_sponsors_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "sponsors_layout": {
+          "name": "sponsors_layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'static'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_sponsors_block_order_idx": {
+          "name": "_home_pages_v_blocks_sponsors_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_sponsors_block_parent_id_idx": {
+          "name": "_home_pages_v_blocks_sponsors_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_sponsors_block_path_idx": {
+          "name": "_home_pages_v_blocks_sponsors_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_sponsors_block_parent_id_fk": {
+          "name": "_home_pages_v_blocks_sponsors_block_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_sponsors_block",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_blocks_team": {
+      "name": "_home_pages_v_blocks_team",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_blocks_team_order_idx": {
+          "name": "_home_pages_v_blocks_team_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_team_parent_id_idx": {
+          "name": "_home_pages_v_blocks_team_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_team_path_idx": {
+          "name": "_home_pages_v_blocks_team_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_home_pages_v_blocks_team_team_idx": {
+          "name": "_home_pages_v_blocks_team_team_idx",
+          "columns": ["team_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_blocks_team_team_id_teams_id_fk": {
+          "name": "_home_pages_v_blocks_team_team_id_teams_id_fk",
+          "tableFrom": "_home_pages_v_blocks_team",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_blocks_team_parent_id_fk": {
+          "name": "_home_pages_v_blocks_team_parent_id_fk",
+          "tableFrom": "_home_pages_v_blocks_team",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_version_blocks_in_highlighted_content": {
+      "name": "_home_pages_v_version_blocks_in_highlighted_content",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "block_type": {
+          "name": "block_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_version_blocks_in_highlighted_content_order_idx": {
+          "name": "_home_pages_v_version_blocks_in_highlighted_content_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_version_blocks_in_highlighted_content_parent_id_idx": {
+          "name": "_home_pages_v_version_blocks_in_highlighted_content_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_version_blocks_in_highlighted_content_parent_id_fk": {
+          "name": "_home_pages_v_version_blocks_in_highlighted_content_parent_id_fk",
+          "tableFrom": "_home_pages_v_version_blocks_in_highlighted_content",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_version_document_references": {
+      "name": "_home_pages_v_version_document_references",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instances": {
+          "name": "instances",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_version_document_references_order_idx": {
+          "name": "_home_pages_v_version_document_references_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_home_pages_v_version_document_references_parent_id_idx": {
+          "name": "_home_pages_v_version_document_references_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_version_document_references_parent_id_fk": {
+          "name": "_home_pages_v_version_document_references_parent_id_fk",
+          "tableFrom": "_home_pages_v_version_document_references",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v": {
+      "name": "_home_pages_v",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_tenant_id": {
+          "name": "version_tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_highlighted_content_enabled": {
+          "name": "version_highlighted_content_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "version_highlighted_content_heading": {
+          "name": "version_highlighted_content_heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_highlighted_content_background_color": {
+          "name": "version_highlighted_content_background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "version_published_at": {
+          "name": "version_published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_content_hash": {
+          "name": "version_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_parent_idx": {
+          "name": "_home_pages_v_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_version_version_tenant_idx": {
+          "name": "_home_pages_v_version_version_tenant_idx",
+          "columns": ["version_tenant_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_version_version_updated_at_idx": {
+          "name": "_home_pages_v_version_version_updated_at_idx",
+          "columns": ["version_updated_at"],
+          "isUnique": false
+        },
+        "_home_pages_v_version_version_created_at_idx": {
+          "name": "_home_pages_v_version_version_created_at_idx",
+          "columns": ["version_created_at"],
+          "isUnique": false
+        },
+        "_home_pages_v_version_version__status_idx": {
+          "name": "_home_pages_v_version_version__status_idx",
+          "columns": ["version__status"],
+          "isUnique": false
+        },
+        "_home_pages_v_created_at_idx": {
+          "name": "_home_pages_v_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "_home_pages_v_updated_at_idx": {
+          "name": "_home_pages_v_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "_home_pages_v_latest_idx": {
+          "name": "_home_pages_v_latest_idx",
+          "columns": ["latest"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_parent_id_home_pages_id_fk": {
+          "name": "_home_pages_v_parent_id_home_pages_id_fk",
+          "tableFrom": "_home_pages_v",
+          "tableTo": "home_pages",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_version_tenant_id_tenants_id_fk": {
+          "name": "_home_pages_v_version_tenant_id_tenants_id_fk",
+          "tableFrom": "_home_pages_v",
+          "tableTo": "tenants",
+          "columnsFrom": ["version_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_home_pages_v_rels": {
+      "name": "_home_pages_v_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "built_in_pages_id": {
+          "name": "built_in_pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posts_id": {
+          "name": "posts_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_groups_id": {
+          "name": "event_groups_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_tags_id": {
+          "name": "event_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events_id": {
+          "name": "events_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sponsors_id": {
+          "name": "sponsors_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_home_pages_v_rels_order_idx": {
+          "name": "_home_pages_v_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_home_pages_v_rels_parent_idx": {
+          "name": "_home_pages_v_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_rels_path_idx": {
+          "name": "_home_pages_v_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "_home_pages_v_rels_pages_id_idx": {
+          "name": "_home_pages_v_rels_pages_id_idx",
+          "columns": ["pages_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_rels_built_in_pages_id_idx": {
+          "name": "_home_pages_v_rels_built_in_pages_id_idx",
+          "columns": ["built_in_pages_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_rels_posts_id_idx": {
+          "name": "_home_pages_v_rels_posts_id_idx",
+          "columns": ["posts_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_rels_tags_id_idx": {
+          "name": "_home_pages_v_rels_tags_id_idx",
+          "columns": ["tags_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_rels_event_groups_id_idx": {
+          "name": "_home_pages_v_rels_event_groups_id_idx",
+          "columns": ["event_groups_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_rels_event_tags_id_idx": {
+          "name": "_home_pages_v_rels_event_tags_id_idx",
+          "columns": ["event_tags_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_rels_events_id_idx": {
+          "name": "_home_pages_v_rels_events_id_idx",
+          "columns": ["events_id"],
+          "isUnique": false
+        },
+        "_home_pages_v_rels_sponsors_id_idx": {
+          "name": "_home_pages_v_rels_sponsors_id_idx",
+          "columns": ["sponsors_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_home_pages_v_rels_parent_fk": {
+          "name": "_home_pages_v_rels_parent_fk",
+          "tableFrom": "_home_pages_v_rels",
+          "tableTo": "_home_pages_v",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_rels_pages_fk": {
+          "name": "_home_pages_v_rels_pages_fk",
+          "tableFrom": "_home_pages_v_rels",
+          "tableTo": "pages",
+          "columnsFrom": ["pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_rels_built_in_pages_fk": {
+          "name": "_home_pages_v_rels_built_in_pages_fk",
+          "tableFrom": "_home_pages_v_rels",
+          "tableTo": "built_in_pages",
+          "columnsFrom": ["built_in_pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_rels_posts_fk": {
+          "name": "_home_pages_v_rels_posts_fk",
+          "tableFrom": "_home_pages_v_rels",
+          "tableTo": "posts",
+          "columnsFrom": ["posts_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_rels_tags_fk": {
+          "name": "_home_pages_v_rels_tags_fk",
+          "tableFrom": "_home_pages_v_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_rels_event_groups_fk": {
+          "name": "_home_pages_v_rels_event_groups_fk",
+          "tableFrom": "_home_pages_v_rels",
+          "tableTo": "event_groups",
+          "columnsFrom": ["event_groups_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_rels_event_tags_fk": {
+          "name": "_home_pages_v_rels_event_tags_fk",
+          "tableFrom": "_home_pages_v_rels",
+          "tableTo": "event_tags",
+          "columnsFrom": ["event_tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_rels_events_fk": {
+          "name": "_home_pages_v_rels_events_fk",
+          "tableFrom": "_home_pages_v_rels",
+          "tableTo": "events",
+          "columnsFrom": ["events_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_home_pages_v_rels_sponsors_fk": {
+          "name": "_home_pages_v_rels_sponsors_fk",
+          "tableFrom": "_home_pages_v_rels",
+          "tableTo": "sponsors",
+          "columnsFrom": ["sponsors_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "built_in_pages": {
+      "name": "built_in_pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "built_in_pages_tenant_idx": {
+          "name": "built_in_pages_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "built_in_pages_updated_at_idx": {
+          "name": "built_in_pages_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "built_in_pages_created_at_idx": {
+          "name": "built_in_pages_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "built_in_pages_tenant_id_tenants_id_fk": {
+          "name": "built_in_pages_tenant_id_tenants_id_fk",
+          "tableFrom": "built_in_pages",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_blog_list": {
+      "name": "pages_blocks_blog_list",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "below_heading_content": {
+          "name": "below_heading_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "post_options": {
+          "name": "post_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dynamic'"
+        },
+        "dynamic_options_sort_by": {
+          "name": "dynamic_options_sort_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'-publishedAt'"
+        },
+        "dynamic_options_max_posts": {
+          "name": "dynamic_options_max_posts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_blog_list_order_idx": {
+          "name": "pages_blocks_blog_list_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_blog_list_parent_id_idx": {
+          "name": "pages_blocks_blog_list_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_blog_list_path_idx": {
+          "name": "pages_blocks_blog_list_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_blog_list_parent_id_fk": {
+          "name": "pages_blocks_blog_list_parent_id_fk",
+          "tableFrom": "pages_blocks_blog_list",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_content_columns": {
+      "name": "pages_blocks_content_columns",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{\"root\":{\"type\":\"root\",\"format\":\"\",\"indent\":0,\"version\":1,\"children\":[{\"type\":\"paragraph\",\"format\":\"\",\"indent\":0,\"version\":1,\"children\":[],\"direction\":\"ltr\",\"textStyle\":\"\",\"textFormat\":0}],\"direction\":\"ltr\"}}'"
+        }
+      },
+      "indexes": {
+        "pages_blocks_content_columns_order_idx": {
+          "name": "pages_blocks_content_columns_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_content_columns_parent_id_idx": {
+          "name": "pages_blocks_content_columns_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_content_columns_parent_id_fk": {
+          "name": "pages_blocks_content_columns_parent_id_fk",
+          "tableFrom": "pages_blocks_content_columns",
+          "tableTo": "pages_blocks_content",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_content": {
+      "name": "pages_blocks_content",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'1_1'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_content_order_idx": {
+          "name": "pages_blocks_content_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_content_parent_id_idx": {
+          "name": "pages_blocks_content_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_content_path_idx": {
+          "name": "pages_blocks_content_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_content_parent_id_fk": {
+          "name": "pages_blocks_content_parent_id_fk",
+          "tableFrom": "pages_blocks_content",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_document_block": {
+      "name": "pages_blocks_document_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_document_block_order_idx": {
+          "name": "pages_blocks_document_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_document_block_parent_id_idx": {
+          "name": "pages_blocks_document_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_document_block_path_idx": {
+          "name": "pages_blocks_document_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "pages_blocks_document_block_document_idx": {
+          "name": "pages_blocks_document_block_document_idx",
+          "columns": ["document_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_document_block_document_id_documents_id_fk": {
+          "name": "pages_blocks_document_block_document_id_documents_id_fk",
+          "tableFrom": "pages_blocks_document_block",
+          "tableTo": "documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_blocks_document_block_parent_id_fk": {
+          "name": "pages_blocks_document_block_parent_id_fk",
+          "tableFrom": "pages_blocks_document_block",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_event_list_dynamic_opts_by_types": {
+      "name": "pages_blocks_event_list_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_event_list_dynamic_opts_by_types_order_idx": {
+          "name": "pages_blocks_event_list_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "pages_blocks_event_list_dynamic_opts_by_types_parent_idx": {
+          "name": "pages_blocks_event_list_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_event_list_dynamic_opts_by_types_parent_fk": {
+          "name": "pages_blocks_event_list_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "pages_blocks_event_list_dynamic_opts_by_types",
+          "tableTo": "pages_blocks_event_list",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_event_list": {
+      "name": "pages_blocks_event_list",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "below_heading_content": {
+          "name": "below_heading_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_options": {
+          "name": "event_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dynamic'"
+        },
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_event_list_order_idx": {
+          "name": "pages_blocks_event_list_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_event_list_parent_id_idx": {
+          "name": "pages_blocks_event_list_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_event_list_path_idx": {
+          "name": "pages_blocks_event_list_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_event_list_parent_id_fk": {
+          "name": "pages_blocks_event_list_parent_id_fk",
+          "tableFrom": "pages_blocks_event_list",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_event_table_dynamic_opts_by_types": {
+      "name": "pages_blocks_event_table_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_event_table_dynamic_opts_by_types_order_idx": {
+          "name": "pages_blocks_event_table_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "pages_blocks_event_table_dynamic_opts_by_types_parent_idx": {
+          "name": "pages_blocks_event_table_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_event_table_dynamic_opts_by_types_parent_fk": {
+          "name": "pages_blocks_event_table_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "pages_blocks_event_table_dynamic_opts_by_types",
+          "tableTo": "pages_blocks_event_table",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_event_table": {
+      "name": "pages_blocks_event_table",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "below_heading_content": {
+          "name": "below_heading_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_options": {
+          "name": "event_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dynamic'"
+        },
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_event_table_order_idx": {
+          "name": "pages_blocks_event_table_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_event_table_parent_id_idx": {
+          "name": "pages_blocks_event_table_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_event_table_path_idx": {
+          "name": "pages_blocks_event_table_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_event_table_parent_id_fk": {
+          "name": "pages_blocks_event_table_parent_id_fk",
+          "tableFrom": "pages_blocks_event_table",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_form_block": {
+      "name": "pages_blocks_form_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_intro": {
+          "name": "enable_intro",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intro_content": {
+          "name": "intro_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_form_block_order_idx": {
+          "name": "pages_blocks_form_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_form_block_parent_id_idx": {
+          "name": "pages_blocks_form_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_form_block_path_idx": {
+          "name": "pages_blocks_form_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "pages_blocks_form_block_form_idx": {
+          "name": "pages_blocks_form_block_form_idx",
+          "columns": ["form_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_form_block_form_id_forms_id_fk": {
+          "name": "pages_blocks_form_block_form_id_forms_id_fk",
+          "tableFrom": "pages_blocks_form_block",
+          "tableTo": "forms",
+          "columnsFrom": ["form_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_blocks_form_block_parent_id_fk": {
+          "name": "pages_blocks_form_block_parent_id_fk",
+          "tableFrom": "pages_blocks_form_block",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_generic_embed": {
+      "name": "pages_blocks_generic_embed",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "align_content": {
+          "name": "align_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_generic_embed_order_idx": {
+          "name": "pages_blocks_generic_embed_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_generic_embed_parent_id_idx": {
+          "name": "pages_blocks_generic_embed_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_generic_embed_path_idx": {
+          "name": "pages_blocks_generic_embed_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_generic_embed_parent_id_fk": {
+          "name": "pages_blocks_generic_embed_parent_id_fk",
+          "tableFrom": "pages_blocks_generic_embed",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_header_block": {
+      "name": "pages_blocks_header_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "full_width_color": {
+          "name": "full_width_color",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_header_block_order_idx": {
+          "name": "pages_blocks_header_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_header_block_parent_id_idx": {
+          "name": "pages_blocks_header_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_header_block_path_idx": {
+          "name": "pages_blocks_header_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_header_block_parent_id_fk": {
+          "name": "pages_blocks_header_block_parent_id_fk",
+          "tableFrom": "pages_blocks_header_block",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_image_link_grid_columns": {
+      "name": "pages_blocks_image_link_grid_columns",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_image_link_grid_columns_order_idx": {
+          "name": "pages_blocks_image_link_grid_columns_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_image_link_grid_columns_parent_id_idx": {
+          "name": "pages_blocks_image_link_grid_columns_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_image_link_grid_columns_image_idx": {
+          "name": "pages_blocks_image_link_grid_columns_image_idx",
+          "columns": ["image_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_image_link_grid_columns_image_id_media_id_fk": {
+          "name": "pages_blocks_image_link_grid_columns_image_id_media_id_fk",
+          "tableFrom": "pages_blocks_image_link_grid_columns",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_blocks_image_link_grid_columns_parent_id_fk": {
+          "name": "pages_blocks_image_link_grid_columns_parent_id_fk",
+          "tableFrom": "pages_blocks_image_link_grid_columns",
+          "tableTo": "pages_blocks_image_link_grid",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_image_link_grid": {
+      "name": "pages_blocks_image_link_grid",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_image_link_grid_order_idx": {
+          "name": "pages_blocks_image_link_grid_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_image_link_grid_parent_id_idx": {
+          "name": "pages_blocks_image_link_grid_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_image_link_grid_path_idx": {
+          "name": "pages_blocks_image_link_grid_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_image_link_grid_parent_id_fk": {
+          "name": "pages_blocks_image_link_grid_parent_id_fk",
+          "tableFrom": "pages_blocks_image_link_grid",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_image_text": {
+      "name": "pages_blocks_image_text",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "image_layout": {
+          "name": "image_layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_wrap": {
+          "name": "text_wrap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_image_text_order_idx": {
+          "name": "pages_blocks_image_text_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_image_text_parent_id_idx": {
+          "name": "pages_blocks_image_text_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_image_text_path_idx": {
+          "name": "pages_blocks_image_text_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "pages_blocks_image_text_image_idx": {
+          "name": "pages_blocks_image_text_image_idx",
+          "columns": ["image_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_image_text_image_id_media_id_fk": {
+          "name": "pages_blocks_image_text_image_id_media_id_fk",
+          "tableFrom": "pages_blocks_image_text",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_blocks_image_text_parent_id_fk": {
+          "name": "pages_blocks_image_text_parent_id_fk",
+          "tableFrom": "pages_blocks_image_text",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_link_preview_cards": {
+      "name": "pages_blocks_link_preview_cards",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_type": {
+          "name": "button_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "button_new_tab": {
+          "name": "button_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_url": {
+          "name": "button_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_label": {
+          "name": "button_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_variant": {
+          "name": "button_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'default'"
+        }
+      },
+      "indexes": {
+        "pages_blocks_link_preview_cards_order_idx": {
+          "name": "pages_blocks_link_preview_cards_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_link_preview_cards_parent_id_idx": {
+          "name": "pages_blocks_link_preview_cards_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_link_preview_cards_image_idx": {
+          "name": "pages_blocks_link_preview_cards_image_idx",
+          "columns": ["image_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_link_preview_cards_image_id_media_id_fk": {
+          "name": "pages_blocks_link_preview_cards_image_id_media_id_fk",
+          "tableFrom": "pages_blocks_link_preview_cards",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_blocks_link_preview_cards_parent_id_fk": {
+          "name": "pages_blocks_link_preview_cards_parent_id_fk",
+          "tableFrom": "pages_blocks_link_preview_cards",
+          "tableTo": "pages_blocks_link_preview",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_link_preview": {
+      "name": "pages_blocks_link_preview",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_link_preview_order_idx": {
+          "name": "pages_blocks_link_preview_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_link_preview_parent_id_idx": {
+          "name": "pages_blocks_link_preview_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_link_preview_path_idx": {
+          "name": "pages_blocks_link_preview_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_link_preview_parent_id_fk": {
+          "name": "pages_blocks_link_preview_parent_id_fk",
+          "tableFrom": "pages_blocks_link_preview",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_media_block": {
+      "name": "pages_blocks_media_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "align_content": {
+          "name": "align_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "image_size": {
+          "name": "image_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'original'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_media_block_order_idx": {
+          "name": "pages_blocks_media_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_media_block_parent_id_idx": {
+          "name": "pages_blocks_media_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_media_block_path_idx": {
+          "name": "pages_blocks_media_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "pages_blocks_media_block_media_idx": {
+          "name": "pages_blocks_media_block_media_idx",
+          "columns": ["media_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_media_block_media_id_media_id_fk": {
+          "name": "pages_blocks_media_block_media_id_media_id_fk",
+          "tableFrom": "pages_blocks_media_block",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_blocks_media_block_parent_id_fk": {
+          "name": "pages_blocks_media_block_parent_id_fk",
+          "tableFrom": "pages_blocks_media_block",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_nac_media_block": {
+      "name": "pages_blocks_nac_media_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'carousel'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_nac_media_block_order_idx": {
+          "name": "pages_blocks_nac_media_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_nac_media_block_parent_id_idx": {
+          "name": "pages_blocks_nac_media_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_nac_media_block_path_idx": {
+          "name": "pages_blocks_nac_media_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_nac_media_block_parent_id_fk": {
+          "name": "pages_blocks_nac_media_block_parent_id_fk",
+          "tableFrom": "pages_blocks_nac_media_block",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_single_blog_post": {
+      "name": "pages_blocks_single_blog_post",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_single_blog_post_order_idx": {
+          "name": "pages_blocks_single_blog_post_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_single_blog_post_parent_id_idx": {
+          "name": "pages_blocks_single_blog_post_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_single_blog_post_path_idx": {
+          "name": "pages_blocks_single_blog_post_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "pages_blocks_single_blog_post_post_idx": {
+          "name": "pages_blocks_single_blog_post_post_idx",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_single_blog_post_post_id_posts_id_fk": {
+          "name": "pages_blocks_single_blog_post_post_id_posts_id_fk",
+          "tableFrom": "pages_blocks_single_blog_post",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_blocks_single_blog_post_parent_id_fk": {
+          "name": "pages_blocks_single_blog_post_parent_id_fk",
+          "tableFrom": "pages_blocks_single_blog_post",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_single_event": {
+      "name": "pages_blocks_single_event",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_single_event_order_idx": {
+          "name": "pages_blocks_single_event_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_single_event_parent_id_idx": {
+          "name": "pages_blocks_single_event_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_single_event_path_idx": {
+          "name": "pages_blocks_single_event_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "pages_blocks_single_event_event_idx": {
+          "name": "pages_blocks_single_event_event_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_single_event_event_id_events_id_fk": {
+          "name": "pages_blocks_single_event_event_id_events_id_fk",
+          "tableFrom": "pages_blocks_single_event",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_blocks_single_event_parent_id_fk": {
+          "name": "pages_blocks_single_event_parent_id_fk",
+          "tableFrom": "pages_blocks_single_event",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_sponsors_block": {
+      "name": "pages_blocks_sponsors_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "sponsors_layout": {
+          "name": "sponsors_layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'static'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_sponsors_block_order_idx": {
+          "name": "pages_blocks_sponsors_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_sponsors_block_parent_id_idx": {
+          "name": "pages_blocks_sponsors_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_sponsors_block_path_idx": {
+          "name": "pages_blocks_sponsors_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_sponsors_block_parent_id_fk": {
+          "name": "pages_blocks_sponsors_block_parent_id_fk",
+          "tableFrom": "pages_blocks_sponsors_block",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_blocks_team": {
+      "name": "pages_blocks_team",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_team_order_idx": {
+          "name": "pages_blocks_team_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_blocks_team_parent_id_idx": {
+          "name": "pages_blocks_team_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "pages_blocks_team_path_idx": {
+          "name": "pages_blocks_team_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "pages_blocks_team_team_idx": {
+          "name": "pages_blocks_team_team_idx",
+          "columns": ["team_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_team_team_id_teams_id_fk": {
+          "name": "pages_blocks_team_team_id_teams_id_fk",
+          "tableFrom": "pages_blocks_team",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_blocks_team_parent_id_fk": {
+          "name": "pages_blocks_team_parent_id_fk",
+          "tableFrom": "pages_blocks_team",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_document_references": {
+      "name": "pages_document_references",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instances": {
+          "name": "instances",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_document_references_order_idx": {
+          "name": "pages_document_references_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "pages_document_references_parent_id_idx": {
+          "name": "pages_document_references_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_document_references_parent_id_fk": {
+          "name": "pages_document_references_parent_id_fk",
+          "tableFrom": "pages_document_references",
+          "tableTo": "pages",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages": {
+      "name": "pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_image_id": {
+          "name": "meta_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "pages_meta_meta_image_idx": {
+          "name": "pages_meta_meta_image_idx",
+          "columns": ["meta_image_id"],
+          "isUnique": false
+        },
+        "pages_slug_idx": {
+          "name": "pages_slug_idx",
+          "columns": ["slug"],
+          "isUnique": false
+        },
+        "pages_tenant_idx": {
+          "name": "pages_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "pages_updated_at_idx": {
+          "name": "pages_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "pages_created_at_idx": {
+          "name": "pages_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "pages__status_idx": {
+          "name": "pages__status_idx",
+          "columns": ["_status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_meta_image_id_media_id_fk": {
+          "name": "pages_meta_image_id_media_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "media",
+          "columnsFrom": ["meta_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_tenant_id_tenants_id_fk": {
+          "name": "pages_tenant_id_tenants_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_rels": {
+      "name": "pages_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posts_id": {
+          "name": "posts_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_groups_id": {
+          "name": "event_groups_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_tags_id": {
+          "name": "event_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events_id": {
+          "name": "events_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "built_in_pages_id": {
+          "name": "built_in_pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sponsors_id": {
+          "name": "sponsors_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_rels_order_idx": {
+          "name": "pages_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "pages_rels_parent_idx": {
+          "name": "pages_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "pages_rels_path_idx": {
+          "name": "pages_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "pages_rels_tags_id_idx": {
+          "name": "pages_rels_tags_id_idx",
+          "columns": ["tags_id"],
+          "isUnique": false
+        },
+        "pages_rels_posts_id_idx": {
+          "name": "pages_rels_posts_id_idx",
+          "columns": ["posts_id"],
+          "isUnique": false
+        },
+        "pages_rels_event_groups_id_idx": {
+          "name": "pages_rels_event_groups_id_idx",
+          "columns": ["event_groups_id"],
+          "isUnique": false
+        },
+        "pages_rels_event_tags_id_idx": {
+          "name": "pages_rels_event_tags_id_idx",
+          "columns": ["event_tags_id"],
+          "isUnique": false
+        },
+        "pages_rels_events_id_idx": {
+          "name": "pages_rels_events_id_idx",
+          "columns": ["events_id"],
+          "isUnique": false
+        },
+        "pages_rels_pages_id_idx": {
+          "name": "pages_rels_pages_id_idx",
+          "columns": ["pages_id"],
+          "isUnique": false
+        },
+        "pages_rels_built_in_pages_id_idx": {
+          "name": "pages_rels_built_in_pages_id_idx",
+          "columns": ["built_in_pages_id"],
+          "isUnique": false
+        },
+        "pages_rels_sponsors_id_idx": {
+          "name": "pages_rels_sponsors_id_idx",
+          "columns": ["sponsors_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_rels_parent_fk": {
+          "name": "pages_rels_parent_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "pages",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_rels_tags_fk": {
+          "name": "pages_rels_tags_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_rels_posts_fk": {
+          "name": "pages_rels_posts_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "posts",
+          "columnsFrom": ["posts_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_rels_event_groups_fk": {
+          "name": "pages_rels_event_groups_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "event_groups",
+          "columnsFrom": ["event_groups_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_rels_event_tags_fk": {
+          "name": "pages_rels_event_tags_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "event_tags",
+          "columnsFrom": ["event_tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_rels_events_fk": {
+          "name": "pages_rels_events_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "events",
+          "columnsFrom": ["events_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_rels_pages_fk": {
+          "name": "pages_rels_pages_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "pages",
+          "columnsFrom": ["pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_rels_built_in_pages_fk": {
+          "name": "pages_rels_built_in_pages_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "built_in_pages",
+          "columnsFrom": ["built_in_pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_rels_sponsors_fk": {
+          "name": "pages_rels_sponsors_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "sponsors",
+          "columnsFrom": ["sponsors_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_blog_list": {
+      "name": "_pages_v_blocks_blog_list",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "below_heading_content": {
+          "name": "below_heading_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "post_options": {
+          "name": "post_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dynamic'"
+        },
+        "dynamic_options_sort_by": {
+          "name": "dynamic_options_sort_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'-publishedAt'"
+        },
+        "dynamic_options_max_posts": {
+          "name": "dynamic_options_max_posts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_blog_list_order_idx": {
+          "name": "_pages_v_blocks_blog_list_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_blog_list_parent_id_idx": {
+          "name": "_pages_v_blocks_blog_list_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_blog_list_path_idx": {
+          "name": "_pages_v_blocks_blog_list_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_blog_list_parent_id_fk": {
+          "name": "_pages_v_blocks_blog_list_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_blog_list",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_content_columns": {
+      "name": "_pages_v_blocks_content_columns",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{\"root\":{\"type\":\"root\",\"format\":\"\",\"indent\":0,\"version\":1,\"children\":[{\"type\":\"paragraph\",\"format\":\"\",\"indent\":0,\"version\":1,\"children\":[],\"direction\":\"ltr\",\"textStyle\":\"\",\"textFormat\":0}],\"direction\":\"ltr\"}}'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_content_columns_order_idx": {
+          "name": "_pages_v_blocks_content_columns_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_content_columns_parent_id_idx": {
+          "name": "_pages_v_blocks_content_columns_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_content_columns_parent_id_fk": {
+          "name": "_pages_v_blocks_content_columns_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_content_columns",
+          "tableTo": "_pages_v_blocks_content",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_content": {
+      "name": "_pages_v_blocks_content",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'1_1'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_content_order_idx": {
+          "name": "_pages_v_blocks_content_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_content_parent_id_idx": {
+          "name": "_pages_v_blocks_content_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_content_path_idx": {
+          "name": "_pages_v_blocks_content_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_content_parent_id_fk": {
+          "name": "_pages_v_blocks_content_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_content",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_document_block": {
+      "name": "_pages_v_blocks_document_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_document_block_order_idx": {
+          "name": "_pages_v_blocks_document_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_document_block_parent_id_idx": {
+          "name": "_pages_v_blocks_document_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_document_block_path_idx": {
+          "name": "_pages_v_blocks_document_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_document_block_document_idx": {
+          "name": "_pages_v_blocks_document_block_document_idx",
+          "columns": ["document_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_document_block_document_id_documents_id_fk": {
+          "name": "_pages_v_blocks_document_block_document_id_documents_id_fk",
+          "tableFrom": "_pages_v_blocks_document_block",
+          "tableTo": "documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_blocks_document_block_parent_id_fk": {
+          "name": "_pages_v_blocks_document_block_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_document_block",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_event_list_dynamic_opts_by_types": {
+      "name": "_pages_v_blocks_event_list_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_event_list_dynamic_opts_by_types_order_idx": {
+          "name": "_pages_v_blocks_event_list_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_event_list_dynamic_opts_by_types_parent_idx": {
+          "name": "_pages_v_blocks_event_list_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_event_list_dynamic_opts_by_types_parent_fk": {
+          "name": "_pages_v_blocks_event_list_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "_pages_v_blocks_event_list_dynamic_opts_by_types",
+          "tableTo": "_pages_v_blocks_event_list",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_event_list": {
+      "name": "_pages_v_blocks_event_list",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "below_heading_content": {
+          "name": "below_heading_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_options": {
+          "name": "event_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dynamic'"
+        },
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_event_list_order_idx": {
+          "name": "_pages_v_blocks_event_list_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_event_list_parent_id_idx": {
+          "name": "_pages_v_blocks_event_list_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_event_list_path_idx": {
+          "name": "_pages_v_blocks_event_list_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_event_list_parent_id_fk": {
+          "name": "_pages_v_blocks_event_list_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_event_list",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_event_table_dynamic_opts_by_types": {
+      "name": "_pages_v_blocks_event_table_dynamic_opts_by_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_event_table_dynamic_opts_by_types_order_idx": {
+          "name": "_pages_v_blocks_event_table_dynamic_opts_by_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_event_table_dynamic_opts_by_types_parent_idx": {
+          "name": "_pages_v_blocks_event_table_dynamic_opts_by_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_event_table_dynamic_opts_by_types_parent_fk": {
+          "name": "_pages_v_blocks_event_table_dynamic_opts_by_types_parent_fk",
+          "tableFrom": "_pages_v_blocks_event_table_dynamic_opts_by_types",
+          "tableTo": "_pages_v_blocks_event_table",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_event_table": {
+      "name": "_pages_v_blocks_event_table",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "below_heading_content": {
+          "name": "below_heading_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_options": {
+          "name": "event_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dynamic'"
+        },
+        "dynamic_opts_max_events": {
+          "name": "dynamic_opts_max_events",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_event_table_order_idx": {
+          "name": "_pages_v_blocks_event_table_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_event_table_parent_id_idx": {
+          "name": "_pages_v_blocks_event_table_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_event_table_path_idx": {
+          "name": "_pages_v_blocks_event_table_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_event_table_parent_id_fk": {
+          "name": "_pages_v_blocks_event_table_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_event_table",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_form_block": {
+      "name": "_pages_v_blocks_form_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_intro": {
+          "name": "enable_intro",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "intro_content": {
+          "name": "intro_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_form_block_order_idx": {
+          "name": "_pages_v_blocks_form_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_form_block_parent_id_idx": {
+          "name": "_pages_v_blocks_form_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_form_block_path_idx": {
+          "name": "_pages_v_blocks_form_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_form_block_form_idx": {
+          "name": "_pages_v_blocks_form_block_form_idx",
+          "columns": ["form_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_form_block_form_id_forms_id_fk": {
+          "name": "_pages_v_blocks_form_block_form_id_forms_id_fk",
+          "tableFrom": "_pages_v_blocks_form_block",
+          "tableTo": "forms",
+          "columnsFrom": ["form_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_blocks_form_block_parent_id_fk": {
+          "name": "_pages_v_blocks_form_block_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_form_block",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_generic_embed": {
+      "name": "_pages_v_blocks_generic_embed",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "align_content": {
+          "name": "align_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_generic_embed_order_idx": {
+          "name": "_pages_v_blocks_generic_embed_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_generic_embed_parent_id_idx": {
+          "name": "_pages_v_blocks_generic_embed_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_generic_embed_path_idx": {
+          "name": "_pages_v_blocks_generic_embed_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_generic_embed_parent_id_fk": {
+          "name": "_pages_v_blocks_generic_embed_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_generic_embed",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_header_block": {
+      "name": "_pages_v_blocks_header_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "full_width_color": {
+          "name": "full_width_color",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_header_block_order_idx": {
+          "name": "_pages_v_blocks_header_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_header_block_parent_id_idx": {
+          "name": "_pages_v_blocks_header_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_header_block_path_idx": {
+          "name": "_pages_v_blocks_header_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_header_block_parent_id_fk": {
+          "name": "_pages_v_blocks_header_block_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_header_block",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_image_link_grid_columns": {
+      "name": "_pages_v_blocks_image_link_grid_columns",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_image_link_grid_columns_order_idx": {
+          "name": "_pages_v_blocks_image_link_grid_columns_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_image_link_grid_columns_parent_id_idx": {
+          "name": "_pages_v_blocks_image_link_grid_columns_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_image_link_grid_columns_image_idx": {
+          "name": "_pages_v_blocks_image_link_grid_columns_image_idx",
+          "columns": ["image_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_image_link_grid_columns_image_id_media_id_fk": {
+          "name": "_pages_v_blocks_image_link_grid_columns_image_id_media_id_fk",
+          "tableFrom": "_pages_v_blocks_image_link_grid_columns",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_blocks_image_link_grid_columns_parent_id_fk": {
+          "name": "_pages_v_blocks_image_link_grid_columns_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_image_link_grid_columns",
+          "tableTo": "_pages_v_blocks_image_link_grid",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_image_link_grid": {
+      "name": "_pages_v_blocks_image_link_grid",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_image_link_grid_order_idx": {
+          "name": "_pages_v_blocks_image_link_grid_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_image_link_grid_parent_id_idx": {
+          "name": "_pages_v_blocks_image_link_grid_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_image_link_grid_path_idx": {
+          "name": "_pages_v_blocks_image_link_grid_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_image_link_grid_parent_id_fk": {
+          "name": "_pages_v_blocks_image_link_grid_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_image_link_grid",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_image_text": {
+      "name": "_pages_v_blocks_image_text",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "image_layout": {
+          "name": "image_layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_wrap": {
+          "name": "text_wrap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "rich_text": {
+          "name": "rich_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_image_text_order_idx": {
+          "name": "_pages_v_blocks_image_text_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_image_text_parent_id_idx": {
+          "name": "_pages_v_blocks_image_text_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_image_text_path_idx": {
+          "name": "_pages_v_blocks_image_text_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_image_text_image_idx": {
+          "name": "_pages_v_blocks_image_text_image_idx",
+          "columns": ["image_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_image_text_image_id_media_id_fk": {
+          "name": "_pages_v_blocks_image_text_image_id_media_id_fk",
+          "tableFrom": "_pages_v_blocks_image_text",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_blocks_image_text_parent_id_fk": {
+          "name": "_pages_v_blocks_image_text_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_image_text",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_link_preview_cards": {
+      "name": "_pages_v_blocks_link_preview_cards",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_type": {
+          "name": "button_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "button_new_tab": {
+          "name": "button_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_url": {
+          "name": "button_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_label": {
+          "name": "button_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "button_variant": {
+          "name": "button_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_link_preview_cards_order_idx": {
+          "name": "_pages_v_blocks_link_preview_cards_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_link_preview_cards_parent_id_idx": {
+          "name": "_pages_v_blocks_link_preview_cards_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_link_preview_cards_image_idx": {
+          "name": "_pages_v_blocks_link_preview_cards_image_idx",
+          "columns": ["image_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_link_preview_cards_image_id_media_id_fk": {
+          "name": "_pages_v_blocks_link_preview_cards_image_id_media_id_fk",
+          "tableFrom": "_pages_v_blocks_link_preview_cards",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_blocks_link_preview_cards_parent_id_fk": {
+          "name": "_pages_v_blocks_link_preview_cards_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_link_preview_cards",
+          "tableTo": "_pages_v_blocks_link_preview",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_link_preview": {
+      "name": "_pages_v_blocks_link_preview",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_link_preview_order_idx": {
+          "name": "_pages_v_blocks_link_preview_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_link_preview_parent_id_idx": {
+          "name": "_pages_v_blocks_link_preview_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_link_preview_path_idx": {
+          "name": "_pages_v_blocks_link_preview_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_link_preview_parent_id_fk": {
+          "name": "_pages_v_blocks_link_preview_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_link_preview",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_media_block": {
+      "name": "_pages_v_blocks_media_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "align_content": {
+          "name": "align_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'left'"
+        },
+        "image_size": {
+          "name": "image_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'original'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_media_block_order_idx": {
+          "name": "_pages_v_blocks_media_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_media_block_parent_id_idx": {
+          "name": "_pages_v_blocks_media_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_media_block_path_idx": {
+          "name": "_pages_v_blocks_media_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_media_block_media_idx": {
+          "name": "_pages_v_blocks_media_block_media_idx",
+          "columns": ["media_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_media_block_media_id_media_id_fk": {
+          "name": "_pages_v_blocks_media_block_media_id_media_id_fk",
+          "tableFrom": "_pages_v_blocks_media_block",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_blocks_media_block_parent_id_fk": {
+          "name": "_pages_v_blocks_media_block_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_media_block",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_nac_media_block": {
+      "name": "_pages_v_blocks_nac_media_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'carousel'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_nac_media_block_order_idx": {
+          "name": "_pages_v_blocks_nac_media_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_nac_media_block_parent_id_idx": {
+          "name": "_pages_v_blocks_nac_media_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_nac_media_block_path_idx": {
+          "name": "_pages_v_blocks_nac_media_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_nac_media_block_parent_id_fk": {
+          "name": "_pages_v_blocks_nac_media_block_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_nac_media_block",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_single_blog_post": {
+      "name": "_pages_v_blocks_single_blog_post",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_single_blog_post_order_idx": {
+          "name": "_pages_v_blocks_single_blog_post_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_single_blog_post_parent_id_idx": {
+          "name": "_pages_v_blocks_single_blog_post_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_single_blog_post_path_idx": {
+          "name": "_pages_v_blocks_single_blog_post_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_single_blog_post_post_idx": {
+          "name": "_pages_v_blocks_single_blog_post_post_idx",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_single_blog_post_post_id_posts_id_fk": {
+          "name": "_pages_v_blocks_single_blog_post_post_id_posts_id_fk",
+          "tableFrom": "_pages_v_blocks_single_blog_post",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_blocks_single_blog_post_parent_id_fk": {
+          "name": "_pages_v_blocks_single_blog_post_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_single_blog_post",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_single_event": {
+      "name": "_pages_v_blocks_single_event",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_single_event_order_idx": {
+          "name": "_pages_v_blocks_single_event_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_single_event_parent_id_idx": {
+          "name": "_pages_v_blocks_single_event_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_single_event_path_idx": {
+          "name": "_pages_v_blocks_single_event_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_single_event_event_idx": {
+          "name": "_pages_v_blocks_single_event_event_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_single_event_event_id_events_id_fk": {
+          "name": "_pages_v_blocks_single_event_event_id_events_id_fk",
+          "tableFrom": "_pages_v_blocks_single_event",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_blocks_single_event_parent_id_fk": {
+          "name": "_pages_v_blocks_single_event_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_single_event",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_sponsors_block": {
+      "name": "_pages_v_blocks_sponsors_block",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'transparent'"
+        },
+        "sponsors_layout": {
+          "name": "sponsors_layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'static'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_sponsors_block_order_idx": {
+          "name": "_pages_v_blocks_sponsors_block_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_sponsors_block_parent_id_idx": {
+          "name": "_pages_v_blocks_sponsors_block_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_sponsors_block_path_idx": {
+          "name": "_pages_v_blocks_sponsors_block_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_sponsors_block_parent_id_fk": {
+          "name": "_pages_v_blocks_sponsors_block_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_sponsors_block",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_blocks_team": {
+      "name": "_pages_v_blocks_team",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_team_order_idx": {
+          "name": "_pages_v_blocks_team_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_team_parent_id_idx": {
+          "name": "_pages_v_blocks_team_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_team_path_idx": {
+          "name": "_pages_v_blocks_team_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        },
+        "_pages_v_blocks_team_team_idx": {
+          "name": "_pages_v_blocks_team_team_idx",
+          "columns": ["team_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_team_team_id_teams_id_fk": {
+          "name": "_pages_v_blocks_team_team_id_teams_id_fk",
+          "tableFrom": "_pages_v_blocks_team",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_blocks_team_parent_id_fk": {
+          "name": "_pages_v_blocks_team_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_team",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_version_document_references": {
+      "name": "_pages_v_version_document_references",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instances": {
+          "name": "instances",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_version_document_references_order_idx": {
+          "name": "_pages_v_version_document_references_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_pages_v_version_document_references_parent_id_idx": {
+          "name": "_pages_v_version_document_references_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_version_document_references_parent_id_fk": {
+          "name": "_pages_v_version_document_references_parent_id_fk",
+          "tableFrom": "_pages_v_version_document_references",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v": {
+      "name": "_pages_v",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_title": {
+          "name": "version_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_meta_image_id": {
+          "name": "version_meta_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_meta_description": {
+          "name": "version_meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_published_at": {
+          "name": "version_published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_slug": {
+          "name": "version_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_tenant_id": {
+          "name": "version_tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_content_hash": {
+          "name": "version_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_parent_idx": {
+          "name": "_pages_v_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_version_meta_version_meta_image_idx": {
+          "name": "_pages_v_version_meta_version_meta_image_idx",
+          "columns": ["version_meta_image_id"],
+          "isUnique": false
+        },
+        "_pages_v_version_version_slug_idx": {
+          "name": "_pages_v_version_version_slug_idx",
+          "columns": ["version_slug"],
+          "isUnique": false
+        },
+        "_pages_v_version_version_tenant_idx": {
+          "name": "_pages_v_version_version_tenant_idx",
+          "columns": ["version_tenant_id"],
+          "isUnique": false
+        },
+        "_pages_v_version_version_updated_at_idx": {
+          "name": "_pages_v_version_version_updated_at_idx",
+          "columns": ["version_updated_at"],
+          "isUnique": false
+        },
+        "_pages_v_version_version_created_at_idx": {
+          "name": "_pages_v_version_version_created_at_idx",
+          "columns": ["version_created_at"],
+          "isUnique": false
+        },
+        "_pages_v_version_version__status_idx": {
+          "name": "_pages_v_version_version__status_idx",
+          "columns": ["version__status"],
+          "isUnique": false
+        },
+        "_pages_v_created_at_idx": {
+          "name": "_pages_v_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "_pages_v_updated_at_idx": {
+          "name": "_pages_v_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "_pages_v_latest_idx": {
+          "name": "_pages_v_latest_idx",
+          "columns": ["latest"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_parent_id_pages_id_fk": {
+          "name": "_pages_v_parent_id_pages_id_fk",
+          "tableFrom": "_pages_v",
+          "tableTo": "pages",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_version_meta_image_id_media_id_fk": {
+          "name": "_pages_v_version_meta_image_id_media_id_fk",
+          "tableFrom": "_pages_v",
+          "tableTo": "media",
+          "columnsFrom": ["version_meta_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_version_tenant_id_tenants_id_fk": {
+          "name": "_pages_v_version_tenant_id_tenants_id_fk",
+          "tableFrom": "_pages_v",
+          "tableTo": "tenants",
+          "columnsFrom": ["version_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pages_v_rels": {
+      "name": "_pages_v_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posts_id": {
+          "name": "posts_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_groups_id": {
+          "name": "event_groups_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_tags_id": {
+          "name": "event_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events_id": {
+          "name": "events_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "built_in_pages_id": {
+          "name": "built_in_pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sponsors_id": {
+          "name": "sponsors_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_pages_v_rels_order_idx": {
+          "name": "_pages_v_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_pages_v_rels_parent_idx": {
+          "name": "_pages_v_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "_pages_v_rels_path_idx": {
+          "name": "_pages_v_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "_pages_v_rels_tags_id_idx": {
+          "name": "_pages_v_rels_tags_id_idx",
+          "columns": ["tags_id"],
+          "isUnique": false
+        },
+        "_pages_v_rels_posts_id_idx": {
+          "name": "_pages_v_rels_posts_id_idx",
+          "columns": ["posts_id"],
+          "isUnique": false
+        },
+        "_pages_v_rels_event_groups_id_idx": {
+          "name": "_pages_v_rels_event_groups_id_idx",
+          "columns": ["event_groups_id"],
+          "isUnique": false
+        },
+        "_pages_v_rels_event_tags_id_idx": {
+          "name": "_pages_v_rels_event_tags_id_idx",
+          "columns": ["event_tags_id"],
+          "isUnique": false
+        },
+        "_pages_v_rels_events_id_idx": {
+          "name": "_pages_v_rels_events_id_idx",
+          "columns": ["events_id"],
+          "isUnique": false
+        },
+        "_pages_v_rels_pages_id_idx": {
+          "name": "_pages_v_rels_pages_id_idx",
+          "columns": ["pages_id"],
+          "isUnique": false
+        },
+        "_pages_v_rels_built_in_pages_id_idx": {
+          "name": "_pages_v_rels_built_in_pages_id_idx",
+          "columns": ["built_in_pages_id"],
+          "isUnique": false
+        },
+        "_pages_v_rels_sponsors_id_idx": {
+          "name": "_pages_v_rels_sponsors_id_idx",
+          "columns": ["sponsors_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_rels_parent_fk": {
+          "name": "_pages_v_rels_parent_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "_pages_v",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_pages_v_rels_tags_fk": {
+          "name": "_pages_v_rels_tags_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_pages_v_rels_posts_fk": {
+          "name": "_pages_v_rels_posts_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "posts",
+          "columnsFrom": ["posts_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_pages_v_rels_event_groups_fk": {
+          "name": "_pages_v_rels_event_groups_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "event_groups",
+          "columnsFrom": ["event_groups_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_pages_v_rels_event_tags_fk": {
+          "name": "_pages_v_rels_event_tags_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "event_tags",
+          "columnsFrom": ["event_tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_pages_v_rels_events_fk": {
+          "name": "_pages_v_rels_events_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "events",
+          "columnsFrom": ["events_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_pages_v_rels_pages_fk": {
+          "name": "_pages_v_rels_pages_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "pages",
+          "columnsFrom": ["pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_pages_v_rels_built_in_pages_fk": {
+          "name": "_pages_v_rels_built_in_pages_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "built_in_pages",
+          "columnsFrom": ["built_in_pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_pages_v_rels_sponsors_fk": {
+          "name": "_pages_v_rels_sponsors_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "sponsors",
+          "columnsFrom": ["sponsors_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts_populated_authors": {
+      "name": "posts_populated_authors",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_populated_authors_order_idx": {
+          "name": "posts_populated_authors_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "posts_populated_authors_parent_id_idx": {
+          "name": "posts_populated_authors_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_populated_authors_parent_id_fk": {
+          "name": "posts_populated_authors_parent_id_fk",
+          "tableFrom": "posts_populated_authors",
+          "tableTo": "posts",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts_blocks_in_content": {
+      "name": "posts_blocks_in_content",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "block_type": {
+          "name": "block_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_blocks_in_content_order_idx": {
+          "name": "posts_blocks_in_content_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "posts_blocks_in_content_parent_id_idx": {
+          "name": "posts_blocks_in_content_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_blocks_in_content_parent_id_fk": {
+          "name": "posts_blocks_in_content_parent_id_fk",
+          "tableFrom": "posts_blocks_in_content",
+          "tableTo": "posts",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts_document_references": {
+      "name": "posts_document_references",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instances": {
+          "name": "instances",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_document_references_order_idx": {
+          "name": "posts_document_references_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "posts_document_references_parent_id_idx": {
+          "name": "posts_document_references_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_document_references_parent_id_fk": {
+          "name": "posts_document_references_parent_id_fk",
+          "tableFrom": "posts_document_references",
+          "tableTo": "posts",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "featured_image_id": {
+          "name": "featured_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_authors": {
+          "name": "show_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_date": {
+          "name": "show_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "posts_tenant_idx": {
+          "name": "posts_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "posts_featured_image_idx": {
+          "name": "posts_featured_image_idx",
+          "columns": ["featured_image_id"],
+          "isUnique": false
+        },
+        "posts_slug_idx": {
+          "name": "posts_slug_idx",
+          "columns": ["slug"],
+          "isUnique": false
+        },
+        "posts_updated_at_idx": {
+          "name": "posts_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "posts_created_at_idx": {
+          "name": "posts_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "posts__status_idx": {
+          "name": "posts__status_idx",
+          "columns": ["_status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_tenant_id_tenants_id_fk": {
+          "name": "posts_tenant_id_tenants_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_featured_image_id_media_id_fk": {
+          "name": "posts_featured_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["featured_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts_rels": {
+      "name": "posts_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "biographies_id": {
+          "name": "biographies_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posts_id": {
+          "name": "posts_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_rels_order_idx": {
+          "name": "posts_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "posts_rels_parent_idx": {
+          "name": "posts_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "posts_rels_path_idx": {
+          "name": "posts_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "posts_rels_biographies_id_idx": {
+          "name": "posts_rels_biographies_id_idx",
+          "columns": ["biographies_id"],
+          "isUnique": false
+        },
+        "posts_rels_tags_id_idx": {
+          "name": "posts_rels_tags_id_idx",
+          "columns": ["tags_id"],
+          "isUnique": false
+        },
+        "posts_rels_posts_id_idx": {
+          "name": "posts_rels_posts_id_idx",
+          "columns": ["posts_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_rels_parent_fk": {
+          "name": "posts_rels_parent_fk",
+          "tableFrom": "posts_rels",
+          "tableTo": "posts",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_rels_biographies_fk": {
+          "name": "posts_rels_biographies_fk",
+          "tableFrom": "posts_rels",
+          "tableTo": "biographies",
+          "columnsFrom": ["biographies_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_rels_tags_fk": {
+          "name": "posts_rels_tags_fk",
+          "tableFrom": "posts_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_rels_posts_fk": {
+          "name": "posts_rels_posts_fk",
+          "tableFrom": "posts_rels",
+          "tableTo": "posts",
+          "columnsFrom": ["posts_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_posts_v_version_populated_authors": {
+      "name": "_posts_v_version_populated_authors",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_posts_v_version_populated_authors_order_idx": {
+          "name": "_posts_v_version_populated_authors_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_posts_v_version_populated_authors_parent_id_idx": {
+          "name": "_posts_v_version_populated_authors_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_posts_v_version_populated_authors_parent_id_fk": {
+          "name": "_posts_v_version_populated_authors_parent_id_fk",
+          "tableFrom": "_posts_v_version_populated_authors",
+          "tableTo": "_posts_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_posts_v_version_blocks_in_content": {
+      "name": "_posts_v_version_blocks_in_content",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "block_type": {
+          "name": "block_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_posts_v_version_blocks_in_content_order_idx": {
+          "name": "_posts_v_version_blocks_in_content_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_posts_v_version_blocks_in_content_parent_id_idx": {
+          "name": "_posts_v_version_blocks_in_content_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_posts_v_version_blocks_in_content_parent_id_fk": {
+          "name": "_posts_v_version_blocks_in_content_parent_id_fk",
+          "tableFrom": "_posts_v_version_blocks_in_content",
+          "tableTo": "_posts_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_posts_v_version_document_references": {
+      "name": "_posts_v_version_document_references",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instances": {
+          "name": "instances",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_posts_v_version_document_references_order_idx": {
+          "name": "_posts_v_version_document_references_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_posts_v_version_document_references_parent_id_idx": {
+          "name": "_posts_v_version_document_references_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_posts_v_version_document_references_parent_id_fk": {
+          "name": "_posts_v_version_document_references_parent_id_fk",
+          "tableFrom": "_posts_v_version_document_references",
+          "tableTo": "_posts_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_posts_v": {
+      "name": "_posts_v",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_tenant_id": {
+          "name": "version_tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_title": {
+          "name": "version_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_featured_image_id": {
+          "name": "version_featured_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_description": {
+          "name": "version_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_content": {
+          "name": "version_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_show_authors": {
+          "name": "version_show_authors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "version_published_at": {
+          "name": "version_published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_show_date": {
+          "name": "version_show_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_slug": {
+          "name": "version_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_content_hash": {
+          "name": "version_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_posts_v_parent_idx": {
+          "name": "_posts_v_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "_posts_v_version_version_tenant_idx": {
+          "name": "_posts_v_version_version_tenant_idx",
+          "columns": ["version_tenant_id"],
+          "isUnique": false
+        },
+        "_posts_v_version_version_featured_image_idx": {
+          "name": "_posts_v_version_version_featured_image_idx",
+          "columns": ["version_featured_image_id"],
+          "isUnique": false
+        },
+        "_posts_v_version_version_slug_idx": {
+          "name": "_posts_v_version_version_slug_idx",
+          "columns": ["version_slug"],
+          "isUnique": false
+        },
+        "_posts_v_version_version_updated_at_idx": {
+          "name": "_posts_v_version_version_updated_at_idx",
+          "columns": ["version_updated_at"],
+          "isUnique": false
+        },
+        "_posts_v_version_version_created_at_idx": {
+          "name": "_posts_v_version_version_created_at_idx",
+          "columns": ["version_created_at"],
+          "isUnique": false
+        },
+        "_posts_v_version_version__status_idx": {
+          "name": "_posts_v_version_version__status_idx",
+          "columns": ["version__status"],
+          "isUnique": false
+        },
+        "_posts_v_created_at_idx": {
+          "name": "_posts_v_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "_posts_v_updated_at_idx": {
+          "name": "_posts_v_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "_posts_v_latest_idx": {
+          "name": "_posts_v_latest_idx",
+          "columns": ["latest"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_posts_v_parent_id_posts_id_fk": {
+          "name": "_posts_v_parent_id_posts_id_fk",
+          "tableFrom": "_posts_v",
+          "tableTo": "posts",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_posts_v_version_tenant_id_tenants_id_fk": {
+          "name": "_posts_v_version_tenant_id_tenants_id_fk",
+          "tableFrom": "_posts_v",
+          "tableTo": "tenants",
+          "columnsFrom": ["version_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_posts_v_version_featured_image_id_media_id_fk": {
+          "name": "_posts_v_version_featured_image_id_media_id_fk",
+          "tableFrom": "_posts_v",
+          "tableTo": "media",
+          "columnsFrom": ["version_featured_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_posts_v_rels": {
+      "name": "_posts_v_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "biographies_id": {
+          "name": "biographies_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posts_id": {
+          "name": "posts_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_posts_v_rels_order_idx": {
+          "name": "_posts_v_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_posts_v_rels_parent_idx": {
+          "name": "_posts_v_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "_posts_v_rels_path_idx": {
+          "name": "_posts_v_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "_posts_v_rels_biographies_id_idx": {
+          "name": "_posts_v_rels_biographies_id_idx",
+          "columns": ["biographies_id"],
+          "isUnique": false
+        },
+        "_posts_v_rels_tags_id_idx": {
+          "name": "_posts_v_rels_tags_id_idx",
+          "columns": ["tags_id"],
+          "isUnique": false
+        },
+        "_posts_v_rels_posts_id_idx": {
+          "name": "_posts_v_rels_posts_id_idx",
+          "columns": ["posts_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_posts_v_rels_parent_fk": {
+          "name": "_posts_v_rels_parent_fk",
+          "tableFrom": "_posts_v_rels",
+          "tableTo": "_posts_v",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_posts_v_rels_biographies_fk": {
+          "name": "_posts_v_rels_biographies_fk",
+          "tableFrom": "_posts_v_rels",
+          "tableTo": "biographies",
+          "columnsFrom": ["biographies_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_posts_v_rels_tags_fk": {
+          "name": "_posts_v_rels_tags_fk",
+          "tableFrom": "_posts_v_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_posts_v_rels_posts_fk": {
+          "name": "_posts_v_rels_posts_fk",
+          "tableFrom": "_posts_v_rels",
+          "tableTo": "posts",
+          "columnsFrom": ["posts_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blur_data_url": {
+          "name": "blur_data_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sizes_thumbnail_url": {
+          "name": "sizes_thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sizes_thumbnail_width": {
+          "name": "sizes_thumbnail_width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sizes_thumbnail_height": {
+          "name": "sizes_thumbnail_height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sizes_thumbnail_mime_type": {
+          "name": "sizes_thumbnail_mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sizes_thumbnail_filesize": {
+          "name": "sizes_thumbnail_filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sizes_thumbnail_filename": {
+          "name": "sizes_thumbnail_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_tenant_idx": {
+          "name": "media_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": ["filename"],
+          "isUnique": true
+        },
+        "media_sizes_thumbnail_sizes_thumbnail_filename_idx": {
+          "name": "media_sizes_thumbnail_sizes_thumbnail_filename_idx",
+          "columns": ["sizes_thumbnail_filename"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_tenant_id_tenants_id_fk": {
+          "name": "media_tenant_id_tenants_id_fk",
+          "tableFrom": "media",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "documents_tenant_idx": {
+          "name": "documents_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "documents_updated_at_idx": {
+          "name": "documents_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "documents_created_at_idx": {
+          "name": "documents_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "documents_filename_idx": {
+          "name": "documents_filename_idx",
+          "columns": ["filename"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "documents_tenant_id_tenants_id_fk": {
+          "name": "documents_tenant_id_tenants_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sponsors": {
+      "name": "sponsors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "photo_id": {
+          "name": "photo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "sponsors_tenant_idx": {
+          "name": "sponsors_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "sponsors_photo_idx": {
+          "name": "sponsors_photo_idx",
+          "columns": ["photo_id"],
+          "isUnique": false
+        },
+        "sponsors_updated_at_idx": {
+          "name": "sponsors_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "sponsors_created_at_idx": {
+          "name": "sponsors_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sponsors_tenant_id_tenants_id_fk": {
+          "name": "sponsors_tenant_id_tenants_id_fk",
+          "tableFrom": "sponsors",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sponsors_photo_id_media_id_fk": {
+          "name": "sponsors_photo_id_media_id_fk",
+          "tableFrom": "sponsors",
+          "tableTo": "media",
+          "columnsFrom": ["photo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "tags_tenant_idx": {
+          "name": "tags_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "tags_slug_idx": {
+          "name": "tags_slug_idx",
+          "columns": ["slug"],
+          "isUnique": false
+        },
+        "tags_updated_at_idx": {
+          "name": "tags_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "tags_created_at_idx": {
+          "name": "tags_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tags_tenant_id_tenants_id_fk": {
+          "name": "tags_tenant_id_tenants_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events_blocks_in_content": {
+      "name": "events_blocks_in_content",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "block_type": {
+          "name": "block_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_blocks_in_content_order_idx": {
+          "name": "events_blocks_in_content_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "events_blocks_in_content_parent_id_idx": {
+          "name": "events_blocks_in_content_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_blocks_in_content_parent_id_fk": {
+          "name": "events_blocks_in_content_parent_id_fk",
+          "tableFrom": "events_blocks_in_content",
+          "tableTo": "events",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events_mode_of_travel": {
+      "name": "events_mode_of_travel",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_mode_of_travel_order_idx": {
+          "name": "events_mode_of_travel_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "events_mode_of_travel_parent_idx": {
+          "name": "events_mode_of_travel_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_mode_of_travel_parent_fk": {
+          "name": "events_mode_of_travel_parent_fk",
+          "tableFrom": "events_mode_of_travel",
+          "tableTo": "events",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events_document_references": {
+      "name": "events_document_references",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instances": {
+          "name": "instances",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_document_references_order_idx": {
+          "name": "events_document_references_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "events_document_references_parent_id_idx": {
+          "name": "events_document_references_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_document_references_parent_id_fk": {
+          "name": "events_document_references_parent_id_fk",
+          "tableFrom": "events_document_references",
+          "tableTo": "events",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startdate_tz": {
+          "name": "startdate_tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enddate_tz": {
+          "name": "enddate_tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_is_virtual": {
+          "name": "location_is_virtual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "location_place_name": {
+          "name": "location_place_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_address": {
+          "name": "location_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_city": {
+          "name": "location_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_state": {
+          "name": "location_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_zip": {
+          "name": "location_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_country": {
+          "name": "location_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'US'"
+        },
+        "location_virtual_url": {
+          "name": "location_virtual_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_extra_info": {
+          "name": "location_extra_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "featured_image_id": {
+          "name": "featured_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_image_id": {
+          "name": "thumbnail_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registration_url": {
+          "name": "registration_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_event_url": {
+          "name": "external_event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registration_deadline": {
+          "name": "registration_deadline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registrationdeadline_tz": {
+          "name": "registrationdeadline_tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skill_level": {
+          "name": "skill_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "events_featured_image_idx": {
+          "name": "events_featured_image_idx",
+          "columns": ["featured_image_id"],
+          "isUnique": false
+        },
+        "events_thumbnail_image_idx": {
+          "name": "events_thumbnail_image_idx",
+          "columns": ["thumbnail_image_id"],
+          "isUnique": false
+        },
+        "events_slug_idx": {
+          "name": "events_slug_idx",
+          "columns": ["slug"],
+          "isUnique": false
+        },
+        "events_tenant_idx": {
+          "name": "events_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "events_updated_at_idx": {
+          "name": "events_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "events_created_at_idx": {
+          "name": "events_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "events__status_idx": {
+          "name": "events__status_idx",
+          "columns": ["_status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_featured_image_id_media_id_fk": {
+          "name": "events_featured_image_id_media_id_fk",
+          "tableFrom": "events",
+          "tableTo": "media",
+          "columnsFrom": ["featured_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_thumbnail_image_id_media_id_fk": {
+          "name": "events_thumbnail_image_id_media_id_fk",
+          "tableFrom": "events",
+          "tableTo": "media",
+          "columnsFrom": ["thumbnail_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_tenant_id_tenants_id_fk": {
+          "name": "events_tenant_id_tenants_id_fk",
+          "tableFrom": "events",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events_rels": {
+      "name": "events_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_groups_id": {
+          "name": "event_groups_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_tags_id": {
+          "name": "event_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_rels_order_idx": {
+          "name": "events_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "events_rels_parent_idx": {
+          "name": "events_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "events_rels_path_idx": {
+          "name": "events_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "events_rels_event_groups_id_idx": {
+          "name": "events_rels_event_groups_id_idx",
+          "columns": ["event_groups_id"],
+          "isUnique": false
+        },
+        "events_rels_event_tags_id_idx": {
+          "name": "events_rels_event_tags_id_idx",
+          "columns": ["event_tags_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_rels_parent_fk": {
+          "name": "events_rels_parent_fk",
+          "tableFrom": "events_rels",
+          "tableTo": "events",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_rels_event_groups_fk": {
+          "name": "events_rels_event_groups_fk",
+          "tableFrom": "events_rels",
+          "tableTo": "event_groups",
+          "columnsFrom": ["event_groups_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_rels_event_tags_fk": {
+          "name": "events_rels_event_tags_fk",
+          "tableFrom": "events_rels",
+          "tableTo": "event_tags",
+          "columnsFrom": ["event_tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_events_v_version_blocks_in_content": {
+      "name": "_events_v_version_blocks_in_content",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "block_type": {
+          "name": "block_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_events_v_version_blocks_in_content_order_idx": {
+          "name": "_events_v_version_blocks_in_content_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_events_v_version_blocks_in_content_parent_id_idx": {
+          "name": "_events_v_version_blocks_in_content_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_events_v_version_blocks_in_content_parent_id_fk": {
+          "name": "_events_v_version_blocks_in_content_parent_id_fk",
+          "tableFrom": "_events_v_version_blocks_in_content",
+          "tableTo": "_events_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_events_v_version_mode_of_travel": {
+      "name": "_events_v_version_mode_of_travel",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_events_v_version_mode_of_travel_order_idx": {
+          "name": "_events_v_version_mode_of_travel_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_events_v_version_mode_of_travel_parent_idx": {
+          "name": "_events_v_version_mode_of_travel_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_events_v_version_mode_of_travel_parent_fk": {
+          "name": "_events_v_version_mode_of_travel_parent_fk",
+          "tableFrom": "_events_v_version_mode_of_travel",
+          "tableTo": "_events_v",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_events_v_version_document_references": {
+      "name": "_events_v_version_document_references",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instances": {
+          "name": "instances",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_events_v_version_document_references_order_idx": {
+          "name": "_events_v_version_document_references_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_events_v_version_document_references_parent_id_idx": {
+          "name": "_events_v_version_document_references_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_events_v_version_document_references_parent_id_fk": {
+          "name": "_events_v_version_document_references_parent_id_fk",
+          "tableFrom": "_events_v_version_document_references",
+          "tableTo": "_events_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_events_v": {
+      "name": "_events_v",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_title": {
+          "name": "version_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_subtitle": {
+          "name": "version_subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_description": {
+          "name": "version_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_start_date": {
+          "name": "version_start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_startdate_tz": {
+          "name": "version_startdate_tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_end_date": {
+          "name": "version_end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_enddate_tz": {
+          "name": "version_enddate_tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_is_virtual": {
+          "name": "version_location_is_virtual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "version_location_place_name": {
+          "name": "version_location_place_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_address": {
+          "name": "version_location_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_city": {
+          "name": "version_location_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_state": {
+          "name": "version_location_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_zip": {
+          "name": "version_location_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_country": {
+          "name": "version_location_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'US'"
+        },
+        "version_location_virtual_url": {
+          "name": "version_location_virtual_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_extra_info": {
+          "name": "version_location_extra_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_featured_image_id": {
+          "name": "version_featured_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_thumbnail_image_id": {
+          "name": "version_thumbnail_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_registration_url": {
+          "name": "version_registration_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_external_event_url": {
+          "name": "version_external_event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_registration_deadline": {
+          "name": "version_registration_deadline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_registrationdeadline_tz": {
+          "name": "version_registrationdeadline_tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_skill_level": {
+          "name": "version_skill_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_content": {
+          "name": "version_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_slug": {
+          "name": "version_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_type": {
+          "name": "version_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_tenant_id": {
+          "name": "version_tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_content_hash": {
+          "name": "version_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_events_v_parent_idx": {
+          "name": "_events_v_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "_events_v_version_version_featured_image_idx": {
+          "name": "_events_v_version_version_featured_image_idx",
+          "columns": ["version_featured_image_id"],
+          "isUnique": false
+        },
+        "_events_v_version_version_thumbnail_image_idx": {
+          "name": "_events_v_version_version_thumbnail_image_idx",
+          "columns": ["version_thumbnail_image_id"],
+          "isUnique": false
+        },
+        "_events_v_version_version_slug_idx": {
+          "name": "_events_v_version_version_slug_idx",
+          "columns": ["version_slug"],
+          "isUnique": false
+        },
+        "_events_v_version_version_tenant_idx": {
+          "name": "_events_v_version_version_tenant_idx",
+          "columns": ["version_tenant_id"],
+          "isUnique": false
+        },
+        "_events_v_version_version_updated_at_idx": {
+          "name": "_events_v_version_version_updated_at_idx",
+          "columns": ["version_updated_at"],
+          "isUnique": false
+        },
+        "_events_v_version_version_created_at_idx": {
+          "name": "_events_v_version_version_created_at_idx",
+          "columns": ["version_created_at"],
+          "isUnique": false
+        },
+        "_events_v_version_version__status_idx": {
+          "name": "_events_v_version_version__status_idx",
+          "columns": ["version__status"],
+          "isUnique": false
+        },
+        "_events_v_created_at_idx": {
+          "name": "_events_v_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "_events_v_updated_at_idx": {
+          "name": "_events_v_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "_events_v_latest_idx": {
+          "name": "_events_v_latest_idx",
+          "columns": ["latest"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_events_v_parent_id_events_id_fk": {
+          "name": "_events_v_parent_id_events_id_fk",
+          "tableFrom": "_events_v",
+          "tableTo": "events",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_events_v_version_featured_image_id_media_id_fk": {
+          "name": "_events_v_version_featured_image_id_media_id_fk",
+          "tableFrom": "_events_v",
+          "tableTo": "media",
+          "columnsFrom": ["version_featured_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_events_v_version_thumbnail_image_id_media_id_fk": {
+          "name": "_events_v_version_thumbnail_image_id_media_id_fk",
+          "tableFrom": "_events_v",
+          "tableTo": "media",
+          "columnsFrom": ["version_thumbnail_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_events_v_version_tenant_id_tenants_id_fk": {
+          "name": "_events_v_version_tenant_id_tenants_id_fk",
+          "tableFrom": "_events_v",
+          "tableTo": "tenants",
+          "columnsFrom": ["version_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_events_v_rels": {
+      "name": "_events_v_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_groups_id": {
+          "name": "event_groups_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_tags_id": {
+          "name": "event_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_events_v_rels_order_idx": {
+          "name": "_events_v_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_events_v_rels_parent_idx": {
+          "name": "_events_v_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "_events_v_rels_path_idx": {
+          "name": "_events_v_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "_events_v_rels_event_groups_id_idx": {
+          "name": "_events_v_rels_event_groups_id_idx",
+          "columns": ["event_groups_id"],
+          "isUnique": false
+        },
+        "_events_v_rels_event_tags_id_idx": {
+          "name": "_events_v_rels_event_tags_id_idx",
+          "columns": ["event_tags_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_events_v_rels_parent_fk": {
+          "name": "_events_v_rels_parent_fk",
+          "tableFrom": "_events_v_rels",
+          "tableTo": "_events_v",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_events_v_rels_event_groups_fk": {
+          "name": "_events_v_rels_event_groups_fk",
+          "tableFrom": "_events_v_rels",
+          "tableTo": "event_groups",
+          "columnsFrom": ["event_groups_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_events_v_rels_event_tags_fk": {
+          "name": "_events_v_rels_event_tags_fk",
+          "tableFrom": "_events_v_rels",
+          "tableTo": "event_tags",
+          "columnsFrom": ["event_tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_groups": {
+      "name": "event_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "event_groups_tenant_idx": {
+          "name": "event_groups_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "event_groups_slug_idx": {
+          "name": "event_groups_slug_idx",
+          "columns": ["slug"],
+          "isUnique": false
+        },
+        "event_groups_updated_at_idx": {
+          "name": "event_groups_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "event_groups_created_at_idx": {
+          "name": "event_groups_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_groups_tenant_id_tenants_id_fk": {
+          "name": "event_groups_tenant_id_tenants_id_fk",
+          "tableFrom": "event_groups",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_tags": {
+      "name": "event_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "event_tags_tenant_idx": {
+          "name": "event_tags_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "event_tags_slug_idx": {
+          "name": "event_tags_slug_idx",
+          "columns": ["slug"],
+          "isUnique": false
+        },
+        "event_tags_updated_at_idx": {
+          "name": "event_tags_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "event_tags_created_at_idx": {
+          "name": "event_tags_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_tags_tenant_id_tenants_id_fk": {
+          "name": "event_tags_tenant_id_tenants_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers_states_serviced": {
+      "name": "providers_states_serviced",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "providers_states_serviced_order_idx": {
+          "name": "providers_states_serviced_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "providers_states_serviced_parent_idx": {
+          "name": "providers_states_serviced_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "providers_states_serviced_parent_fk": {
+          "name": "providers_states_serviced_parent_fk",
+          "tableFrom": "providers_states_serviced",
+          "tableTo": "providers",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers_course_types": {
+      "name": "providers_course_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "providers_course_types_order_idx": {
+          "name": "providers_course_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "providers_course_types_parent_idx": {
+          "name": "providers_course_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "providers_course_types_parent_fk": {
+          "name": "providers_course_types_parent_fk",
+          "tableFrom": "providers_course_types",
+          "tableTo": "providers",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers": {
+      "name": "providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_address": {
+          "name": "location_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_city": {
+          "name": "location_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_state": {
+          "name": "location_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_zip": {
+          "name": "location_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_country": {
+          "name": "location_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'US'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "providers_slug_idx": {
+          "name": "providers_slug_idx",
+          "columns": ["slug"],
+          "isUnique": false
+        },
+        "providers_updated_at_idx": {
+          "name": "providers_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "providers_created_at_idx": {
+          "name": "providers_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "providers__status_idx": {
+          "name": "providers__status_idx",
+          "columns": ["_status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_providers_v_version_states_serviced": {
+      "name": "_providers_v_version_states_serviced",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_providers_v_version_states_serviced_order_idx": {
+          "name": "_providers_v_version_states_serviced_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_providers_v_version_states_serviced_parent_idx": {
+          "name": "_providers_v_version_states_serviced_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_providers_v_version_states_serviced_parent_fk": {
+          "name": "_providers_v_version_states_serviced_parent_fk",
+          "tableFrom": "_providers_v_version_states_serviced",
+          "tableTo": "_providers_v",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_providers_v_version_course_types": {
+      "name": "_providers_v_version_course_types",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_providers_v_version_course_types_order_idx": {
+          "name": "_providers_v_version_course_types_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_providers_v_version_course_types_parent_idx": {
+          "name": "_providers_v_version_course_types_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_providers_v_version_course_types_parent_fk": {
+          "name": "_providers_v_version_course_types_parent_fk",
+          "tableFrom": "_providers_v_version_course_types",
+          "tableTo": "_providers_v",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_providers_v": {
+      "name": "_providers_v",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_name": {
+          "name": "version_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_details": {
+          "name": "version_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_email": {
+          "name": "version_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_phone": {
+          "name": "version_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_website": {
+          "name": "version_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_address": {
+          "name": "version_location_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_city": {
+          "name": "version_location_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_state": {
+          "name": "version_location_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_zip": {
+          "name": "version_location_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_country": {
+          "name": "version_location_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'US'"
+        },
+        "version_slug": {
+          "name": "version_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_notification_email": {
+          "name": "version_notification_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_content_hash": {
+          "name": "version_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_providers_v_parent_idx": {
+          "name": "_providers_v_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "_providers_v_version_version_slug_idx": {
+          "name": "_providers_v_version_version_slug_idx",
+          "columns": ["version_slug"],
+          "isUnique": false
+        },
+        "_providers_v_version_version_updated_at_idx": {
+          "name": "_providers_v_version_version_updated_at_idx",
+          "columns": ["version_updated_at"],
+          "isUnique": false
+        },
+        "_providers_v_version_version_created_at_idx": {
+          "name": "_providers_v_version_version_created_at_idx",
+          "columns": ["version_created_at"],
+          "isUnique": false
+        },
+        "_providers_v_version_version__status_idx": {
+          "name": "_providers_v_version_version__status_idx",
+          "columns": ["version__status"],
+          "isUnique": false
+        },
+        "_providers_v_created_at_idx": {
+          "name": "_providers_v_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "_providers_v_updated_at_idx": {
+          "name": "_providers_v_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "_providers_v_latest_idx": {
+          "name": "_providers_v_latest_idx",
+          "columns": ["latest"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_providers_v_parent_id_providers_id_fk": {
+          "name": "_providers_v_parent_id_providers_id_fk",
+          "tableFrom": "_providers_v",
+          "tableTo": "providers",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "courses_mode_of_travel": {
+      "name": "courses_mode_of_travel",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "courses_mode_of_travel_order_idx": {
+          "name": "courses_mode_of_travel_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "courses_mode_of_travel_parent_idx": {
+          "name": "courses_mode_of_travel_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "courses_mode_of_travel_parent_fk": {
+          "name": "courses_mode_of_travel_parent_fk",
+          "tableFrom": "courses_mode_of_travel",
+          "tableTo": "courses",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "courses_affinity_groups": {
+      "name": "courses_affinity_groups",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "courses_affinity_groups_order_idx": {
+          "name": "courses_affinity_groups_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "courses_affinity_groups_parent_idx": {
+          "name": "courses_affinity_groups_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "courses_affinity_groups_parent_fk": {
+          "name": "courses_affinity_groups_parent_fk",
+          "tableFrom": "courses_affinity_groups",
+          "tableTo": "courses",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "courses": {
+      "name": "courses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startdate_tz": {
+          "name": "startdate_tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enddate_tz": {
+          "name": "enddate_tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_place_name": {
+          "name": "location_place_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_address": {
+          "name": "location_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_city": {
+          "name": "location_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_state": {
+          "name": "location_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_zip": {
+          "name": "location_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_country": {
+          "name": "location_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'US'"
+        },
+        "course_url": {
+          "name": "course_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registration_deadline": {
+          "name": "registration_deadline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registrationdeadline_tz": {
+          "name": "registrationdeadline_tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course_type": {
+          "name": "course_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "courses_slug_idx": {
+          "name": "courses_slug_idx",
+          "columns": ["slug"],
+          "isUnique": false
+        },
+        "courses_provider_idx": {
+          "name": "courses_provider_idx",
+          "columns": ["provider_id"],
+          "isUnique": false
+        },
+        "courses_updated_at_idx": {
+          "name": "courses_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "courses_created_at_idx": {
+          "name": "courses_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "courses__status_idx": {
+          "name": "courses__status_idx",
+          "columns": ["_status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "courses_provider_id_providers_id_fk": {
+          "name": "courses_provider_id_providers_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_courses_v_version_mode_of_travel": {
+      "name": "_courses_v_version_mode_of_travel",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_courses_v_version_mode_of_travel_order_idx": {
+          "name": "_courses_v_version_mode_of_travel_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_courses_v_version_mode_of_travel_parent_idx": {
+          "name": "_courses_v_version_mode_of_travel_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_courses_v_version_mode_of_travel_parent_fk": {
+          "name": "_courses_v_version_mode_of_travel_parent_fk",
+          "tableFrom": "_courses_v_version_mode_of_travel",
+          "tableTo": "_courses_v",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_courses_v_version_affinity_groups": {
+      "name": "_courses_v_version_affinity_groups",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_courses_v_version_affinity_groups_order_idx": {
+          "name": "_courses_v_version_affinity_groups_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_courses_v_version_affinity_groups_parent_idx": {
+          "name": "_courses_v_version_affinity_groups_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_courses_v_version_affinity_groups_parent_fk": {
+          "name": "_courses_v_version_affinity_groups_parent_fk",
+          "tableFrom": "_courses_v_version_affinity_groups",
+          "tableTo": "_courses_v",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_courses_v": {
+      "name": "_courses_v",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_title": {
+          "name": "version_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_subtitle": {
+          "name": "version_subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_description": {
+          "name": "version_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_start_date": {
+          "name": "version_start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_startdate_tz": {
+          "name": "version_startdate_tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_end_date": {
+          "name": "version_end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_enddate_tz": {
+          "name": "version_enddate_tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_place_name": {
+          "name": "version_location_place_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_address": {
+          "name": "version_location_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_city": {
+          "name": "version_location_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_state": {
+          "name": "version_location_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_zip": {
+          "name": "version_location_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_location_country": {
+          "name": "version_location_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'US'"
+        },
+        "version_course_url": {
+          "name": "version_course_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_registration_deadline": {
+          "name": "version_registration_deadline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_registrationdeadline_tz": {
+          "name": "version_registrationdeadline_tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_slug": {
+          "name": "version_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_course_type": {
+          "name": "version_course_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_provider_id": {
+          "name": "version_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_content_hash": {
+          "name": "version_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_courses_v_parent_idx": {
+          "name": "_courses_v_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "_courses_v_version_version_slug_idx": {
+          "name": "_courses_v_version_version_slug_idx",
+          "columns": ["version_slug"],
+          "isUnique": false
+        },
+        "_courses_v_version_version_provider_idx": {
+          "name": "_courses_v_version_version_provider_idx",
+          "columns": ["version_provider_id"],
+          "isUnique": false
+        },
+        "_courses_v_version_version_updated_at_idx": {
+          "name": "_courses_v_version_version_updated_at_idx",
+          "columns": ["version_updated_at"],
+          "isUnique": false
+        },
+        "_courses_v_version_version_created_at_idx": {
+          "name": "_courses_v_version_version_created_at_idx",
+          "columns": ["version_created_at"],
+          "isUnique": false
+        },
+        "_courses_v_version_version__status_idx": {
+          "name": "_courses_v_version_version__status_idx",
+          "columns": ["version__status"],
+          "isUnique": false
+        },
+        "_courses_v_created_at_idx": {
+          "name": "_courses_v_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "_courses_v_updated_at_idx": {
+          "name": "_courses_v_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "_courses_v_latest_idx": {
+          "name": "_courses_v_latest_idx",
+          "columns": ["latest"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_courses_v_parent_id_courses_id_fk": {
+          "name": "_courses_v_parent_id_courses_id_fk",
+          "tableFrom": "_courses_v",
+          "tableTo": "courses",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_courses_v_version_provider_id_providers_id_fk": {
+          "name": "_courses_v_version_provider_id_providers_id_fk",
+          "tableFrom": "_courses_v",
+          "tableTo": "providers",
+          "columnsFrom": ["version_provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "biographies": {
+      "name": "biographies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "photo_id": {
+          "name": "photo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "biography": {
+          "name": "biography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "biographies_tenant_idx": {
+          "name": "biographies_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "biographies_photo_idx": {
+          "name": "biographies_photo_idx",
+          "columns": ["photo_id"],
+          "isUnique": false
+        },
+        "biographies_updated_at_idx": {
+          "name": "biographies_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "biographies_created_at_idx": {
+          "name": "biographies_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "biographies_tenant_id_tenants_id_fk": {
+          "name": "biographies_tenant_id_tenants_id_fk",
+          "tableFrom": "biographies",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "biographies_photo_id_media_id_fk": {
+          "name": "biographies_photo_id_media_id_fk",
+          "tableFrom": "biographies",
+          "tableTo": "media",
+          "columnsFrom": ["photo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "teams_tenant_idx": {
+          "name": "teams_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "teams_updated_at_idx": {
+          "name": "teams_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "teams_created_at_idx": {
+          "name": "teams_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "teams_tenant_id_tenants_id_fk": {
+          "name": "teams_tenant_id_tenants_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams_rels": {
+      "name": "teams_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "biographies_id": {
+          "name": "biographies_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "teams_rels_order_idx": {
+          "name": "teams_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "teams_rels_parent_idx": {
+          "name": "teams_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "teams_rels_path_idx": {
+          "name": "teams_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "teams_rels_biographies_id_idx": {
+          "name": "teams_rels_biographies_id_idx",
+          "columns": ["biographies_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "teams_rels_parent_fk": {
+          "name": "teams_rels_parent_fk",
+          "tableFrom": "teams_rels",
+          "tableTo": "teams",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_rels_biographies_fk": {
+          "name": "teams_rels_biographies_fk",
+          "tableFrom": "teams_rels",
+          "tableTo": "biographies",
+          "columnsFrom": ["biographies_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_sessions": {
+      "name": "users_sessions",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invite_expiration": {
+          "name": "invite_expiration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_name_idx": {
+          "name": "users_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_rels": {
+      "name": "users_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providers_id": {
+          "name": "providers_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_rels_order_idx": {
+          "name": "users_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "users_rels_parent_idx": {
+          "name": "users_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "users_rels_path_idx": {
+          "name": "users_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "users_rels_providers_id_idx": {
+          "name": "users_rels_providers_id_idx",
+          "columns": ["providers_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "users_rels_parent_fk": {
+          "name": "users_rels_parent_fk",
+          "tableFrom": "users_rels",
+          "tableTo": "users",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_rels_providers_fk": {
+          "name": "users_rels_providers_fk",
+          "tableFrom": "users_rels",
+          "tableTo": "providers",
+          "columnsFrom": ["providers_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles_rules_actions": {
+      "name": "roles_rules_actions",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "roles_rules_actions_order_idx": {
+          "name": "roles_rules_actions_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "roles_rules_actions_parent_idx": {
+          "name": "roles_rules_actions_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "roles_rules_actions_parent_fk": {
+          "name": "roles_rules_actions_parent_fk",
+          "tableFrom": "roles_rules_actions",
+          "tableTo": "roles_rules",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles_rules": {
+      "name": "roles_rules",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "roles_rules_order_idx": {
+          "name": "roles_rules_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "roles_rules_parent_id_idx": {
+          "name": "roles_rules_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "roles_rules_parent_id_fk": {
+          "name": "roles_rules_parent_id_fk",
+          "tableFrom": "roles_rules",
+          "tableTo": "roles",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "roles_name_idx": {
+          "name": "roles_name_idx",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "roles_updated_at_idx": {
+          "name": "roles_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "roles_created_at_idx": {
+          "name": "roles_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles_texts": {
+      "name": "roles_texts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "roles_texts_order_parent": {
+          "name": "roles_texts_order_parent",
+          "columns": ["order", "parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "roles_texts_parent_fk": {
+          "name": "roles_texts_parent_fk",
+          "tableFrom": "roles_texts",
+          "tableTo": "roles",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "role_assignments": {
+      "name": "role_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "role_assignments_tenant_idx": {
+          "name": "role_assignments_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "role_assignments_role_idx": {
+          "name": "role_assignments_role_idx",
+          "columns": ["role_id"],
+          "isUnique": false
+        },
+        "role_assignments_user_idx": {
+          "name": "role_assignments_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "role_assignments_updated_at_idx": {
+          "name": "role_assignments_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "role_assignments_created_at_idx": {
+          "name": "role_assignments_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "role_assignments_tenant_id_tenants_id_fk": {
+          "name": "role_assignments_tenant_id_tenants_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "role_assignments_role_id_roles_id_fk": {
+          "name": "role_assignments_role_id_roles_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "role_assignments_user_id_users_id_fk": {
+          "name": "role_assignments_user_id_users_id_fk",
+          "tableFrom": "role_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_roles_rules_actions": {
+      "name": "global_roles_rules_actions",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "global_roles_rules_actions_order_idx": {
+          "name": "global_roles_rules_actions_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "global_roles_rules_actions_parent_idx": {
+          "name": "global_roles_rules_actions_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "global_roles_rules_actions_parent_fk": {
+          "name": "global_roles_rules_actions_parent_fk",
+          "tableFrom": "global_roles_rules_actions",
+          "tableTo": "global_roles_rules",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_roles_rules": {
+      "name": "global_roles_rules",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "global_roles_rules_order_idx": {
+          "name": "global_roles_rules_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "global_roles_rules_parent_id_idx": {
+          "name": "global_roles_rules_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "global_roles_rules_parent_id_fk": {
+          "name": "global_roles_rules_parent_id_fk",
+          "tableFrom": "global_roles_rules",
+          "tableTo": "global_roles",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_roles": {
+      "name": "global_roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "global_roles_name_idx": {
+          "name": "global_roles_name_idx",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "global_roles_updated_at_idx": {
+          "name": "global_roles_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "global_roles_created_at_idx": {
+          "name": "global_roles_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_roles_texts": {
+      "name": "global_roles_texts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "global_roles_texts_order_parent": {
+          "name": "global_roles_texts_order_parent",
+          "columns": ["order", "parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "global_roles_texts_parent_fk": {
+          "name": "global_roles_texts_parent_fk",
+          "tableFrom": "global_roles_texts",
+          "tableTo": "global_roles",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "global_role_assignments": {
+      "name": "global_role_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_role_id": {
+          "name": "global_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "global_role_assignments_global_role_idx": {
+          "name": "global_role_assignments_global_role_idx",
+          "columns": ["global_role_id"],
+          "isUnique": false
+        },
+        "global_role_assignments_user_idx": {
+          "name": "global_role_assignments_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "global_role_assignments_updated_at_idx": {
+          "name": "global_role_assignments_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "global_role_assignments_created_at_idx": {
+          "name": "global_role_assignments_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "global_role_assignments_global_role_id_global_roles_id_fk": {
+          "name": "global_role_assignments_global_role_id_global_roles_id_fk",
+          "tableFrom": "global_role_assignments",
+          "tableTo": "global_roles",
+          "columnsFrom": ["global_role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "global_role_assignments_user_id_users_id_fk": {
+          "name": "global_role_assignments_user_id_users_id_fk",
+          "tableFrom": "global_role_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenants": {
+      "name": "tenants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provisioning_status": {
+          "name": "provisioning_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_started'"
+        },
+        "provisioning_last_run_at": {
+          "name": "provisioning_last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provisioning_failed": {
+          "name": "provisioning_failed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "tenants_slug_idx": {
+          "name": "tenants_slug_idx",
+          "columns": ["slug"],
+          "isUnique": true
+        },
+        "tenants_updated_at_idx": {
+          "name": "tenants_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "tenants_created_at_idx": {
+          "name": "tenants_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_forecasts_items_items": {
+      "name": "navigations_forecasts_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_forecasts_items_items_order_idx": {
+          "name": "navigations_forecasts_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_forecasts_items_items_parent_id_idx": {
+          "name": "navigations_forecasts_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_forecasts_items_items_parent_id_fk": {
+          "name": "navigations_forecasts_items_items_parent_id_fk",
+          "tableFrom": "navigations_forecasts_items_items",
+          "tableTo": "navigations_forecasts_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_forecasts_items": {
+      "name": "navigations_forecasts_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_forecasts_items_order_idx": {
+          "name": "navigations_forecasts_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_forecasts_items_parent_id_idx": {
+          "name": "navigations_forecasts_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_forecasts_items_parent_id_fk": {
+          "name": "navigations_forecasts_items_parent_id_fk",
+          "tableFrom": "navigations_forecasts_items",
+          "tableTo": "navigations",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_observations_items_items": {
+      "name": "navigations_observations_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_observations_items_items_order_idx": {
+          "name": "navigations_observations_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_observations_items_items_parent_id_idx": {
+          "name": "navigations_observations_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_observations_items_items_parent_id_fk": {
+          "name": "navigations_observations_items_items_parent_id_fk",
+          "tableFrom": "navigations_observations_items_items",
+          "tableTo": "navigations_observations_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_observations_items": {
+      "name": "navigations_observations_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_observations_items_order_idx": {
+          "name": "navigations_observations_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_observations_items_parent_id_idx": {
+          "name": "navigations_observations_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_observations_items_parent_id_fk": {
+          "name": "navigations_observations_items_parent_id_fk",
+          "tableFrom": "navigations_observations_items",
+          "tableTo": "navigations",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_weather_items_items": {
+      "name": "navigations_weather_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_weather_items_items_order_idx": {
+          "name": "navigations_weather_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_weather_items_items_parent_id_idx": {
+          "name": "navigations_weather_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_weather_items_items_parent_id_fk": {
+          "name": "navigations_weather_items_items_parent_id_fk",
+          "tableFrom": "navigations_weather_items_items",
+          "tableTo": "navigations_weather_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_weather_items": {
+      "name": "navigations_weather_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_weather_items_order_idx": {
+          "name": "navigations_weather_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_weather_items_parent_id_idx": {
+          "name": "navigations_weather_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_weather_items_parent_id_fk": {
+          "name": "navigations_weather_items_parent_id_fk",
+          "tableFrom": "navigations_weather_items",
+          "tableTo": "navigations",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_education_items_items": {
+      "name": "navigations_education_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_education_items_items_order_idx": {
+          "name": "navigations_education_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_education_items_items_parent_id_idx": {
+          "name": "navigations_education_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_education_items_items_parent_id_fk": {
+          "name": "navigations_education_items_items_parent_id_fk",
+          "tableFrom": "navigations_education_items_items",
+          "tableTo": "navigations_education_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_education_items": {
+      "name": "navigations_education_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_education_items_order_idx": {
+          "name": "navigations_education_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_education_items_parent_id_idx": {
+          "name": "navigations_education_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_education_items_parent_id_fk": {
+          "name": "navigations_education_items_parent_id_fk",
+          "tableFrom": "navigations_education_items",
+          "tableTo": "navigations",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_accidents_items_items": {
+      "name": "navigations_accidents_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_accidents_items_items_order_idx": {
+          "name": "navigations_accidents_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_accidents_items_items_parent_id_idx": {
+          "name": "navigations_accidents_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_accidents_items_items_parent_id_fk": {
+          "name": "navigations_accidents_items_items_parent_id_fk",
+          "tableFrom": "navigations_accidents_items_items",
+          "tableTo": "navigations_accidents_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_accidents_items": {
+      "name": "navigations_accidents_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_accidents_items_order_idx": {
+          "name": "navigations_accidents_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_accidents_items_parent_id_idx": {
+          "name": "navigations_accidents_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_accidents_items_parent_id_fk": {
+          "name": "navigations_accidents_items_parent_id_fk",
+          "tableFrom": "navigations_accidents_items",
+          "tableTo": "navigations",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_blog_items_items": {
+      "name": "navigations_blog_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_blog_items_items_order_idx": {
+          "name": "navigations_blog_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_blog_items_items_parent_id_idx": {
+          "name": "navigations_blog_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_blog_items_items_parent_id_fk": {
+          "name": "navigations_blog_items_items_parent_id_fk",
+          "tableFrom": "navigations_blog_items_items",
+          "tableTo": "navigations_blog_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_blog_items": {
+      "name": "navigations_blog_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_blog_items_order_idx": {
+          "name": "navigations_blog_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_blog_items_parent_id_idx": {
+          "name": "navigations_blog_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_blog_items_parent_id_fk": {
+          "name": "navigations_blog_items_parent_id_fk",
+          "tableFrom": "navigations_blog_items",
+          "tableTo": "navigations",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_events_items_items": {
+      "name": "navigations_events_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_events_items_items_order_idx": {
+          "name": "navigations_events_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_events_items_items_parent_id_idx": {
+          "name": "navigations_events_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_events_items_items_parent_id_fk": {
+          "name": "navigations_events_items_items_parent_id_fk",
+          "tableFrom": "navigations_events_items_items",
+          "tableTo": "navigations_events_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_events_items": {
+      "name": "navigations_events_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_events_items_order_idx": {
+          "name": "navigations_events_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_events_items_parent_id_idx": {
+          "name": "navigations_events_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_events_items_parent_id_fk": {
+          "name": "navigations_events_items_parent_id_fk",
+          "tableFrom": "navigations_events_items",
+          "tableTo": "navigations",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_about_items_items": {
+      "name": "navigations_about_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_about_items_items_order_idx": {
+          "name": "navigations_about_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_about_items_items_parent_id_idx": {
+          "name": "navigations_about_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_about_items_items_parent_id_fk": {
+          "name": "navigations_about_items_items_parent_id_fk",
+          "tableFrom": "navigations_about_items_items",
+          "tableTo": "navigations_about_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_about_items": {
+      "name": "navigations_about_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_about_items_order_idx": {
+          "name": "navigations_about_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_about_items_parent_id_idx": {
+          "name": "navigations_about_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_about_items_parent_id_fk": {
+          "name": "navigations_about_items_parent_id_fk",
+          "tableFrom": "navigations_about_items",
+          "tableTo": "navigations",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_support_items_items": {
+      "name": "navigations_support_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_support_items_items_order_idx": {
+          "name": "navigations_support_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_support_items_items_parent_id_idx": {
+          "name": "navigations_support_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_support_items_items_parent_id_fk": {
+          "name": "navigations_support_items_items_parent_id_fk",
+          "tableFrom": "navigations_support_items_items",
+          "tableTo": "navigations_support_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_support_items": {
+      "name": "navigations_support_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_support_items_order_idx": {
+          "name": "navigations_support_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_support_items_parent_id_idx": {
+          "name": "navigations_support_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_support_items_parent_id_fk": {
+          "name": "navigations_support_items_parent_id_fk",
+          "tableFrom": "navigations_support_items",
+          "tableTo": "navigations",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_donate_items_items": {
+      "name": "navigations_donate_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_donate_items_items_order_idx": {
+          "name": "navigations_donate_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_donate_items_items_parent_id_idx": {
+          "name": "navigations_donate_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_donate_items_items_parent_id_fk": {
+          "name": "navigations_donate_items_items_parent_id_fk",
+          "tableFrom": "navigations_donate_items_items",
+          "tableTo": "navigations_donate_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_donate_items": {
+      "name": "navigations_donate_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "navigations_donate_items_order_idx": {
+          "name": "navigations_donate_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "navigations_donate_items_parent_id_idx": {
+          "name": "navigations_donate_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_donate_items_parent_id_fk": {
+          "name": "navigations_donate_items_parent_id_fk",
+          "tableFrom": "navigations_donate_items",
+          "tableTo": "navigations",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations": {
+      "name": "navigations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forecasts_options_display_mode": {
+          "name": "forecasts_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "forecasts_link_type": {
+          "name": "forecasts_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "forecasts_link_url": {
+          "name": "forecasts_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forecasts_link_label": {
+          "name": "forecasts_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forecasts_link_new_tab": {
+          "name": "forecasts_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "observations_options_display_mode": {
+          "name": "observations_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "observations_link_type": {
+          "name": "observations_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "observations_link_url": {
+          "name": "observations_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "observations_link_label": {
+          "name": "observations_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "observations_link_new_tab": {
+          "name": "observations_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "weather_options_display_mode": {
+          "name": "weather_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "weather_options_enabled": {
+          "name": "weather_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "weather_link_type": {
+          "name": "weather_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "weather_link_url": {
+          "name": "weather_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weather_link_label": {
+          "name": "weather_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weather_link_new_tab": {
+          "name": "weather_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "education_options_display_mode": {
+          "name": "education_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "education_options_enabled": {
+          "name": "education_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "education_link_type": {
+          "name": "education_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "education_link_url": {
+          "name": "education_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "education_link_label": {
+          "name": "education_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "education_link_new_tab": {
+          "name": "education_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "accidents_options_display_mode": {
+          "name": "accidents_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "accidents_options_enabled": {
+          "name": "accidents_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "accidents_link_type": {
+          "name": "accidents_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "accidents_link_url": {
+          "name": "accidents_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accidents_link_label": {
+          "name": "accidents_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accidents_link_new_tab": {
+          "name": "accidents_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "blog_options_display_mode": {
+          "name": "blog_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'link'"
+        },
+        "blog_options_enabled": {
+          "name": "blog_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "blog_link_type": {
+          "name": "blog_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "blog_link_url": {
+          "name": "blog_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blog_link_label": {
+          "name": "blog_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blog_link_new_tab": {
+          "name": "blog_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "events_options_display_mode": {
+          "name": "events_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'link'"
+        },
+        "events_options_enabled": {
+          "name": "events_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "events_link_type": {
+          "name": "events_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "events_link_url": {
+          "name": "events_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events_link_label": {
+          "name": "events_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events_link_new_tab": {
+          "name": "events_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "about_options_display_mode": {
+          "name": "about_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "about_options_enabled": {
+          "name": "about_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "about_link_type": {
+          "name": "about_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "about_link_url": {
+          "name": "about_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "about_link_label": {
+          "name": "about_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "about_link_new_tab": {
+          "name": "about_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "support_options_display_mode": {
+          "name": "support_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "support_options_enabled": {
+          "name": "support_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "support_link_type": {
+          "name": "support_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "support_link_url": {
+          "name": "support_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "support_link_label": {
+          "name": "support_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "support_link_new_tab": {
+          "name": "support_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "donate_options_display_mode": {
+          "name": "donate_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'button'"
+        },
+        "donate_options_enabled": {
+          "name": "donate_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "donate_link_type": {
+          "name": "donate_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "donate_link_url": {
+          "name": "donate_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "donate_link_label": {
+          "name": "donate_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "donate_link_new_tab": {
+          "name": "donate_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "navigations_tenant_idx": {
+          "name": "navigations_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": true
+        },
+        "navigations_updated_at_idx": {
+          "name": "navigations_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "navigations_created_at_idx": {
+          "name": "navigations_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "navigations__status_idx": {
+          "name": "navigations__status_idx",
+          "columns": ["_status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_tenant_id_tenants_id_fk": {
+          "name": "navigations_tenant_id_tenants_id_fk",
+          "tableFrom": "navigations",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "navigations_rels": {
+      "name": "navigations_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "built_in_pages_id": {
+          "name": "built_in_pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posts_id": {
+          "name": "posts_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "navigations_rels_order_idx": {
+          "name": "navigations_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "navigations_rels_parent_idx": {
+          "name": "navigations_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "navigations_rels_path_idx": {
+          "name": "navigations_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "navigations_rels_pages_id_idx": {
+          "name": "navigations_rels_pages_id_idx",
+          "columns": ["pages_id"],
+          "isUnique": false
+        },
+        "navigations_rels_built_in_pages_id_idx": {
+          "name": "navigations_rels_built_in_pages_id_idx",
+          "columns": ["built_in_pages_id"],
+          "isUnique": false
+        },
+        "navigations_rels_posts_id_idx": {
+          "name": "navigations_rels_posts_id_idx",
+          "columns": ["posts_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "navigations_rels_parent_fk": {
+          "name": "navigations_rels_parent_fk",
+          "tableFrom": "navigations_rels",
+          "tableTo": "navigations",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "navigations_rels_pages_fk": {
+          "name": "navigations_rels_pages_fk",
+          "tableFrom": "navigations_rels",
+          "tableTo": "pages",
+          "columnsFrom": ["pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "navigations_rels_built_in_pages_fk": {
+          "name": "navigations_rels_built_in_pages_fk",
+          "tableFrom": "navigations_rels",
+          "tableTo": "built_in_pages",
+          "columnsFrom": ["built_in_pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "navigations_rels_posts_fk": {
+          "name": "navigations_rels_posts_fk",
+          "tableFrom": "navigations_rels",
+          "tableTo": "posts",
+          "columnsFrom": ["posts_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_forecasts_items_items": {
+      "name": "_navigations_v_version_forecasts_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_forecasts_items_items_order_idx": {
+          "name": "_navigations_v_version_forecasts_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_forecasts_items_items_parent_id_idx": {
+          "name": "_navigations_v_version_forecasts_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_forecasts_items_items_parent_id_fk": {
+          "name": "_navigations_v_version_forecasts_items_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_forecasts_items_items",
+          "tableTo": "_navigations_v_version_forecasts_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_forecasts_items": {
+      "name": "_navigations_v_version_forecasts_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_forecasts_items_order_idx": {
+          "name": "_navigations_v_version_forecasts_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_forecasts_items_parent_id_idx": {
+          "name": "_navigations_v_version_forecasts_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_forecasts_items_parent_id_fk": {
+          "name": "_navigations_v_version_forecasts_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_forecasts_items",
+          "tableTo": "_navigations_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_observations_items_items": {
+      "name": "_navigations_v_version_observations_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_observations_items_items_order_idx": {
+          "name": "_navigations_v_version_observations_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_observations_items_items_parent_id_idx": {
+          "name": "_navigations_v_version_observations_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_observations_items_items_parent_id_fk": {
+          "name": "_navigations_v_version_observations_items_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_observations_items_items",
+          "tableTo": "_navigations_v_version_observations_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_observations_items": {
+      "name": "_navigations_v_version_observations_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_observations_items_order_idx": {
+          "name": "_navigations_v_version_observations_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_observations_items_parent_id_idx": {
+          "name": "_navigations_v_version_observations_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_observations_items_parent_id_fk": {
+          "name": "_navigations_v_version_observations_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_observations_items",
+          "tableTo": "_navigations_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_weather_items_items": {
+      "name": "_navigations_v_version_weather_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_weather_items_items_order_idx": {
+          "name": "_navigations_v_version_weather_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_weather_items_items_parent_id_idx": {
+          "name": "_navigations_v_version_weather_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_weather_items_items_parent_id_fk": {
+          "name": "_navigations_v_version_weather_items_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_weather_items_items",
+          "tableTo": "_navigations_v_version_weather_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_weather_items": {
+      "name": "_navigations_v_version_weather_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_weather_items_order_idx": {
+          "name": "_navigations_v_version_weather_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_weather_items_parent_id_idx": {
+          "name": "_navigations_v_version_weather_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_weather_items_parent_id_fk": {
+          "name": "_navigations_v_version_weather_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_weather_items",
+          "tableTo": "_navigations_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_education_items_items": {
+      "name": "_navigations_v_version_education_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_education_items_items_order_idx": {
+          "name": "_navigations_v_version_education_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_education_items_items_parent_id_idx": {
+          "name": "_navigations_v_version_education_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_education_items_items_parent_id_fk": {
+          "name": "_navigations_v_version_education_items_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_education_items_items",
+          "tableTo": "_navigations_v_version_education_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_education_items": {
+      "name": "_navigations_v_version_education_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_education_items_order_idx": {
+          "name": "_navigations_v_version_education_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_education_items_parent_id_idx": {
+          "name": "_navigations_v_version_education_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_education_items_parent_id_fk": {
+          "name": "_navigations_v_version_education_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_education_items",
+          "tableTo": "_navigations_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_accidents_items_items": {
+      "name": "_navigations_v_version_accidents_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_accidents_items_items_order_idx": {
+          "name": "_navigations_v_version_accidents_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_accidents_items_items_parent_id_idx": {
+          "name": "_navigations_v_version_accidents_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_accidents_items_items_parent_id_fk": {
+          "name": "_navigations_v_version_accidents_items_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_accidents_items_items",
+          "tableTo": "_navigations_v_version_accidents_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_accidents_items": {
+      "name": "_navigations_v_version_accidents_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_accidents_items_order_idx": {
+          "name": "_navigations_v_version_accidents_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_accidents_items_parent_id_idx": {
+          "name": "_navigations_v_version_accidents_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_accidents_items_parent_id_fk": {
+          "name": "_navigations_v_version_accidents_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_accidents_items",
+          "tableTo": "_navigations_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_blog_items_items": {
+      "name": "_navigations_v_version_blog_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_blog_items_items_order_idx": {
+          "name": "_navigations_v_version_blog_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_blog_items_items_parent_id_idx": {
+          "name": "_navigations_v_version_blog_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_blog_items_items_parent_id_fk": {
+          "name": "_navigations_v_version_blog_items_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_blog_items_items",
+          "tableTo": "_navigations_v_version_blog_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_blog_items": {
+      "name": "_navigations_v_version_blog_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_blog_items_order_idx": {
+          "name": "_navigations_v_version_blog_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_blog_items_parent_id_idx": {
+          "name": "_navigations_v_version_blog_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_blog_items_parent_id_fk": {
+          "name": "_navigations_v_version_blog_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_blog_items",
+          "tableTo": "_navigations_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_events_items_items": {
+      "name": "_navigations_v_version_events_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_events_items_items_order_idx": {
+          "name": "_navigations_v_version_events_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_events_items_items_parent_id_idx": {
+          "name": "_navigations_v_version_events_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_events_items_items_parent_id_fk": {
+          "name": "_navigations_v_version_events_items_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_events_items_items",
+          "tableTo": "_navigations_v_version_events_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_events_items": {
+      "name": "_navigations_v_version_events_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_events_items_order_idx": {
+          "name": "_navigations_v_version_events_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_events_items_parent_id_idx": {
+          "name": "_navigations_v_version_events_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_events_items_parent_id_fk": {
+          "name": "_navigations_v_version_events_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_events_items",
+          "tableTo": "_navigations_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_about_items_items": {
+      "name": "_navigations_v_version_about_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_about_items_items_order_idx": {
+          "name": "_navigations_v_version_about_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_about_items_items_parent_id_idx": {
+          "name": "_navigations_v_version_about_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_about_items_items_parent_id_fk": {
+          "name": "_navigations_v_version_about_items_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_about_items_items",
+          "tableTo": "_navigations_v_version_about_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_about_items": {
+      "name": "_navigations_v_version_about_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_about_items_order_idx": {
+          "name": "_navigations_v_version_about_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_about_items_parent_id_idx": {
+          "name": "_navigations_v_version_about_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_about_items_parent_id_fk": {
+          "name": "_navigations_v_version_about_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_about_items",
+          "tableTo": "_navigations_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_support_items_items": {
+      "name": "_navigations_v_version_support_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_support_items_items_order_idx": {
+          "name": "_navigations_v_version_support_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_support_items_items_parent_id_idx": {
+          "name": "_navigations_v_version_support_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_support_items_items_parent_id_fk": {
+          "name": "_navigations_v_version_support_items_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_support_items_items",
+          "tableTo": "_navigations_v_version_support_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_support_items": {
+      "name": "_navigations_v_version_support_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_support_items_order_idx": {
+          "name": "_navigations_v_version_support_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_support_items_parent_id_idx": {
+          "name": "_navigations_v_version_support_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_support_items_parent_id_fk": {
+          "name": "_navigations_v_version_support_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_support_items",
+          "tableTo": "_navigations_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_donate_items_items": {
+      "name": "_navigations_v_version_donate_items_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_donate_items_items_order_idx": {
+          "name": "_navigations_v_version_donate_items_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_donate_items_items_parent_id_idx": {
+          "name": "_navigations_v_version_donate_items_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_donate_items_items_parent_id_fk": {
+          "name": "_navigations_v_version_donate_items_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_donate_items_items",
+          "tableTo": "_navigations_v_version_donate_items",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_version_donate_items": {
+      "name": "_navigations_v_version_donate_items",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_version_donate_items_order_idx": {
+          "name": "_navigations_v_version_donate_items_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "_navigations_v_version_donate_items_parent_id_idx": {
+          "name": "_navigations_v_version_donate_items_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_version_donate_items_parent_id_fk": {
+          "name": "_navigations_v_version_donate_items_parent_id_fk",
+          "tableFrom": "_navigations_v_version_donate_items",
+          "tableTo": "_navigations_v",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v": {
+      "name": "_navigations_v",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_tenant_id": {
+          "name": "version_tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_forecasts_options_display_mode": {
+          "name": "version_forecasts_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "version_forecasts_link_type": {
+          "name": "version_forecasts_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "version_forecasts_link_url": {
+          "name": "version_forecasts_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_forecasts_link_label": {
+          "name": "version_forecasts_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_forecasts_link_new_tab": {
+          "name": "version_forecasts_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_observations_options_display_mode": {
+          "name": "version_observations_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "version_observations_link_type": {
+          "name": "version_observations_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "version_observations_link_url": {
+          "name": "version_observations_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_observations_link_label": {
+          "name": "version_observations_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_observations_link_new_tab": {
+          "name": "version_observations_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_weather_options_display_mode": {
+          "name": "version_weather_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "version_weather_options_enabled": {
+          "name": "version_weather_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_weather_link_type": {
+          "name": "version_weather_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "version_weather_link_url": {
+          "name": "version_weather_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_weather_link_label": {
+          "name": "version_weather_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_weather_link_new_tab": {
+          "name": "version_weather_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_education_options_display_mode": {
+          "name": "version_education_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "version_education_options_enabled": {
+          "name": "version_education_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_education_link_type": {
+          "name": "version_education_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "version_education_link_url": {
+          "name": "version_education_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_education_link_label": {
+          "name": "version_education_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_education_link_new_tab": {
+          "name": "version_education_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_accidents_options_display_mode": {
+          "name": "version_accidents_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "version_accidents_options_enabled": {
+          "name": "version_accidents_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_accidents_link_type": {
+          "name": "version_accidents_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "version_accidents_link_url": {
+          "name": "version_accidents_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_accidents_link_label": {
+          "name": "version_accidents_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_accidents_link_new_tab": {
+          "name": "version_accidents_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_blog_options_display_mode": {
+          "name": "version_blog_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'link'"
+        },
+        "version_blog_options_enabled": {
+          "name": "version_blog_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_blog_link_type": {
+          "name": "version_blog_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "version_blog_link_url": {
+          "name": "version_blog_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_blog_link_label": {
+          "name": "version_blog_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_blog_link_new_tab": {
+          "name": "version_blog_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_events_options_display_mode": {
+          "name": "version_events_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'link'"
+        },
+        "version_events_options_enabled": {
+          "name": "version_events_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_events_link_type": {
+          "name": "version_events_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "version_events_link_url": {
+          "name": "version_events_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_events_link_label": {
+          "name": "version_events_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_events_link_new_tab": {
+          "name": "version_events_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_about_options_display_mode": {
+          "name": "version_about_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "version_about_options_enabled": {
+          "name": "version_about_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_about_link_type": {
+          "name": "version_about_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "version_about_link_url": {
+          "name": "version_about_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_about_link_label": {
+          "name": "version_about_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_about_link_new_tab": {
+          "name": "version_about_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_support_options_display_mode": {
+          "name": "version_support_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'dropdown'"
+        },
+        "version_support_options_enabled": {
+          "name": "version_support_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_support_link_type": {
+          "name": "version_support_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "version_support_link_url": {
+          "name": "version_support_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_support_link_label": {
+          "name": "version_support_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_support_link_new_tab": {
+          "name": "version_support_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_donate_options_display_mode": {
+          "name": "version_donate_options_display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'button'"
+        },
+        "version_donate_options_enabled": {
+          "name": "version_donate_options_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_donate_link_type": {
+          "name": "version_donate_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "version_donate_link_url": {
+          "name": "version_donate_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_donate_link_label": {
+          "name": "version_donate_link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_donate_link_new_tab": {
+          "name": "version_donate_link_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "version_content_hash": {
+          "name": "version_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_parent_idx": {
+          "name": "_navigations_v_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "_navigations_v_version_version_tenant_idx": {
+          "name": "_navigations_v_version_version_tenant_idx",
+          "columns": ["version_tenant_id"],
+          "isUnique": false
+        },
+        "_navigations_v_version_version_updated_at_idx": {
+          "name": "_navigations_v_version_version_updated_at_idx",
+          "columns": ["version_updated_at"],
+          "isUnique": false
+        },
+        "_navigations_v_version_version_created_at_idx": {
+          "name": "_navigations_v_version_version_created_at_idx",
+          "columns": ["version_created_at"],
+          "isUnique": false
+        },
+        "_navigations_v_version_version__status_idx": {
+          "name": "_navigations_v_version_version__status_idx",
+          "columns": ["version__status"],
+          "isUnique": false
+        },
+        "_navigations_v_created_at_idx": {
+          "name": "_navigations_v_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "_navigations_v_updated_at_idx": {
+          "name": "_navigations_v_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "_navigations_v_latest_idx": {
+          "name": "_navigations_v_latest_idx",
+          "columns": ["latest"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_parent_id_navigations_id_fk": {
+          "name": "_navigations_v_parent_id_navigations_id_fk",
+          "tableFrom": "_navigations_v",
+          "tableTo": "navigations",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_navigations_v_version_tenant_id_tenants_id_fk": {
+          "name": "_navigations_v_version_tenant_id_tenants_id_fk",
+          "tableFrom": "_navigations_v",
+          "tableTo": "tenants",
+          "columnsFrom": ["version_tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_navigations_v_rels": {
+      "name": "_navigations_v_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "built_in_pages_id": {
+          "name": "built_in_pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posts_id": {
+          "name": "posts_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "_navigations_v_rels_order_idx": {
+          "name": "_navigations_v_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "_navigations_v_rels_parent_idx": {
+          "name": "_navigations_v_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "_navigations_v_rels_path_idx": {
+          "name": "_navigations_v_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "_navigations_v_rels_pages_id_idx": {
+          "name": "_navigations_v_rels_pages_id_idx",
+          "columns": ["pages_id"],
+          "isUnique": false
+        },
+        "_navigations_v_rels_built_in_pages_id_idx": {
+          "name": "_navigations_v_rels_built_in_pages_id_idx",
+          "columns": ["built_in_pages_id"],
+          "isUnique": false
+        },
+        "_navigations_v_rels_posts_id_idx": {
+          "name": "_navigations_v_rels_posts_id_idx",
+          "columns": ["posts_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_navigations_v_rels_parent_fk": {
+          "name": "_navigations_v_rels_parent_fk",
+          "tableFrom": "_navigations_v_rels",
+          "tableTo": "_navigations_v",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_navigations_v_rels_pages_fk": {
+          "name": "_navigations_v_rels_pages_fk",
+          "tableFrom": "_navigations_v_rels",
+          "tableTo": "pages",
+          "columnsFrom": ["pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_navigations_v_rels_built_in_pages_fk": {
+          "name": "_navigations_v_rels_built_in_pages_fk",
+          "tableFrom": "_navigations_v_rels",
+          "tableTo": "built_in_pages",
+          "columnsFrom": ["built_in_pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_navigations_v_rels_posts_fk": {
+          "name": "_navigations_v_rels_posts_fk",
+          "tableFrom": "_navigations_v_rels",
+          "tableTo": "posts",
+          "columnsFrom": ["posts_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone_label": {
+          "name": "phone_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone_secondary_label": {
+          "name": "phone_secondary_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone_secondary": {
+          "name": "phone_secondary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "footer_form_title": {
+          "name": "footer_form_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "footer_form_subtitle": {
+          "name": "footer_form_subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "footer_form_type": {
+          "name": "footer_form_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "footer_form_html": {
+          "name": "footer_form_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_id": {
+          "name": "logo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon_id": {
+          "name": "icon_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "banner_id": {
+          "name": "banner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usfs_logo_id": {
+          "name": "usfs_logo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "social_media_instagram": {
+          "name": "social_media_instagram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "social_media_facebook": {
+          "name": "social_media_facebook",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "social_media_twitter": {
+          "name": "social_media_twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "social_media_linkedin": {
+          "name": "social_media_linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "social_media_youtube": {
+          "name": "social_media_youtube",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "social_media_hashtag": {
+          "name": "social_media_hashtag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "terms_id": {
+          "name": "terms_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "privacy_id": {
+          "name": "privacy_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "settings_tenant_idx": {
+          "name": "settings_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": true
+        },
+        "settings_logo_idx": {
+          "name": "settings_logo_idx",
+          "columns": ["logo_id"],
+          "isUnique": false
+        },
+        "settings_icon_idx": {
+          "name": "settings_icon_idx",
+          "columns": ["icon_id"],
+          "isUnique": false
+        },
+        "settings_banner_idx": {
+          "name": "settings_banner_idx",
+          "columns": ["banner_id"],
+          "isUnique": false
+        },
+        "settings_usfs_logo_idx": {
+          "name": "settings_usfs_logo_idx",
+          "columns": ["usfs_logo_id"],
+          "isUnique": false
+        },
+        "settings_terms_idx": {
+          "name": "settings_terms_idx",
+          "columns": ["terms_id"],
+          "isUnique": false
+        },
+        "settings_privacy_idx": {
+          "name": "settings_privacy_idx",
+          "columns": ["privacy_id"],
+          "isUnique": false
+        },
+        "settings_updated_at_idx": {
+          "name": "settings_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "settings_created_at_idx": {
+          "name": "settings_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "settings_tenant_id_tenants_id_fk": {
+          "name": "settings_tenant_id_tenants_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "settings_logo_id_media_id_fk": {
+          "name": "settings_logo_id_media_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "media",
+          "columnsFrom": ["logo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "settings_icon_id_media_id_fk": {
+          "name": "settings_icon_id_media_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "media",
+          "columnsFrom": ["icon_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "settings_banner_id_media_id_fk": {
+          "name": "settings_banner_id_media_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "media",
+          "columnsFrom": ["banner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "settings_usfs_logo_id_media_id_fk": {
+          "name": "settings_usfs_logo_id_media_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "media",
+          "columnsFrom": ["usfs_logo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "settings_terms_id_pages_id_fk": {
+          "name": "settings_terms_id_pages_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "pages",
+          "columnsFrom": ["terms_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "settings_privacy_id_pages_id_fk": {
+          "name": "settings_privacy_id_pages_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "pages",
+          "columnsFrom": ["privacy_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings_rels": {
+      "name": "settings_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "forms_id": {
+          "name": "forms_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "settings_rels_order_idx": {
+          "name": "settings_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "settings_rels_parent_idx": {
+          "name": "settings_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "settings_rels_path_idx": {
+          "name": "settings_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "settings_rels_forms_id_idx": {
+          "name": "settings_rels_forms_id_idx",
+          "columns": ["forms_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "settings_rels_parent_fk": {
+          "name": "settings_rels_parent_fk",
+          "tableFrom": "settings_rels",
+          "tableTo": "settings",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "settings_rels_forms_fk": {
+          "name": "settings_rels_forms_fk",
+          "tableFrom": "settings_rels",
+          "tableTo": "forms",
+          "columnsFrom": ["forms_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "redirects": {
+      "name": "redirects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from": {
+          "name": "from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_type": {
+          "name": "to_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'internal'"
+        },
+        "to_new_tab": {
+          "name": "to_new_tab",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_url": {
+          "name": "to_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "redirects_from_idx": {
+          "name": "redirects_from_idx",
+          "columns": ["from"],
+          "isUnique": false
+        },
+        "redirects_tenant_idx": {
+          "name": "redirects_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "redirects_updated_at_idx": {
+          "name": "redirects_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "redirects_created_at_idx": {
+          "name": "redirects_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "redirects_tenant_id_tenants_id_fk": {
+          "name": "redirects_tenant_id_tenants_id_fk",
+          "tableFrom": "redirects",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "redirects_rels": {
+      "name": "redirects_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "built_in_pages_id": {
+          "name": "built_in_pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posts_id": {
+          "name": "posts_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "redirects_rels_order_idx": {
+          "name": "redirects_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "redirects_rels_parent_idx": {
+          "name": "redirects_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "redirects_rels_path_idx": {
+          "name": "redirects_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "redirects_rels_pages_id_idx": {
+          "name": "redirects_rels_pages_id_idx",
+          "columns": ["pages_id"],
+          "isUnique": false
+        },
+        "redirects_rels_built_in_pages_id_idx": {
+          "name": "redirects_rels_built_in_pages_id_idx",
+          "columns": ["built_in_pages_id"],
+          "isUnique": false
+        },
+        "redirects_rels_posts_id_idx": {
+          "name": "redirects_rels_posts_id_idx",
+          "columns": ["posts_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "redirects_rels_parent_fk": {
+          "name": "redirects_rels_parent_fk",
+          "tableFrom": "redirects_rels",
+          "tableTo": "redirects",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "redirects_rels_pages_fk": {
+          "name": "redirects_rels_pages_fk",
+          "tableFrom": "redirects_rels",
+          "tableTo": "pages",
+          "columnsFrom": ["pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "redirects_rels_built_in_pages_fk": {
+          "name": "redirects_rels_built_in_pages_fk",
+          "tableFrom": "redirects_rels",
+          "tableTo": "built_in_pages",
+          "columnsFrom": ["built_in_pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "redirects_rels_posts_fk": {
+          "name": "redirects_rels_posts_fk",
+          "tableFrom": "redirects_rels",
+          "tableTo": "posts",
+          "columnsFrom": ["posts_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms_blocks_checkbox": {
+      "name": "forms_blocks_checkbox",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_checkbox_order_idx": {
+          "name": "forms_blocks_checkbox_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "forms_blocks_checkbox_parent_id_idx": {
+          "name": "forms_blocks_checkbox_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "forms_blocks_checkbox_path_idx": {
+          "name": "forms_blocks_checkbox_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_checkbox_parent_id_fk": {
+          "name": "forms_blocks_checkbox_parent_id_fk",
+          "tableFrom": "forms_blocks_checkbox",
+          "tableTo": "forms",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms_blocks_country": {
+      "name": "forms_blocks_country",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_country_order_idx": {
+          "name": "forms_blocks_country_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "forms_blocks_country_parent_id_idx": {
+          "name": "forms_blocks_country_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "forms_blocks_country_path_idx": {
+          "name": "forms_blocks_country_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_country_parent_id_fk": {
+          "name": "forms_blocks_country_parent_id_fk",
+          "tableFrom": "forms_blocks_country",
+          "tableTo": "forms",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms_blocks_email": {
+      "name": "forms_blocks_email",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_email_order_idx": {
+          "name": "forms_blocks_email_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "forms_blocks_email_parent_id_idx": {
+          "name": "forms_blocks_email_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "forms_blocks_email_path_idx": {
+          "name": "forms_blocks_email_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_email_parent_id_fk": {
+          "name": "forms_blocks_email_parent_id_fk",
+          "tableFrom": "forms_blocks_email",
+          "tableTo": "forms",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms_blocks_message": {
+      "name": "forms_blocks_message",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_message_order_idx": {
+          "name": "forms_blocks_message_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "forms_blocks_message_parent_id_idx": {
+          "name": "forms_blocks_message_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "forms_blocks_message_path_idx": {
+          "name": "forms_blocks_message_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_message_parent_id_fk": {
+          "name": "forms_blocks_message_parent_id_fk",
+          "tableFrom": "forms_blocks_message",
+          "tableTo": "forms",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms_blocks_number": {
+      "name": "forms_blocks_number",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_number_order_idx": {
+          "name": "forms_blocks_number_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "forms_blocks_number_parent_id_idx": {
+          "name": "forms_blocks_number_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "forms_blocks_number_path_idx": {
+          "name": "forms_blocks_number_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_number_parent_id_fk": {
+          "name": "forms_blocks_number_parent_id_fk",
+          "tableFrom": "forms_blocks_number",
+          "tableTo": "forms",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms_blocks_select_options": {
+      "name": "forms_blocks_select_options",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_select_options_order_idx": {
+          "name": "forms_blocks_select_options_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "forms_blocks_select_options_parent_id_idx": {
+          "name": "forms_blocks_select_options_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_select_options_parent_id_fk": {
+          "name": "forms_blocks_select_options_parent_id_fk",
+          "tableFrom": "forms_blocks_select_options",
+          "tableTo": "forms_blocks_select",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms_blocks_select": {
+      "name": "forms_blocks_select",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "placeholder": {
+          "name": "placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_select_order_idx": {
+          "name": "forms_blocks_select_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "forms_blocks_select_parent_id_idx": {
+          "name": "forms_blocks_select_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "forms_blocks_select_path_idx": {
+          "name": "forms_blocks_select_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_select_parent_id_fk": {
+          "name": "forms_blocks_select_parent_id_fk",
+          "tableFrom": "forms_blocks_select",
+          "tableTo": "forms",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms_blocks_state": {
+      "name": "forms_blocks_state",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_state_order_idx": {
+          "name": "forms_blocks_state_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "forms_blocks_state_parent_id_idx": {
+          "name": "forms_blocks_state_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "forms_blocks_state_path_idx": {
+          "name": "forms_blocks_state_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_state_parent_id_fk": {
+          "name": "forms_blocks_state_parent_id_fk",
+          "tableFrom": "forms_blocks_state",
+          "tableTo": "forms",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms_blocks_text": {
+      "name": "forms_blocks_text",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_text_order_idx": {
+          "name": "forms_blocks_text_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "forms_blocks_text_parent_id_idx": {
+          "name": "forms_blocks_text_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "forms_blocks_text_path_idx": {
+          "name": "forms_blocks_text_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_text_parent_id_fk": {
+          "name": "forms_blocks_text_parent_id_fk",
+          "tableFrom": "forms_blocks_text",
+          "tableTo": "forms",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms_blocks_textarea": {
+      "name": "forms_blocks_textarea",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "required": {
+          "name": "required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_textarea_order_idx": {
+          "name": "forms_blocks_textarea_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "forms_blocks_textarea_parent_id_idx": {
+          "name": "forms_blocks_textarea_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        },
+        "forms_blocks_textarea_path_idx": {
+          "name": "forms_blocks_textarea_path_idx",
+          "columns": ["_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_textarea_parent_id_fk": {
+          "name": "forms_blocks_textarea_parent_id_fk",
+          "tableFrom": "forms_blocks_textarea",
+          "tableTo": "forms",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms_emails": {
+      "name": "forms_emails",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_to": {
+          "name": "email_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cc": {
+          "name": "cc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_from": {
+          "name": "email_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'You''ve received a new message.'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "forms_emails_order_idx": {
+          "name": "forms_emails_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "forms_emails_parent_id_idx": {
+          "name": "forms_emails_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_emails_parent_id_fk": {
+          "name": "forms_emails_parent_id_fk",
+          "tableFrom": "forms_emails",
+          "tableTo": "forms",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forms": {
+      "name": "forms",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "submit_button_label": {
+          "name": "submit_button_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmation_type": {
+          "name": "confirmation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'message'"
+        },
+        "confirmation_message": {
+          "name": "confirmation_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "forms_tenant_idx": {
+          "name": "forms_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "forms_updated_at_idx": {
+          "name": "forms_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "forms_created_at_idx": {
+          "name": "forms_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forms_tenant_id_tenants_id_fk": {
+          "name": "forms_tenant_id_tenants_id_fk",
+          "tableFrom": "forms",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "form_submissions_submission_data": {
+      "name": "form_submissions_submission_data",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "form_submissions_submission_data_order_idx": {
+          "name": "form_submissions_submission_data_order_idx",
+          "columns": ["_order"],
+          "isUnique": false
+        },
+        "form_submissions_submission_data_parent_id_idx": {
+          "name": "form_submissions_submission_data_parent_id_idx",
+          "columns": ["_parent_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "form_submissions_submission_data_parent_id_fk": {
+          "name": "form_submissions_submission_data_parent_id_fk",
+          "tableFrom": "form_submissions_submission_data",
+          "tableTo": "form_submissions",
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "form_submissions": {
+      "name": "form_submissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "form_submissions_form_idx": {
+          "name": "form_submissions_form_idx",
+          "columns": ["form_id"],
+          "isUnique": false
+        },
+        "form_submissions_tenant_idx": {
+          "name": "form_submissions_tenant_idx",
+          "columns": ["tenant_id"],
+          "isUnique": false
+        },
+        "form_submissions_updated_at_idx": {
+          "name": "form_submissions_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "form_submissions_created_at_idx": {
+          "name": "form_submissions_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "form_submissions_form_id_forms_id_fk": {
+          "name": "form_submissions_form_id_forms_id_fk",
+          "tableFrom": "form_submissions",
+          "tableTo": "forms",
+          "columnsFrom": ["form_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "form_submissions_tenant_id_tenants_id_fk": {
+          "name": "form_submissions_tenant_id_tenants_id_fk",
+          "tableFrom": "form_submissions",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payload_mcp_api_keys": {
+      "name": "payload_mcp_api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pages_find": {
+          "name": "pages_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "posts_find": {
+          "name": "posts_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "home_pages_find": {
+          "name": "home_pages_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "events_find": {
+          "name": "events_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "media_find": {
+          "name": "media_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "teams_find": {
+          "name": "teams_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "biographies_find": {
+          "name": "biographies_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "sponsors_find": {
+          "name": "sponsors_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "tags_find": {
+          "name": "tags_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "documents_find": {
+          "name": "documents_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "forms_find": {
+          "name": "forms_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "navigations_find": {
+          "name": "navigations_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "settings_find": {
+          "name": "settings_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "tenants_find": {
+          "name": "tenants_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "event_groups_find": {
+          "name": "event_groups_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "event_tags_find": {
+          "name": "event_tags_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "nac_widgets_config_find": {
+          "name": "nac_widgets_config_find",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "enable_a_p_i_key": {
+          "name": "enable_a_p_i_key",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_index": {
+          "name": "api_key_index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "payload_mcp_api_keys_user_idx": {
+          "name": "payload_mcp_api_keys_user_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "payload_mcp_api_keys_updated_at_idx": {
+          "name": "payload_mcp_api_keys_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "payload_mcp_api_keys_created_at_idx": {
+          "name": "payload_mcp_api_keys_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "payload_mcp_api_keys_user_id_users_id_fk": {
+          "name": "payload_mcp_api_keys_user_id_users_id_fk",
+          "tableFrom": "payload_mcp_api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payload_kv": {
+      "name": "payload_kv",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": ["key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": ["global_slug"],
+          "isUnique": false
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "home_pages_id": {
+          "name": "home_pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "built_in_pages_id": {
+          "name": "built_in_pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posts_id": {
+          "name": "posts_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "documents_id": {
+          "name": "documents_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sponsors_id": {
+          "name": "sponsors_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags_id": {
+          "name": "tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events_id": {
+          "name": "events_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_groups_id": {
+          "name": "event_groups_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_tags_id": {
+          "name": "event_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "providers_id": {
+          "name": "providers_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "courses_id": {
+          "name": "courses_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "biographies_id": {
+          "name": "biographies_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teams_id": {
+          "name": "teams_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "roles_id": {
+          "name": "roles_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role_assignments_id": {
+          "name": "role_assignments_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "global_roles_id": {
+          "name": "global_roles_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "global_role_assignments_id": {
+          "name": "global_role_assignments_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenants_id": {
+          "name": "tenants_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "navigations_id": {
+          "name": "navigations_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings_id": {
+          "name": "settings_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirects_id": {
+          "name": "redirects_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forms_id": {
+          "name": "forms_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "form_submissions_id": {
+          "name": "form_submissions_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_mcp_api_keys_id": {
+          "name": "payload_mcp_api_keys_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_home_pages_id_idx": {
+          "name": "payload_locked_documents_rels_home_pages_id_idx",
+          "columns": ["home_pages_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_built_in_pages_id_idx": {
+          "name": "payload_locked_documents_rels_built_in_pages_id_idx",
+          "columns": ["built_in_pages_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_pages_id_idx": {
+          "name": "payload_locked_documents_rels_pages_id_idx",
+          "columns": ["pages_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_posts_id_idx": {
+          "name": "payload_locked_documents_rels_posts_id_idx",
+          "columns": ["posts_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": ["media_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_documents_id_idx": {
+          "name": "payload_locked_documents_rels_documents_id_idx",
+          "columns": ["documents_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_sponsors_id_idx": {
+          "name": "payload_locked_documents_rels_sponsors_id_idx",
+          "columns": ["sponsors_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_tags_id_idx": {
+          "name": "payload_locked_documents_rels_tags_id_idx",
+          "columns": ["tags_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_events_id_idx": {
+          "name": "payload_locked_documents_rels_events_id_idx",
+          "columns": ["events_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_event_groups_id_idx": {
+          "name": "payload_locked_documents_rels_event_groups_id_idx",
+          "columns": ["event_groups_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_event_tags_id_idx": {
+          "name": "payload_locked_documents_rels_event_tags_id_idx",
+          "columns": ["event_tags_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_providers_id_idx": {
+          "name": "payload_locked_documents_rels_providers_id_idx",
+          "columns": ["providers_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_courses_id_idx": {
+          "name": "payload_locked_documents_rels_courses_id_idx",
+          "columns": ["courses_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_biographies_id_idx": {
+          "name": "payload_locked_documents_rels_biographies_id_idx",
+          "columns": ["biographies_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_teams_id_idx": {
+          "name": "payload_locked_documents_rels_teams_id_idx",
+          "columns": ["teams_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": ["users_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_roles_id_idx": {
+          "name": "payload_locked_documents_rels_roles_id_idx",
+          "columns": ["roles_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_role_assignments_id_idx": {
+          "name": "payload_locked_documents_rels_role_assignments_id_idx",
+          "columns": ["role_assignments_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_global_roles_id_idx": {
+          "name": "payload_locked_documents_rels_global_roles_id_idx",
+          "columns": ["global_roles_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_global_role_assignments_id_idx": {
+          "name": "payload_locked_documents_rels_global_role_assignments_id_idx",
+          "columns": ["global_role_assignments_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_tenants_id_idx": {
+          "name": "payload_locked_documents_rels_tenants_id_idx",
+          "columns": ["tenants_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_navigations_id_idx": {
+          "name": "payload_locked_documents_rels_navigations_id_idx",
+          "columns": ["navigations_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_settings_id_idx": {
+          "name": "payload_locked_documents_rels_settings_id_idx",
+          "columns": ["settings_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_redirects_id_idx": {
+          "name": "payload_locked_documents_rels_redirects_id_idx",
+          "columns": ["redirects_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_forms_id_idx": {
+          "name": "payload_locked_documents_rels_forms_id_idx",
+          "columns": ["forms_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_form_submissions_id_idx": {
+          "name": "payload_locked_documents_rels_form_submissions_id_idx",
+          "columns": ["form_submissions_id"],
+          "isUnique": false
+        },
+        "payload_locked_documents_rels_payload_mcp_api_keys_id_idx": {
+          "name": "payload_locked_documents_rels_payload_mcp_api_keys_id_idx",
+          "columns": ["payload_mcp_api_keys_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_home_pages_fk": {
+          "name": "payload_locked_documents_rels_home_pages_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "home_pages",
+          "columnsFrom": ["home_pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_built_in_pages_fk": {
+          "name": "payload_locked_documents_rels_built_in_pages_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "built_in_pages",
+          "columnsFrom": ["built_in_pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_pages_fk": {
+          "name": "payload_locked_documents_rels_pages_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "pages",
+          "columnsFrom": ["pages_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_posts_fk": {
+          "name": "payload_locked_documents_rels_posts_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "posts",
+          "columnsFrom": ["posts_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_documents_fk": {
+          "name": "payload_locked_documents_rels_documents_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "documents",
+          "columnsFrom": ["documents_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_sponsors_fk": {
+          "name": "payload_locked_documents_rels_sponsors_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "sponsors",
+          "columnsFrom": ["sponsors_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_tags_fk": {
+          "name": "payload_locked_documents_rels_tags_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "tags",
+          "columnsFrom": ["tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_events_fk": {
+          "name": "payload_locked_documents_rels_events_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "events",
+          "columnsFrom": ["events_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_event_groups_fk": {
+          "name": "payload_locked_documents_rels_event_groups_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "event_groups",
+          "columnsFrom": ["event_groups_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_event_tags_fk": {
+          "name": "payload_locked_documents_rels_event_tags_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "event_tags",
+          "columnsFrom": ["event_tags_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_providers_fk": {
+          "name": "payload_locked_documents_rels_providers_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "providers",
+          "columnsFrom": ["providers_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_courses_fk": {
+          "name": "payload_locked_documents_rels_courses_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "courses",
+          "columnsFrom": ["courses_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_biographies_fk": {
+          "name": "payload_locked_documents_rels_biographies_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "biographies",
+          "columnsFrom": ["biographies_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_teams_fk": {
+          "name": "payload_locked_documents_rels_teams_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "teams",
+          "columnsFrom": ["teams_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_roles_fk": {
+          "name": "payload_locked_documents_rels_roles_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "roles",
+          "columnsFrom": ["roles_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_role_assignments_fk": {
+          "name": "payload_locked_documents_rels_role_assignments_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "role_assignments",
+          "columnsFrom": ["role_assignments_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_global_roles_fk": {
+          "name": "payload_locked_documents_rels_global_roles_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "global_roles",
+          "columnsFrom": ["global_roles_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_global_role_assignments_fk": {
+          "name": "payload_locked_documents_rels_global_role_assignments_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "global_role_assignments",
+          "columnsFrom": ["global_role_assignments_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_tenants_fk": {
+          "name": "payload_locked_documents_rels_tenants_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "tenants",
+          "columnsFrom": ["tenants_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_navigations_fk": {
+          "name": "payload_locked_documents_rels_navigations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "navigations",
+          "columnsFrom": ["navigations_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_settings_fk": {
+          "name": "payload_locked_documents_rels_settings_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "settings",
+          "columnsFrom": ["settings_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_redirects_fk": {
+          "name": "payload_locked_documents_rels_redirects_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "redirects",
+          "columnsFrom": ["redirects_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_forms_fk": {
+          "name": "payload_locked_documents_rels_forms_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "forms",
+          "columnsFrom": ["forms_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_form_submissions_fk": {
+          "name": "payload_locked_documents_rels_form_submissions_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "form_submissions",
+          "columnsFrom": ["form_submissions_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_payload_mcp_api_keys_fk": {
+          "name": "payload_locked_documents_rels_payload_mcp_api_keys_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_mcp_api_keys",
+          "columnsFrom": ["payload_mcp_api_keys_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payload_preferences": {
+      "name": "payload_preferences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": ["key"],
+          "isUnique": false
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_mcp_api_keys_id": {
+          "name": "payload_mcp_api_keys_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": ["path"],
+          "isUnique": false
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": ["users_id"],
+          "isUnique": false
+        },
+        "payload_preferences_rels_payload_mcp_api_keys_id_idx": {
+          "name": "payload_preferences_rels_payload_mcp_api_keys_id_idx",
+          "columns": ["payload_mcp_api_keys_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_payload_mcp_api_keys_fk": {
+          "name": "payload_preferences_rels_payload_mcp_api_keys_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_mcp_api_keys",
+          "columnsFrom": ["payload_mcp_api_keys_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "payload_migrations": {
+      "name": "payload_migrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "nac_widgets_config": {
+      "name": "nac_widgets_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'https://du6amfiq9m9h7.cloudfront.net/public/v2'"
+        },
+        "dev_mode": {
+          "name": "dev_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "diagnostics": {
+      "name": "diagnostics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "a3_management": {
+      "name": "a3_management",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_manager_role_id": {
+          "name": "provider_manager_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "a3_management_provider_manager_role_idx": {
+          "name": "a3_management_provider_manager_role_idx",
+          "columns": ["provider_manager_role_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "a3_management_provider_manager_role_id_global_roles_id_fk": {
+          "name": "a3_management_provider_manager_role_id_global_roles_id_fk",
+          "tableFrom": "a3_management",
+          "tableTo": "global_roles",
+          "columnsFrom": ["provider_manager_role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  },
+  "id": "724a8da7-a2ff-4afa-9b2a-78ed8d2afdc9",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/src/migrations/20260421_181446_add_tenant_provisioning_field.ts
+++ b/src/migrations/20260421_181446_add_tenant_provisioning_field.ts
@@ -1,0 +1,30 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-sqlite'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  // status defaults to 'not_started' so existing rows satisfy NOT NULL
+  await db.run(
+    sql`ALTER TABLE \`tenants\` ADD \`provisioning_status\` text DEFAULT 'not_started' NOT NULL;`,
+  )
+  // lastRunAt is nullable — brand-new tenants have no run to record yet.
+  await db.run(sql`ALTER TABLE \`tenants\` ADD \`provisioning_last_run_at\` text;`)
+  await db.run(sql`ALTER TABLE \`tenants\` ADD \`provisioning_failed\` text;`)
+
+  // Only backfill tenants that have evidence of a successful provision —
+  // a settings row, a home page, AND a navigation. Half-provisioned tenants
+  // stay at the default 'not_started' so the checklist surfaces a Rerun
+  // affordance instead of claiming they're done.
+  await db.run(sql`
+    UPDATE \`tenants\`
+    SET \`provisioning_status\` = 'complete',
+        \`provisioning_last_run_at\` = \`created_at\`
+    WHERE EXISTS (SELECT 1 FROM \`settings\` WHERE \`settings\`.\`tenant_id\` = \`tenants\`.\`id\`)
+      AND EXISTS (SELECT 1 FROM \`home_pages\` WHERE \`home_pages\`.\`tenant_id\` = \`tenants\`.\`id\`)
+      AND EXISTS (SELECT 1 FROM \`navigations\` WHERE \`navigations\`.\`tenant_id\` = \`tenants\`.\`id\`)
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.run(sql`ALTER TABLE \`tenants\` DROP COLUMN \`provisioning_status\`;`)
+  await db.run(sql`ALTER TABLE \`tenants\` DROP COLUMN \`provisioning_last_run_at\`;`)
+  await db.run(sql`ALTER TABLE \`tenants\` DROP COLUMN \`provisioning_failed\`;`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -52,6 +52,7 @@ import * as migration_20260414_030934_backfill_document_references from './20260
 import * as migration_20260417_202409_add_dev_mode from './20260417_202409_add_dev_mode'
 import * as migration_20260418_120000_convert_auto_nav_items from './20260418_120000_convert_auto_nav_items'
 import * as migration_20260418_120100_backfill_nav_builtin_pages from './20260418_120100_backfill_nav_builtin_pages'
+import * as migration_20260421_181446_add_tenant_provisioning_field from './20260421_181446_add_tenant_provisioning_field'
 
 export const migrations = [
   {
@@ -323,5 +324,10 @@ export const migrations = [
     up: migration_20260418_120100_backfill_nav_builtin_pages.up,
     down: migration_20260418_120100_backfill_nav_builtin_pages.down,
     name: '20260418_120100_backfill_nav_builtin_pages',
+  },
+  {
+    up: migration_20260421_181446_add_tenant_provisioning_field.up,
+    down: migration_20260421_181446_add_tenant_provisioning_field.down,
+    name: '20260421_181446_add_tenant_provisioning_field',
   },
 ]

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -367,7 +367,7 @@ export interface Tenant {
   name: string;
   contentHash?: string | null;
   provisioning: {
-    status: 'not_started' | 'in_progress' | 'complete' | 'partial';
+    status: 'not_started' | 'in_progress' | 'complete' | 'partial' | 'manual';
     lastRunAt?: string | null;
     failed?: {
       pages?: {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -366,6 +366,19 @@ export interface Tenant {
     | 'wcmac';
   name: string;
   contentHash?: string | null;
+  provisioning: {
+    status: 'not_started' | 'in_progress' | 'complete' | 'partial';
+    lastRunAt?: string | null;
+    failed?: {
+      pages?: {
+        [k: string]: string;
+      };
+      homePage?: string;
+      navigation?: string;
+      websiteSettings?: string;
+      timedOut?: string;
+    };
+  };
   updatedAt: string;
   createdAt: string;
 }
@@ -3966,6 +3979,13 @@ export interface TenantsSelect<T extends boolean = true> {
   slug?: T;
   name?: T;
   contentHash?: T;
+  provisioning?:
+    | T
+    | {
+        status?: T;
+        lastRunAt?: T;
+        failed?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
## Description

Improve tenant provisioning to auto-detect forecast zones, conditionally include Mountain Weather, and track the provisioning lifecycle directly on the tenant record so the admin UI always has a single source of truth.

## Related Issues

Fixes #999
Fixes #1000

## Key Changes

### Provisioning updates
- **Static page lists as source of truth** — `BUILT_IN_PAGES` and `PAGES_TO_PROVISION` are hardcoded in `provisionTenant.ts` rather than sourced from a template tenant. New built-in/blank pages get added here explicitly, avoiding drift from whatever DVAC happens to have configured.
- **Provisioning lifecycle tracked on tenant** — New `provisioning` group (`status`, `lastRunAt`, `failed`) on the tenants collection. Status moves `not_started → in_progress → complete | partial | manual`. Writing `in_progress` upfront prevents reloads mid-run from triggering a second provision. `failed` captures per-step error messages (`websiteSettings`, `homePage`, `navigation`, `pages: { [title]: error }`) so the UI can show exactly which pages didn't make it.
- **`manual` state for theme/OG items** — `checkProvisioningStatusAction` flips `complete` ↔ `manual` in the DB based on whether the tenant slug appears in `colors.css` and `centerColorMap`. Surfaces the "needs manual code edit" state distinctly from a provisioning failure.
- **Crashed-run recovery** — if a tenant has been `in_progress` for longer than 5 minutes, `checkProvisioningStatusAction` surfaces it as `partial` with a `timedOut` failure so the checklist shows a Rerun button instead of an infinite spinner.
- **Per-tenant DB lock** — `provision()` acquires the `in_progress` state via a conditional update that only succeeds if the tenant isn't already running (or the active run is past the 5-minute stale cutoff). Prevents two admins clicking Rerun simultaneously from racing through provisioning.
- **StrictMode-safe auto-provision** — the mount-time auto-provision is keyed on `tenantId` via a `useRef` so React StrictMode's double-mount (or any remount) doesn't fire two runs.
- **Super-admin auth on server actions** — `checkProvisioningStatusAction`, `runProvisionAction`, and `markProvisioningCompleteAction` all require super-admin. Previously any authenticated Payload admin could invoke them on any tenant.
- **Migration schema-drift fix** — `20260418_120100_backfill_nav_builtin_pages` now reads tenants via raw SQL (`SELECT id, slug FROM tenants`) instead of `payload.find`. Avoids SQLite's double-quoted-identifier gotcha where Drizzle's SELECT of a column added by a later migration silently returns the column name as a string literal and chokes the JSON parser.


### AFP dependent 
- **Zone-aware forecast provisioning** — `provisionTenant.ts` calls `getActiveForecastZones()` during provisioning. Single-zone centers get one "Avalanche Forecast" page; multi-zone centers get "All Forecasts" + per-zone pages sorted by rank. Falls back to a default "All Forecasts" page if AFP is unavailable.
- **Mountain Weather from NAC** — Mountain Weather (`/weather/forecast`) is conditionally included per-tenant based on `platforms.weather` from NAC.
- **Zone-aware navigation** — Provisioning populates the forecasts tab (single zone: direct link; multi-zone: "All Forecasts" + per-zone items) and the observations tab with built-in page links. Also fixes missing `blog` and `events` tab data that was causing nav creation to silently fail.
- **Shared `resolveBuiltInPages`** — The AFP zone query + Mountain Weather resolution is factored out so both `provisionTenant.ts` and the onboarding status check use the same logic.


### UI updates
- **Onboarding checklist UI** — Auto-provisions brand-new tenants on mount, shows placeholder items with spinners during `in_progress`, collapses to a "Complete" / "Complete manual actions" / "Failed" header afterward with per-step failure detail and a Rerun button. An inline link to the tenant's Website Settings sets the tenant cookie via `useTenantSelection` before navigating, so the admin doesn't redirect back to the previously selected tenant. Create-view is handled (no tenant yet → no spinner, placeholder items only).
- **List view pill** — New `OnboardingStatusCell` renders a Complete / Manual actions / Partial / In progress / Not started pill on the tenants list so provisioning state is visible without opening each tenant.


## How to test

1. `pnpm migrate` to apply the new provisioning columns, then `pnpm seed`
2. At `/admin/collections/tenants`, verify the new list-view pill shows "Complete" for all seeded tenants
3. Create a new tenant
    - Checklist shows placeholder items with spinners while provisioning runs
    - Header flips to "Complete" (or "Failed" with per-step detail) when done
    - For multi-zone `btac` (4 zones): "All Forecasts" + 4 zone pages are created as built-in pages
    - For single-zone `msac`: a single "Avalanche Forecast" built-in page is created
4. Verify Mountain Weather is only created for centers with weather forecasts in NAC
5. Reload the tenant page mid-provision — the UI shows "in progress" state and does **not** retrigger a second provisioning run
6. Simulate a partial failure (e.g. direct DB write to `provisioning_status='partial'` with a `provisioning_failed` JSON payload) and verify the checklist lists the failed pages and shows a Rerun button
7. `pnpm test`

## Screenshots / Demo video

| &nbsp; | &nbsp; |
|--------|--------|
| <img width="461" height="433" alt="Screenshot 2026-04-22 at 13 12 52" src="https://github.com/user-attachments/assets/8b69bc52-4d8a-4cf4-962a-124e6449be99" /> | <img width="475" height="597" alt="Screenshot 2026-04-22 at 09 57 19" src="https://github.com/user-attachments/assets/5066fbd3-519f-49ec-a17c-ad685f9ea4dd" /> | 
| <img width="472" height="473" alt="Screenshot 2026-04-22 at 13 09 04" src="https://github.com/user-attachments/assets/d17a0876-075d-45e1-afef-8b63d609b04b" /> | <img width="462" height="406" alt="Screenshot 2026-04-22 at 13 12 32" src="https://github.com/user-attachments/assets/d853892a-2332-4e17-a9d9-d9b24ddce4b7" /> |


## Migration Explanation

Adds three columns to `tenants`:

- `provisioning_status` (text, NOT NULL, default `'not_started'`)
- `provisioning_last_run_at` (text, nullable)
- `provisioning_failed` (text, JSON)

Existing rows are conditionally backfilled to `complete` only if they have matching `settings`, `home_pages`, and `navigations` rows (with `lastRunAt = created_at`). Half-provisioned tenants stay at `not_started` so the checklist shows Rerun.



## Future enhancements / Questions

- The onboarding status check calls AFP on every checklist load — could cache the zone count if this becomes a performance concern (likely not).