### PR TITLE
Fix events revalidation bugs: wrong block mappings and missing relationship queries

### DIFF
--- a/src/collections/Events/hooks/populateBlocksInContent.ts
+++ b/src/collections/Events/hooks/populateBlocksInContent.ts
@@ -14,8 +14,8 @@ export const populateBlocksInContent: CollectionBeforeChangeHook<Event> = async 
 
   if (data.content?.root?.children) {
     try {
-      const { postsBlockMappings } = await getBlocksFromConfig()
-      blocksInContent = walkLexicalNodes(data.content.root.children, postsBlockMappings)
+      const { eventsBlockMappings } = await getBlocksFromConfig()
+      blocksInContent = walkLexicalNodes(data.content.root.children, eventsBlockMappings)
     } catch (error) {
       req.payload.logger.warn(`Error extracting block references: ${error}`)
       blocksInContent = []

--- a/src/collections/Events/index.ts
+++ b/src/collections/Events/index.ts
@@ -34,7 +34,7 @@ import {
 } from '@payloadcms/richtext-lexical'
 import { CollectionConfig, DateField, ValidateOptions } from 'payload'
 import { date } from 'payload/shared'
-import { populateBlocksInContent } from '../Posts/hooks/populateBlocksInContent'
+import { populateBlocksInContent } from './hooks/populateBlocksInContent'
 import { revalidateEvent, revalidateEventDelete } from './hooks/revalidateEvent'
 
 export const Events: CollectionConfig = {

--- a/src/utilities/findDocumentsWithBlockReferences.ts
+++ b/src/utilities/findDocumentsWithBlockReferences.ts
@@ -147,8 +147,9 @@ export async function findDocumentsWithBlockReferences(
           results.push(...pagesWithBlocks)
         }
       } catch (error) {
+        const cause = error instanceof Error && error.cause ? ` | Cause: ${error.cause}` : ''
         payload.logger.warn(
-          `Error querying pages for ${reference.collection} reference ${reference.id} in field ${mapping.fieldName}: ${error}`,
+          `Error querying pages for ${reference.collection} reference ${reference.id} in field ${mapping.fieldName}: ${error}${cause}`,
         )
       }
     }
@@ -185,8 +186,9 @@ export async function findDocumentsWithBlockReferences(
 
       results.push(...postsWithBlocks)
     } catch (error) {
+      const cause = error instanceof Error && error.cause ? ` | Cause: ${error.cause}` : ''
       payload.logger.warn(
-        `Error querying posts for ${reference.collection} reference ${reference.id}: ${error}`,
+        `Error querying posts for ${reference.collection} reference ${reference.id}: ${error}${cause}`,
       )
     }
   }
@@ -254,8 +256,9 @@ export async function findDocumentsWithBlockReferences(
           results.push(...homePagesWithBlocks)
         }
       } catch (error) {
+        const cause = error instanceof Error && error.cause ? ` | Cause: ${error.cause}` : ''
         payload.logger.warn(
-          `Error querying homePages for ${reference.collection} reference ${reference.id}: ${error}`,
+          `Error querying homePages for ${reference.collection} reference ${reference.id}: ${error}${cause}`,
         )
       }
     }
@@ -293,8 +296,9 @@ export async function findDocumentsWithBlockReferences(
 
       results.push(...homePagesWithBlocks)
     } catch (error) {
+      const cause = error instanceof Error && error.cause ? ` | Cause: ${error.cause}` : ''
       payload.logger.warn(
-        `Error querying homePages.blocksInHighlightedContent for ${reference.collection} reference ${reference.id}: ${error}`,
+        `Error querying homePages.blocksInHighlightedContent for ${reference.collection} reference ${reference.id}: ${error}${cause}`,
       )
     }
   }
@@ -330,8 +334,9 @@ export async function findDocumentsWithBlockReferences(
 
       results.push(...eventsWithBlocks)
     } catch (error) {
+      const cause = error instanceof Error && error.cause ? ` | Cause: ${error.cause}` : ''
       payload.logger.warn(
-        `Error querying events for ${reference.collection} reference ${reference.id}: ${error}`,
+        `Error querying events for ${reference.collection} reference ${reference.id}: ${error}${cause}`,
       )
     }
   }

