### PR TITLE
Speed up preview deploys and CI: clone payloadcms-dev + cache seeded dev.db & Playwright

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,6 +148,15 @@ jobs:
     if: github.event_name == 'merge_group'
     environment: Preview
     runs-on: ubuntu-latest
+    # Shard by Playwright project so admin and frontend specs run on parallel
+    # runners. Roughly halves wall-clock for E2E. Setup steps duplicate per
+    # shard, but the seed and Playwright caches mean the duplication is mostly
+    # the build (~2m). `fail-fast: false` so a failure in one shard doesn't
+    # cancel the other — we want both reports.
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [admin, frontend]
     env:
       DATABASE_URI: 'file:./dev.db'
       PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
@@ -204,12 +213,13 @@ jobs:
       - name: ⏳ Wait for server
         run: timeout 120 bash -c 'until curl -sf http://localhost:3000/admin/login > /dev/null; do sleep 2; done'
       - name: 🧪 Run E2E tests
-        run: pnpm test:e2e
+        run: pnpm test:e2e:${{ matrix.project }}
       - name: 📤 Upload Playwright report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          # One artifact per shard so the parallel jobs don't collide.
+          name: playwright-report-${{ matrix.project }}
           path: playwright-report/
           retention-days: 14
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
-        run: pnpm ii
+        run: pnpm install --frozen-lockfile --ignore-workspace
         shell: bash
       - name: 🧹 Run lint
         run: pnpm lint
@@ -50,7 +50,7 @@ jobs:
           node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
-        run: pnpm ii
+        run: pnpm install --frozen-lockfile --ignore-workspace
         shell: bash
       - name: 📦 Opt out of image optimization
         run: "sed -i 's/unoptimized: false/unoptimized: true/' next.config.js"
@@ -93,7 +93,7 @@ jobs:
           node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
-        run: pnpm ii
+        run: pnpm install --frozen-lockfile --ignore-workspace
         shell: bash
       - name: 🧹 Run pnpm generate:type
         run: |
@@ -138,7 +138,7 @@ jobs:
           node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
-        run: pnpm ii
+        run: pnpm install --frozen-lockfile --ignore-workspace
         shell: bash
       - name: 🧪 Run tests
         run: pnpm test
@@ -164,7 +164,7 @@ jobs:
           node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
-        run: pnpm ii
+        run: pnpm install --frozen-lockfile --ignore-workspace
         shell: bash
       # Cache Playwright browser binaries (~150MB) keyed by lockfile so the
       # cache invalidates when @playwright/test bumps. Cache hit → ~30-60s
@@ -227,7 +227,7 @@ jobs:
           node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
-        run: pnpm ii
+        run: pnpm install --frozen-lockfile --ignore-workspace
         shell: bash
       - name: Check if a migration is needed
         run: |
@@ -266,7 +266,7 @@ jobs:
           node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
-        run: pnpm ii
+        run: pnpm install --frozen-lockfile --ignore-workspace
         shell: bash
       - name: 🔍 Check migration safety
         id: check-migrations

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,17 @@ jobs:
       - name: 📦 Opt out of image optimization
         run: "sed -i 's/unoptimized: false/unoptimized: true/' next.config.js"
         shell: bash
+      - name: 💾 Cache seeded database
+        id: db-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            dev.db
+            dev.db-shm
+            dev.db-wal
+          key: seeded-dev-db-${{ hashFiles('src/endpoints/seed/**', 'src/migrations/**', 'src/payload.config.ts', 'src/collections/**', 'src/globals/**', 'pnpm-lock.yaml') }}
       - name: 🧹 Run seed
+        if: steps.db-cache.outputs.cache-hit != 'true'
         run: pnpm seed:standalone
         shell: bash
         env:
@@ -156,12 +166,36 @@ jobs:
       - name: 📦 Install dependencies
         run: pnpm ii
         shell: bash
+      # Cache Playwright browser binaries (~150MB) keyed by lockfile so the
+      # cache invalidates when @playwright/test bumps. Cache hit → ~30-60s
+      # saved on the chromium download. We still run `playwright install
+      # --with-deps` to ensure the apt system dependencies are present.
+      - name: 💾 Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
       - name: 🎭 Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium
       - name: 📦 Opt out of image optimization
         run: "sed -i 's/unoptimized: false/unoptimized: true/' next.config.js"
         shell: bash
