### PR TITLE
Fix CI: debug Vercel env pull, align Node version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
         run: pnpm ii
@@ -49,7 +49,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
         run: pnpm ii
@@ -82,7 +82,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
         run: pnpm ii
@@ -127,7 +127,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
         run: pnpm ii
@@ -153,7 +153,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
         run: pnpm ii
@@ -192,7 +192,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
         run: pnpm ii
@@ -231,7 +231,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
         run: pnpm ii

--- a/.github/workflows/dependabot-auto-format.yml
+++ b/.github/workflows/dependabot-auto-format.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'pnpm'
 
       - name: 📦 Install dependencies

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -75,6 +75,12 @@ jobs:
         run: echo -n "${{ steps.generate-sync-password.outputs.password }}" | vercel env add NON_PROD_SYNC_PASSWORD preview main --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Pull Vercel Environment Variables into .env file
         run: vercel env pull --yes --environment=preview --git-branch=main --token=${{ secrets.VERCEL_TOKEN }} .env
+      - name: Debug Vercel env pull
+        run: |
+          echo "Vercel CLI version: $(vercel --version)"
+          echo "NON_PROD_SYNC_PASSWORD present in .env: $(grep -c '^NON_PROD_SYNC_PASSWORD=' .env || echo 0)"
+          echo ".env var names (values redacted):"
+          grep -oE '^[A-Z_][A-Z0-9_]*=' .env | sort -u
       - name: Run database migrations
         run: pnpm migrate
         env:

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
         run: pnpm ii

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
         run: pnpm ii

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
         run: pnpm ii

--- a/.github/workflows/sync-prod-to-dev.yml
+++ b/.github/workflows/sync-prod-to-dev.yml
@@ -52,7 +52,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
         run: pnpm ii


### PR DESCRIPTION
## Description

Two CI-focused fixes bundled into one PR.

1. **Debug what `vercel env pull` actually delivers.** The `development` workflow's sanitize step has been failing since #1047 unblocked migrations. The sanitize script logs `NON_PROD_SYNC_PASSWORD not set, using generated password` and then fails the strong-password validator on the UUID fallback. This used to work (PR #968's run on 2026-04-17 showed `Using NON_PROD_SYNC_PASSWORD from environment`) — nothing in the repo has changed in the env-loading chain since, which points at a Vercel CLI or server-side behavior change. Adds a debug step after `vercel env pull` that logs the Vercel CLI version and the variable *names* present in `.env` (values redacted).

2. **Align CI Node version with `package.json` engines.** Commit `11ed44db` (2026-03-02) tightened `engines.node` from `"22.x || 24.x"` to `"24.x"`, but the workflows were left on 22.x. Every pnpm command in CI has been printing `WARN Unsupported engine: wanted: {"node":"24.x"} (current: {"node":"v22.22.2"})` since. Bumps all workflows to `node-version: 24.x`.

## Related Issues

N/A — CI hygiene / investigation.

## Key Changes

- `.github/workflows/development.yaml` — new "Debug Vercel env pull" step logs CLI version, whether `NON_PROD_SYNC_PASSWORD` is in `.env`, and the list of var names delivered by pull.
- `.github/workflows/{ci,development,preview,production,sync-prod-to-dev,dependabot-auto-format}` — `node-version: 22.x` → `24.x` in all setup-node steps.

## How to test

- [ ] Merge and watch the next `development` workflow run on `main`. The "Debug Vercel env pull" step should print the Vercel CLI version and whether `NON_PROD_SYNC_PASSWORD` is present in `.env`. That tells us which layer stopped delivering the variable.
- [ ] Confirm `Unsupported engine` warnings no longer appear in workflow logs.
- [ ] First run on Node 24 will miss pnpm cache (keyed on node version) so expect a one-time slower build while native deps (`sharp`, `@libsql/client`, `better-sqlite3`) recompile.

## Screenshots / Demo video

N/A — workflow-only changes.

## Migration Explanation

No DB migrations.

## Future enhancements / Questions

- Once the debug step tells us where the env var is getting dropped, pick a follow-up: either patch the Vercel pipeline (e.g., `--sensitive` flag, CLI version pin) or stop roundtripping `NON_PROD_SYNC_PASSWORD` through Vercel entirely since no runtime code consumes it.
- The debug step is a temporary diagnostic. Should be removed once root cause is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)