### PR TITLE
Add --no-sensitive to vercel env add calls for non-secret vars

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Update database URI in Vercel
-        run: echo -n "${{ steps.connection.outputs.uri }}" | vercel env add DATABASE_URI preview main --force --token=${{ secrets.VERCEL_TOKEN }}
+        run: echo -n "${{ steps.connection.outputs.uri }}" | vercel env add DATABASE_URI preview main --no-sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Update database token in Vercel
         run: echo -n "${{ steps.connection.outputs.token }}" | vercel env add DATABASE_AUTH_TOKEN preview main --sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Update bootstrap password in Vercel
@@ -72,7 +72,7 @@ jobs:
           echo "::add-mask::$generated_password"
           echo "password=$generated_password" >> "$GITHUB_OUTPUT"
       - name: Update non-prod sync password in Vercel
-        run: echo -n "${{ steps.generate-sync-password.outputs.password }}" | vercel env add NON_PROD_SYNC_PASSWORD preview main --force --token=${{ secrets.VERCEL_TOKEN }}
+        run: echo -n "${{ steps.generate-sync-password.outputs.password }}" | vercel env add NON_PROD_SYNC_PASSWORD preview main --no-sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Pull Vercel Environment Variables into .env file
         run: vercel env pull --yes --environment=preview --git-branch=main --token=${{ secrets.VERCEL_TOKEN }} .env
       - name: Debug Vercel env pull

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -75,12 +75,6 @@ jobs:
         run: echo -n "${{ steps.generate-sync-password.outputs.password }}" | vercel env add NON_PROD_SYNC_PASSWORD preview main --no-sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Pull Vercel Environment Variables into .env file
         run: vercel env pull --yes --environment=preview --git-branch=main --token=${{ secrets.VERCEL_TOKEN }} .env
-      - name: Debug Vercel env pull
-        run: |
-          echo "Vercel CLI version: $(vercel --version)"
-          echo "NON_PROD_SYNC_PASSWORD present in .env: $(grep -c '^NON_PROD_SYNC_PASSWORD=' .env || echo 0)"
-          echo ".env var names (values redacted):"
-          grep -oE '^[A-Z_][A-Z0-9_]*=' .env | sort -u
       - name: Run database migrations
         run: pnpm migrate
         env:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -92,13 +92,13 @@ jobs:
           echo "Preview alias: $PREVIEW_ALIAS"
           echo "Wildcard preview alias: $WILDCARD_PREVIEW_ALIAS"
       - name: Update database URI in Vercel
-        run: echo -n "${{ steps.connection.outputs.uri }}" | vercel env add DATABASE_URI preview ${{ github.head_ref }} --force --token=${{ secrets.VERCEL_TOKEN }}
+        run: echo -n "${{ steps.connection.outputs.uri }}" | vercel env add DATABASE_URI preview ${{ github.head_ref }} --no-sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Update database token in Vercel
         run: echo -n "${{ steps.connection.outputs.token }}" | vercel env add DATABASE_AUTH_TOKEN preview ${{ github.head_ref }} --sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Update bootstrap password in Vercel
         run: echo -n "${{ secrets.PAYLOAD_SEED_PASSWORD }}" | vercel env add PAYLOAD_SEED_PASSWORD preview ${{ github.head_ref }} --sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Update server domain in Vercel
-        run: echo -n "${{ steps.domains.outputs.preview_alias }}" | vercel env add NEXT_PUBLIC_ROOT_DOMAIN preview ${{ github.head_ref }} --force --token=${{ secrets.VERCEL_TOKEN }}
+        run: echo -n "${{ steps.domains.outputs.preview_alias }}" | vercel env add NEXT_PUBLIC_ROOT_DOMAIN preview ${{ github.head_ref }} --no-sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Pull Vercel Environment Variables into .env file
         run: vercel env pull --yes --environment=preview --git-branch="${{ github.head_ref }}" --token=${{ secrets.VERCEL_TOKEN }} .env
       - name: Run database migrations

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Update database URI in Vercel
-        run: echo -n "${{ steps.connection.outputs.uri }}" | vercel env add DATABASE_URI production --force --token=${{ secrets.VERCEL_TOKEN }}
+        run: echo -n "${{ steps.connection.outputs.uri }}" | vercel env add DATABASE_URI production --no-sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Update database token in Vercel
         run: echo -n "${{ steps.connection.outputs.token }}" | vercel env add DATABASE_AUTH_TOKEN production --sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Pull Vercel Environment Variables into .env file

