### PR TITLE
Cache seeded dev.db and Playwright browsers in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,17 @@ jobs:
       - name: 📦 Opt out of image optimization
         run: "sed -i 's/unoptimized: false/unoptimized: true/' next.config.js"
         shell: bash
+      - name: 💾 Cache seeded database
+        id: db-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            dev.db
+            dev.db-shm
+            dev.db-wal
+          key: seeded-dev-db-${{ hashFiles('src/endpoints/seed/**', 'src/migrations/**', 'src/payload.config.ts', 'src/collections/**', 'src/globals/**', 'pnpm-lock.yaml') }}
       - name: 🧹 Run seed
+        if: steps.db-cache.outputs.cache-hit != 'true'
         run: pnpm seed:standalone
         shell: bash
         env:
@@ -156,12 +166,36 @@ jobs:
       - name: 📦 Install dependencies
         run: pnpm ii
         shell: bash
+      # Cache Playwright browser binaries (~150MB) keyed by lockfile so the
+      # cache invalidates when @playwright/test bumps. Cache hit → ~30-60s
+      # saved on the chromium download. We still run `playwright install
+      # --with-deps` to ensure the apt system dependencies are present.
+      - name: 💾 Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
       - name: 🎭 Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium
       - name: 📦 Opt out of image optimization
         run: "sed -i 's/unoptimized: false/unoptimized: true/' next.config.js"
         shell: bash
+      # Reuse the same seeded-DB cache as the `build` job; same key means a
+      # build-job hit warms the cache for e2e and vice versa.
+      - name: 💾 Cache seeded database
+        id: db-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            dev.db
+            dev.db-shm
+            dev.db-wal
+          key: seeded-dev-db-${{ hashFiles('src/endpoints/seed/**', 'src/migrations/**', 'src/payload.config.ts', 'src/collections/**', 'src/globals/**', 'pnpm-lock.yaml') }}
       - name: 🌱 Seed database
+        if: steps.db-cache.outputs.cache-hit != 'true'
         run: pnpm seed:standalone
       - name: 🔨 Build
         run: pnpm build


### PR DESCRIPTION
## Description

Two GitHub Actions caches that target the slowest non-build steps in the `build` and `e2e` jobs of `ci.yaml`. Both are pure additions — cache misses fall back to the original behavior unchanged.

**Stacked on #1060** → which is stacked on #1059. Will retarget to `main` after both merge.

## Related Issues

N/A. Came out of investigation into preview/CI timing — see #1059's [preview run](https://github.com/NWACus/web/actions/runs/25351231181/job/74331059359) where `Seed the database` is 3m 26s.

## Key Changes

### 1. Seeded `dev.db` cache (~3 minutes saved per run when cache hits)

The `build` and `e2e` jobs both run `pnpm seed:standalone` against a local SQLite file. This is **deterministic** — same seed scripts + migrations + schema = same DB output.

```yaml
- name: 💾 Cache seeded database
  id: db-cache
  uses: actions/cache@v4
  with:
    path: |
      dev.db
      dev.db-shm
      dev.db-wal
    key: seeded-dev-db-${{ hashFiles('src/endpoints/seed/**', 'src/migrations/**', 'src/payload.config.ts', 'src/collections/**', 'src/globals/**', 'pnpm-lock.yaml') }}
- name: 🧹 Run seed
  if: steps.db-cache.outputs.cache-hit != 'true'
  run: pnpm seed:standalone
```

The cache key hashes everything that affects what the seed produces: seed scripts, migrations, payload config, collection/global schemas, and `pnpm-lock.yaml` (Payload version). Any change to those bits **automatically evicts** the cache and triggers a fresh seed.

Both `build` and `e2e` share the same key, so the first job to run warms the cache for the second.

### 2. Playwright browser binaries cache (~30-60 seconds saved per run when cache hits)

Chromium is ~150 MB and gets downloaded fresh on every E2E run today. The cache lives at `~/.cache/ms-playwright`, keyed by `pnpm-lock.yaml` so a `@playwright/test` bump invalidates it.

```yaml
- name: 💾 Cache Playwright browsers
  uses: actions/cache@v4
  with:
    path: ~/.cache/ms-playwright
    key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
    restore-keys: |
      playwright-${{ runner.os }}-
- name: 🎭 Install Playwright Chromium
  run: pnpm exec playwright install --with-deps chromium
```

We keep calling `playwright install --with-deps` so apt system dependencies stay in sync; the `--with-deps` step is fast when system packages are already present, and `playwright install` is a no-op when the browser binary is already cached.

## Expected timing

| Step | Cache miss | Cache hit |
|---|---|---|
| Seed database | ~3m 26s | **~5s (skipped)** |
| Install Playwright chromium | ~30-60s | ~5s (system deps only) |

Total saved per CI run on cache hits: **~3-4 minutes**.

The seed cache misses on any PR that touches seed scripts, migrations, schema, or bumps Payload — exactly the cases where running the seed is necessary anyway. So the worst case is "back to today's behavior", not "broken."

## How to test

- [ ] Open this PR — first run misses both caches and runs the seed + downloads chromium normally.
- [ ] Push a noop commit — second run hits both caches and skips the slow steps. Confirm seed step shows as `skipped` in the GitHub Actions UI.
- [ ] Push a commit that changes a seed script (`src/endpoints/seed/**`) — confirm the seed cache is invalidated and the seed runs.

## Migration Explanation

No application database migrations. CI-only change.

## Risks

- **Seed determinism**: assumes `pnpm seed:standalone` produces the same DB content every run for the same inputs. If the seed has hidden non-determinism (e.g. `Date.now()` written to a field), cached and fresh runs will diverge. If this becomes an issue, the cleanest fix is to make the seed deterministic; the workaround is to expand the cache key.
- **Cache size growth**: each unique key creates a cache entry. GitHub keeps caches up to 10 GB total per repo and evicts LRU. The seeded `dev.db` is small (likely <50 MB); we're fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)