+      # Reuse the same seeded-DB cache as the `build` job; same key means a
+      # build-job hit warms the cache for e2e and vice versa.
+      - name: 💾 Cache seeded database
+        id: db-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            dev.db
+            dev.db-shm
+            dev.db-wal
+          key: seeded-dev-db-${{ hashFiles('src/endpoints/seed/**', 'src/migrations/**', 'src/payload.config.ts', 'src/collections/**', 'src/globals/**', 'pnpm-lock.yaml') }}
       - name: 🌱 Seed database
+        if: steps.db-cache.outputs.cache-hit != 'true'
         run: pnpm seed:standalone
       - name: 🔨 Build
         run: pnpm build

--- a/.github/workflows/dependabot-auto-format.yml
+++ b/.github/workflows/dependabot-auto-format.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'pnpm'
 
       - name: 📦 Install dependencies
-        run: pnpm ii
+        run: pnpm install --frozen-lockfile --ignore-workspace
         shell: bash
 
       - name: Run prettify and lint:fix

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -51,7 +51,7 @@ jobs:
           node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
-        run: pnpm ii
+        run: pnpm install --frozen-lockfile --ignore-workspace
         shell: bash
       - name: Install Vercel CLI
         run: npm install --global vercel@latest

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -117,6 +117,19 @@ jobs:
           PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --git-branch="${{ github.head_ref }}" --token=${{ secrets.VERCEL_TOKEN }}
+      # Restore .next/cache between preview runs so `vercel build`'s
+      # underlying `next build` can reuse webpack/SWC module caches and the
+      # ISR fetch cache. Save key includes the commit SHA so each run writes
+      # a fresh entry; restore-keys fall back to the most recent cache for
+      # the same lockfile, then any cache for this OS.
+      - name: 💾 Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: nextjs-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            nextjs-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nextjs-cache-${{ runner.os }}-
       - name: Build Project Artifacts
         run: vercel build --yes --target=preview --token=${{ secrets.VERCEL_TOKEN }}
         env:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -46,7 +46,11 @@ jobs:
           if /home/runner/.turso/turso db show "${name}"; then
             /home/runner/.turso/turso db destroy "${name}" --yes
           fi
-          /home/runner/.turso/turso db create "${name}" --wait
+          # Clone from payloadcms-dev (already migrated + seeded with prod
+          # data via .github/workflows/{development,sync-prod-to-dev}.yaml).
+          # Saves ~5 minutes per preview vs. running migrations + seed from
+          # scratch on a fresh database.
+          /home/runner/.turso/turso db create "${name}" --from-db payloadcms-dev --wait
           /home/runner/.turso/turso db shell "${name}" .tables
           echo "name=${name}" >> "${GITHUB_OUTPUT}"
         env:
@@ -72,7 +76,7 @@ jobs:
           node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
-        run: pnpm ii
+        run: pnpm install --frozen-lockfile --ignore-workspace
         shell: bash
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
@@ -102,17 +106,14 @@ jobs:
       - name: Pull Vercel Environment Variables into .env file
         run: vercel env pull --yes --environment=preview --git-branch="${{ github.head_ref }}" --token=${{ secrets.VERCEL_TOKEN }} .env
       - name: Run database migrations
+        # The cloned DB already has all main's migrations applied. This
+        # only fires for migrations the PR itself adds (idempotent — no-op
+        # otherwise). Seeding is removed because the cloned dev DB already
+        # has the data.
         run: pnpm migrate
         env:
           DATABASE_URI: '${{ steps.connection.outputs.uri }}'
           DATABASE_AUTH_TOKEN: '${{ steps.connection.outputs.token }}'
-          PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
-      - name: Seed the database
-        run: pnpm seed:standalone
-        env:
-          DATABASE_URI: '${{ steps.connection.outputs.uri }}'
-          DATABASE_AUTH_TOKEN: '${{ steps.connection.outputs.token }}'
-          PAYLOAD_SEED_PASSWORD: '${{ secrets.PAYLOAD_SEED_PASSWORD }}'
           PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --git-branch="${{ github.head_ref }}" --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -55,7 +55,7 @@ jobs:
           node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
-        run: pnpm ii
+        run: pnpm install --frozen-lockfile --ignore-workspace
         shell: bash
       - name: Install Vercel CLI
         run: npm install --global vercel@latest