--- a/.github/workflows/sync-prod-to-dev.yml
+++ b/.github/workflows/sync-prod-to-dev.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Update database URI in Vercel
-        run: echo -n "${{ steps.connection.outputs.uri }}" | vercel env add DATABASE_URI preview main --force --token=${{ secrets.VERCEL_TOKEN }}
+        run: echo -n "${{ steps.connection.outputs.uri }}" | vercel env add DATABASE_URI preview main --no-sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Update database token in Vercel
         run: echo -n "${{ steps.connection.outputs.token }}" | vercel env add DATABASE_AUTH_TOKEN preview main --sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Generate random non-prod sync password
@@ -74,7 +74,7 @@ jobs:
           echo "::add-mask::$generated_password"
           echo "password=$generated_password" >> "$GITHUB_OUTPUT"
       - name: Update non-prod sync password in Vercel
-        run: echo -n "${{ steps.generate-sync-password.outputs.password }}" | vercel env add NON_PROD_SYNC_PASSWORD preview main --force --token=${{ secrets.VERCEL_TOKEN }}
+        run: echo -n "${{ steps.generate-sync-password.outputs.password }}" | vercel env add NON_PROD_SYNC_PASSWORD preview main --no-sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Pull Vercel Environment Variables into .env file
         run: vercel env pull --yes --environment=preview --git-branch=main --token=${{ secrets.VERCEL_TOKEN }} .env
       - name: Run database migrations


### PR DESCRIPTION
## Description

Vercel recently started auto-classifying env vars as Sensitive via server-side heuristics (e.g. names containing `PASSWORD`), which redacts the value from `vercel env pull` even when the project's "Sensitive by default" toggle is off. This broke the sanitize step on the `development` workflow: `NON_PROD_SYNC_PASSWORD` came down with a blank value, so `sanitize-db.ts` tripped password validation.

Explicitly pass `--no-sensitive` to the `vercel env add` calls for variables that CI steps or the deployed app need to read back. Vars that already have `--sensitive` keep it.

## Related Issues

N/A — infrastructure fix for the `development` workflow's `Sanitize database` step failures (e.g. https://github.com/NWACus/web/actions/runs/24690930683).

## Key Changes

Added `--no-sensitive` to these `vercel env add` calls:

- **development.yaml** — `DATABASE_URI`, `NON_PROD_SYNC_PASSWORD`
- **sync-prod-to-dev.yml** — `DATABASE_URI`, `NON_PROD_SYNC_PASSWORD`
- **preview.yaml** — `DATABASE_URI`, `NEXT_PUBLIC_ROOT_DOMAIN`
- **production.yaml** — `DATABASE_URI`

Existing `--sensitive` flags on `DATABASE_AUTH_TOKEN` and `PAYLOAD_SEED_PASSWORD` are unchanged.

## How to test

- [ ] Merge and watch the next `development` workflow run on `main`. The `Sanitize database` step should succeed (`Using NON_PROD_SYNC_PASSWORD from environment` → `Database sanitization completed successfully!`).
- [ ] If the `Sanitize` step still fails: the existing sensitive entry in Vercel may not have been demoted by `--force --no-sensitive`. Delete the entry manually in the Vercel dashboard and re-run the workflow.
- [ ] Confirm the `NON_PROD_SYNC_PASSWORD` entry in the Vercel dashboard shows as Plain (not Sensitive) after the next run.

## Screenshots / Demo video

N/A — workflow-only change.

## Migration Explanation

No DB migrations.