--- a/src/utilities/findDocumentsWithRelationshipReferences.ts
+++ b/src/utilities/findDocumentsWithRelationshipReferences.ts
@@ -13,8 +13,12 @@ export async function findDocumentsWithRelationshipReferences(
   const payload = await getPayload({ config: configPromise })
   const results: DocumentForRevalidation[] = []
 
-  const { pagesRelationshipMappings, postsRelationshipMappings, homePagesRelationshipMappings } =
-    await getRelationshipsFromConfig()
+  const {
+    pagesRelationshipMappings,
+    postsRelationshipMappings,
+    homePagesRelationshipMappings,
+    eventsRelationshipMappings,
+  } = await getRelationshipsFromConfig()
 
   const pagesMappings = pagesRelationshipMappings[reference.collection]
 
@@ -117,6 +121,44 @@ export async function findDocumentsWithRelationshipReferences(
       } catch (error) {
         payload.logger.warn(
           `Error querying homePages for ${reference.collection} reference ${reference.id} at ${mapping.fieldPath}: ${error}`,
+        )
+      }
+    }
+  }
+
+  const eventsMappings = eventsRelationshipMappings[reference.collection]
+
+  if (eventsMappings) {
+    for (const mapping of eventsMappings) {
+      try {
+        const eventsWithRelationsRes = await payload.find({
+          collection: 'events',
+          where: {
+            and: [
+              {
+                _status: { equals: 'published' },
+              },
+              {
+                [mapping.fieldPath]: { equals: reference.id },
+              },
+            ],
+          },
+          depth: 1,
+        })
+
+        const eventsWithRelations: DocumentForRevalidation[] = eventsWithRelationsRes.docs.map(
+          (doc) => ({
+            collection: 'events',
+            id: doc.id,
+            slug: doc.slug,
+            tenant: doc.tenant,
+          }),
+        )
+
+        results.push(...eventsWithRelations)
+      } catch (error) {
+        payload.logger.warn(
+          `Error querying events for ${reference.collection} reference ${reference.id} at ${mapping.fieldPath}: ${error}`,
         )
       }
     }

--- a/src/utilities/getBlocksFromConfig.ts
+++ b/src/utilities/getBlocksFromConfig.ts
@@ -35,7 +35,7 @@ export async function getBlocksFromConfig() {
   // Find blocks used in Events collection (in richText lexical editor)
   const eventsCollection = config.collections?.find((collection) => collection.slug === 'events')
   const eventsBlocks = extractBlocksFromRichTextBlocksFeature(eventsCollection?.fields || [])
-  const eventsBlockMappings = extractBlockMappings(postsBlocks)
+  const eventsBlockMappings = extractBlockMappings(eventsBlocks)
 
   return {
     pagesBlocks,

--- a/src/utilities/getRelationshipsFromConfig.ts
+++ b/src/utilities/getRelationshipsFromConfig.ts
@@ -25,10 +25,15 @@ export async function getRelationshipsFromConfig() {
     homePagesCollection?.fields || [],
   )
 
+  // Find relationship fields used in Events collection
+  const eventsCollection = config.collections?.find((collection) => collection.slug === 'events')
+  const eventsRelationshipMappings = extractRelationshipMappings(eventsCollection?.fields || [])
+
   return {
     pagesRelationshipMappings,
     postsRelationshipMappings,
     homePagesRelationshipMappings,
+    eventsRelationshipMappings,
   }
 }
 


### PR DESCRIPTION
## Description

Fixes two bugs in the revalidation system where the events collection was not being properly tracked:

1. `eventsBlockMappings` was incorrectly using `postsBlocks` instead of `eventsBlocks`
2. The events collection was completely omitted from relationship reference tracking and queries in `findDocumentsWithRelationshipReferences`

## Related Issues

Discovered during #455 work. Using a phased approach for the new revalidation system so fixing this while we're still on the old system. 

## Key Changes

- **`src/utilities/getBlocksFromConfig.ts`** — Fix `eventsBlockMappings` to use `eventsBlocks` instead of `postsBlocks`
- **`src/utilities/getRelationshipsFromConfig.ts`** — Add events collection to relationship config extraction
- **`src/utilities/revalidation/findDocumentsWithRelationshipReferences.ts`** — Add events collection to relationship reference queries with proper block and relationship field handling

## How to test

1. Create an event that references another document (e.g., a page or post via a link block)
2. Edit the referenced document
3. Verify the event page is revalidated (appears in revalidation logs and new related content appears)

## Screenshots / Demo video

https://www.loom.com/share/fa0a27d9240f4e42ba7c68568213bfae

## Migration Explanation

No migration needed.

## Future enhancements / Questions

This revalidation system will be replaced but fixing for now. 