--- a/.github/workflows/sync-prod-to-dev.yml
+++ b/.github/workflows/sync-prod-to-dev.yml
@@ -55,7 +55,7 @@ jobs:
           node-version: 24.x
           cache: pnpm
       - name: 📦 Install dependencies
-        run: pnpm ii
+        run: pnpm install --frozen-lockfile --ignore-workspace
         shell: bash
       - name: Install Vercel CLI
         run: npm install --global vercel@latest

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,6 +36,8 @@ export default defineConfig({
     command: 'pnpm dev',
     url: 'http://localhost:3000',
     reuseExistingServer: true,
-    timeout: 300000, // 5 minutes - Next.js + Payload takes a while to compile
+    // Next 16's Turbopack-default dev server boots in ~340ms; was 5min when
+    // webpack dev was the slow path. Lower so we fail fast on real boot issues.
+    timeout: 90000,
   },
 })


### PR DESCRIPTION
## Description

Bundle of CI/deploy speedups, plus consistency cleanups.

**Stacked on #1059** (Next 16 upgrade). Will retarget to `main` after that merges.

## Related Issues

N/A. Investigation came out of #1059's CI timing — the [preview deploy run for that PR](https://github.com/NWACus/web/actions/runs/25351231181/job/74331059359) took 11 minutes, of which:

| Step | Duration |
|---|---|
| Seed the database | **3m 26s** |
| Build Project Artifacts | **2m 17s** |
| Deploy to Vercel | 2m 30s |
| Run database migrations | **1m 35s** |
| Other | ~1m |

## Key Changes

### 1. Preview deploys clone `payloadcms-dev` instead of seeding from scratch

[`.github/workflows/preview.yaml`](.github/workflows/preview.yaml):

- `turso db create "${name}" --wait` → `turso db create "${name}" --from-db payloadcms-dev --wait`. `payloadcms-dev` is already maintained by [development.yaml](.github/workflows/development.yaml) and [sync-prod-to-dev.yml](.github/workflows/sync-prod-to-dev.yml) — has all migrations applied and prod-derived data. Cloning is seconds.
- `pnpm seed:standalone` step removed entirely — clone has the data.
- `pnpm migrate` kept — idempotent. No-op when the PR doesn't add migrations; applies just the new ones when it does.

### 2. CI caches for the build & e2e jobs (was #1061, merged in)

[`.github/workflows/ci.yaml`](.github/workflows/ci.yaml):

- **Seeded `dev.db` cache** (~3 min saved on hit). Cache key hashes seed scripts, migrations, payload config, collections, globals, and `pnpm-lock.yaml`. Applied to both `build` and `e2e` jobs (shared key, so they warm each other). Seed step skipped via `if: steps.db-cache.outputs.cache-hit != 'true'` on a hit.
- **Playwright browser binaries cache** (~30-60s saved on hit). Cache key includes `pnpm-lock.yaml`. We still call `playwright install --with-deps` so apt system deps stay in sync.

### 3. `pnpm install --frozen-lockfile --ignore-workspace` everywhere

Replaced `pnpm ii` (= `pnpm --ignore-workspace install`) across all 11 callsites in 6 workflow files: `ci.yaml` (×7), `preview.yaml`, `development.yaml`, `production.yaml`, `dependabot-auto-format.yml`, `sync-prod-to-dev.yml`. Frozen-lockfile skips lockfile reconciliation on CI and prevents accidental lockfile mutations from CI runs. Small per-job speedup, bigger consistency/safety win.

### 4. Drop Playwright `webServer.timeout` from 5 min → 90s

[`playwright.config.ts`](playwright.config.ts): was sized for slow webpack dev boots when E2E uses `pnpm dev` as its server. Next 16's default Turbopack dev boots in ~340ms (per #1059's tests), so 90s is plenty and we now fail fast when the server actually has trouble booting.

### 5. Cache `.next/cache` between preview deploys

`vercel build` runs `next build` underneath, which uses `.next/cache` for webpack/SWC module caches and ISR fetch cache. Caching that between preview runs lets subsequent deploys reuse incremental compilation state. Typical Next.js project savings on the build step are **30-60%** when the cache hits.

Cache-key hierarchy:
- Primary: `nextjs-cache-<os>-<lockfile-hash>-<sha>` (per-commit, always saves fresh)
- Fallback 1: `nextjs-cache-<os>-<lockfile-hash>-` (most recent cache, same deps)
- Fallback 2: `nextjs-cache-<os>-` (any cache, e.g. when lockfile changes)

