### PR TITLE
Fix migration ordering for intermediate document_references tables

### DIFF
--- a/src/migrations/20260414_030934_backfill_document_references.ts
+++ b/src/migrations/20260414_030934_backfill_document_references.ts
@@ -1,4 +1,4 @@
-import { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/db-sqlite'
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-sqlite'
 
 const ROUTABLE_COLLECTIONS = ['pages', 'posts', 'homePages', 'events'] as const
 
@@ -11,8 +11,63 @@ const ROUTABLE_COLLECTIONS = ['pages', 'posts', 'homePages', 'events'] as const
  * the update throws a validation error. Log and skip those documents so the
  * migration doesn't block the entire deploy on one bad record; the skipped
  * doc's documentReferences will populate naturally on its next save.
+ *
+ * The intermediate collection document_references tables (sponsors, biographies,
+ * teams) are created here because the payload.update() calls below trigger
+ * beforeChange hooks that query those tables via the current schema. A later
+ * migration (20260424_180242) also creates these tables with IF NOT EXISTS.
  */
-export async function up({ payload }: MigrateUpArgs): Promise<void> {
+export async function up({ payload, db }: MigrateUpArgs): Promise<void> {
+  // Pre-create intermediate document_references tables so Payload's hooks
+  // can query them during the backfill below
+  await db.run(sql`CREATE TABLE IF NOT EXISTS \`sponsors_document_references\` (
+  	\`_order\` integer NOT NULL,
+  	\`_parent_id\` integer NOT NULL,
+  	\`id\` text PRIMARY KEY NOT NULL,
+  	\`collection\` text,
+  	\`doc_id\` numeric,
+  	\`instances\` text,
+  	FOREIGN KEY (\`_parent_id\`) REFERENCES \`sponsors\`(\`id\`) ON UPDATE no action ON DELETE cascade
+  );
+  `)
+  await db.run(
+    sql`CREATE INDEX IF NOT EXISTS \`sponsors_document_references_order_idx\` ON \`sponsors_document_references\` (\`_order\`);`,
+  )
+  await db.run(
+    sql`CREATE INDEX IF NOT EXISTS \`sponsors_document_references_parent_id_idx\` ON \`sponsors_document_references\` (\`_parent_id\`);`,
+  )
+  await db.run(sql`CREATE TABLE IF NOT EXISTS \`biographies_document_references\` (
+  	\`_order\` integer NOT NULL,
+  	\`_parent_id\` integer NOT NULL,
+  	\`id\` text PRIMARY KEY NOT NULL,
+  	\`collection\` text,
+  	\`doc_id\` numeric,
+  	\`instances\` text,
+  	FOREIGN KEY (\`_parent_id\`) REFERENCES \`biographies\`(\`id\`) ON UPDATE no action ON DELETE cascade
+  );
+  `)
+  await db.run(
+    sql`CREATE INDEX IF NOT EXISTS \`biographies_document_references_order_idx\` ON \`biographies_document_references\` (\`_order\`);`,
+  )
+  await db.run(
+    sql`CREATE INDEX IF NOT EXISTS \`biographies_document_references_parent_id_idx\` ON \`biographies_document_references\` (\`_parent_id\`);`,
+  )
+  await db.run(sql`CREATE TABLE IF NOT EXISTS \`teams_document_references\` (
+  	\`_order\` integer NOT NULL,
+  	\`_parent_id\` integer NOT NULL,
+  	\`id\` text PRIMARY KEY NOT NULL,
+  	\`collection\` text,
+  	\`doc_id\` numeric,
+  	\`instances\` text,
+  	FOREIGN KEY (\`_parent_id\`) REFERENCES \`teams\`(\`id\`) ON UPDATE no action ON DELETE cascade
+  );
+  `)
+  await db.run(
+    sql`CREATE INDEX IF NOT EXISTS \`teams_document_references_order_idx\` ON \`teams_document_references\` (\`_order\`);`,
+  )
+  await db.run(
+    sql`CREATE INDEX IF NOT EXISTS \`teams_document_references_parent_id_idx\` ON \`teams_document_references\` (\`_parent_id\`);`,
+  )
   for (const collection of ROUTABLE_COLLECTIONS) {
     const docs = await payload.find({
       collection,

--- a/src/migrations/20260424_180242_intermediate_collection_document_references.ts
+++ b/src/migrations/20260424_180242_intermediate_collection_document_references.ts
@@ -1,7 +1,7 @@
 import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-sqlite'
 
 export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
-  await db.run(sql`CREATE TABLE \`sponsors_document_references\` (
+  await db.run(sql`CREATE TABLE IF NOT EXISTS \`sponsors_document_references\` (
   	\`_order\` integer NOT NULL,
   	\`_parent_id\` integer NOT NULL,
   	\`id\` text PRIMARY KEY NOT NULL,
@@ -12,12 +12,12 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   );
   `)
   await db.run(
-    sql`CREATE INDEX \`sponsors_document_references_order_idx\` ON \`sponsors_document_references\` (\`_order\`);`,
+    sql`CREATE INDEX IF NOT EXISTS \`sponsors_document_references_order_idx\` ON \`sponsors_document_references\` (\`_order\`);`,
   )
   await db.run(
-    sql`CREATE INDEX \`sponsors_document_references_parent_id_idx\` ON \`sponsors_document_references\` (\`_parent_id\`);`,
+    sql`CREATE INDEX IF NOT EXISTS \`sponsors_document_references_parent_id_idx\` ON \`sponsors_document_references\` (\`_parent_id\`);`,
   )
-  await db.run(sql`CREATE TABLE \`biographies_document_references\` (
+  await db.run(sql`CREATE TABLE IF NOT EXISTS \`biographies_document_references\` (
   	\`_order\` integer NOT NULL,
   	\`_parent_id\` integer NOT NULL,
   	\`id\` text PRIMARY KEY NOT NULL,
@@ -28,12 +28,12 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   );
   `)
   await db.run(
-    sql`CREATE INDEX \`biographies_document_references_order_idx\` ON \`biographies_document_references\` (\`_order\`);`,
+    sql`CREATE INDEX IF NOT EXISTS \`biographies_document_references_order_idx\` ON \`biographies_document_references\` (\`_order\`);`,
   )
   await db.run(
-    sql`CREATE INDEX \`biographies_document_references_parent_id_idx\` ON \`biographies_document_references\` (\`_parent_id\`);`,
+    sql`CREATE INDEX IF NOT EXISTS \`biographies_document_references_parent_id_idx\` ON \`biographies_document_references\` (\`_parent_id\`);`,
   )
-  await db.run(sql`CREATE TABLE \`teams_document_references\` (
+  await db.run(sql`CREATE TABLE IF NOT EXISTS \`teams_document_references\` (
   	\`_order\` integer NOT NULL,
   	\`_parent_id\` integer NOT NULL,
   	\`id\` text PRIMARY KEY NOT NULL,
@@ -44,10 +44,10 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   );
   `)
   await db.run(
-    sql`CREATE INDEX \`teams_document_references_order_idx\` ON \`teams_document_references\` (\`_order\`);`,
+    sql`CREATE INDEX IF NOT EXISTS \`teams_document_references_order_idx\` ON \`teams_document_references\` (\`_order\`);`,
   )
   await db.run(
-    sql`CREATE INDEX \`teams_document_references_parent_id_idx\` ON \`teams_document_references\` (\`_parent_id\`);`,
+    sql`CREATE INDEX IF NOT EXISTS \`teams_document_references_parent_id_idx\` ON \`teams_document_references\` (\`_parent_id\`);`,
   )
 }
 


### PR DESCRIPTION
## Summary

- The backfill migration (`20260414`) calls `payload.update()` which triggers hooks that query `sponsors_document_references`, `biographies_document_references`, and `teams_document_references` — but those tables aren't created until a later migration (`20260424`), causing `no such table` errors on fresh deploys.
- Fix: pre-create the tables with `IF NOT EXISTS` in the backfill migration, and make the later migration idempotent with `IF NOT EXISTS` too.

## Test plan

- [ ] Preview deploy succeeds (migrations pass)
- [ ] Verify no regressions on existing prod data (later migration is a no-op if tables already exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)