### PR TITLE
Skip docs with invalid data in documentReferences backfill

### DIFF
--- a/src/migrations/20260414_030934_backfill_document_references.ts
+++ b/src/migrations/20260414_030934_backfill_document_references.ts
@@ -6,6 +6,11 @@ const ROUTABLE_COLLECTIONS = ['pages', 'posts', 'homePages', 'events'] as const
  * Backfill the documentReferences field for all existing routable documents.
  * The populateDocumentReferences beforeChange hook only fires on save, so
  * existing documents need a no-op update to trigger it.
+ *
+ * If a document has pre-existing invalid data (e.g. a blank required field),
+ * the update throws a validation error. Log and skip those documents so the
+ * migration doesn't block the entire deploy on one bad record; the skipped
+ * doc's documentReferences will populate naturally on its next save.
  */
 export async function up({ payload }: MigrateUpArgs): Promise<void> {
   for (const collection of ROUTABLE_COLLECTIONS) {
@@ -15,17 +20,29 @@ export async function up({ payload }: MigrateUpArgs): Promise<void> {
       depth: 0,
     })
 
+    let succeeded = 0
+    let skipped = 0
+
     for (const doc of docs.docs) {
-      await payload.update({
-        collection,
-        id: doc.id,
-        data: {},
-        context: { disableRevalidate: true },
-      })
+      try {
+        await payload.update({
+          collection,
+          id: doc.id,
+          data: {},
+          context: { disableRevalidate: true },
+        })
+        succeeded++
+      } catch (err) {
+        skipped++
+        payload.logger.warn(
+          { err, collection, id: doc.id },
+          `Skipping ${collection} id=${doc.id} during documentReferences backfill — existing data fails validation. documentReferences will populate on next save.`,
+        )
+      }
     }
 
     payload.logger.info(
-      `Backfilled documentReferences for ${docs.docs.length} ${collection} documents`,
+      `Backfilled documentReferences for ${succeeded} ${collection} documents (${skipped} skipped)`,
     )
   }
 }


### PR DESCRIPTION
## Description

The `20260414_030934_backfill_document_references` migration re-saves every routable document (pages, posts, homePages, events) to trigger the `populateDocumentReferences` hook. When a doc has pre-existing invalid data (e.g. a blank required slug), the re-save throws a validation error and aborts the entire migration, blocking deploys.

This patch wraps each per-doc update in try/catch: validation failures are logged as warnings and the loop continues. The migration completes, the deploy proceeds, and skipped docs keep their data as-is — their `documentReferences` will populate naturally on their next save in the admin.

## Related Issues

Unblocks deploys on dev / any preview where a routable doc has invalid data (observed on `payloadcms-dev-nwac` with page id=158 having a blank slug). See failing workflows https://github.com/NWACus/web/actions/workflows/development.yaml

## Key Changes

- **`20260414_030934_backfill_document_references.ts`** — per-doc try/catch. Tracks succeeded vs. skipped counts in the final log line.

## How to test

- Manually create a doc with an invalid state (e.g. blank slug via direct SQL).
- Run `pnpm migrate`.
- Verify the migration completes, logs a warning for the invalid doc, and continues.

## Screenshots / Demo video

N/A — migration-only change.

## Migration Explanation

The migration file itself is modified (not a new migration). For DBs where the migration previously failed, re-running will now succeed; skipped docs are logged. For DBs that already ran the original version successfully, no change in behavior.

## Future enhancements / Questions

- If the set of skipped docs grows, we may want a follow-up data repair (e.g., a new migration that sets fallback slugs like `page-<id>` on blank-slug rows so admins can edit them again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)