### 6. Shard E2E job by Playwright project (admin / frontend)

`ci.yaml`'s `e2e` job now uses `strategy.matrix` to run admin and frontend specs on parallel runners via the existing `test:e2e:admin` / `test:e2e:frontend` scripts. Wall-clock for E2E is **roughly halved** on the test-execution side. `fail-fast: false` so a failure in one shard doesn't cancel the other.

**Important**: this changes the GitHub check-run names. The single `e2e` check becomes two checks: `e2e (admin)` and `e2e (frontend)`. **Branch protection / merge-queue required-status-checks need updating** — remove `e2e` and add both `e2e (admin)` and `e2e (frontend)`. (One-time settings change.)

Playwright report artifacts are also split: `playwright-report-admin` and `playwright-report-frontend`, since matrix jobs can't share the same artifact name.

## Expected timing

**Preview deploy:** ~11m → ~5m

| Step | Before | After |
|---|---|---|
| Create DB (now: clone) | ~5s | ~5s |
| Run migrations | 1m 35s | ~5s (no-op for most PRs) |
| Seed | 3m 26s | **removed** |
| Build (warm `.next/cache`) | 2m 17s | ~1m to 1m 30s |
| Deploy | 2m 30s | 2m 30s |

**CI build & e2e jobs:** ~3-4m saved on cache hit, plus E2E roughly halves with sharding.

## How to test

- [ ] Open a no-op PR after this merges. Confirm preview deploys in ~5-6 min.
- [ ] Verify the deployed site has prod-derived content (real tenants/pages, not synthetic seed data).
- [ ] Open a PR that adds a migration; confirm `pnpm migrate` runs and applies it on the cloned DB.
- [ ] First preview build is cold (no `.next/cache` yet). Push a follow-up commit; the second build should be noticeably faster, and the GitHub Actions cache restore step should report a hit.
- [ ] Confirm `build`/`e2e` jobs in CI show the seed step as `skipped` after the cache is warmed.
- [ ] Confirm Playwright chromium download is fast on a second `e2e` run.
- [ ] Confirm `e2e (admin)` and `e2e (frontend)` both appear as separate checks in the merge queue.
- [ ] **Update branch protection / required status checks** to replace `e2e` with `e2e (admin)` + `e2e (frontend)`.

## Tradeoffs / risks

- **Data exposure on previews**: previews now contain real user accounts and prod-derived content — same as the existing `payloadcms-dev` deployment. Risk parity with dev.
- **No more `bootstrap@avy.com` login**: the seed creates that test user; cloning from dev/prod doesn't have it. Reviewers/QA log in with real prod accounts.
- **Race window during dev refresh**: `development.yaml` and `sync-prod-to-dev.yml` do `destroy + create --from-db payloadcms-prod`. A preview that lands in the ~5-second destroy/recreate window will fail at `--from-db`. Cost: rerun the workflow.
- **Seed determinism (CI cache)**: assumes `pnpm seed:standalone` produces the same DB content for the same inputs. If hidden non-determinism (e.g. `Date.now()` in a field) causes flakes, the cleanest fix is making the seed deterministic; workaround is expanding the cache key.
- **`.next/cache` correctness**: the cache restoration is keyed by lockfile + commit SHA with restore-keys for fallback. If a stale cache somehow produces an incorrect build (Next/webpack bugs do happen), bumping the lockfile or running a no-op rebase forces a cold build. Cache size is bounded; GitHub keeps caches up to 10 GB and evicts LRU.
- **E2E sharding doubles runner-minute cost** (~2× the seat hours per E2E run) for ~50% wall-clock savings. Acceptable since E2E only runs on `merge_group`, not every PR push.
- **Required-check rename**: `e2e` → `e2e (admin)` + `e2e (frontend)`. Merges may stall until branch protection settings are updated.

## Migration Explanation

No application database migrations. CI/deploy-only change.

## Future enhancements

- Bigger CI runners (`runs-on: ubuntu-latest-4-cores`) — would shrink the `build` job especially. Cost: more GitHub Actions minutes.
- Composite action for the `setup repo + pnpm + node + install` boilerplate (duplicated 11+ times). Pure refactor, no perf change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)