### PR TITLE
Reduce dependabot PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,19 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     open-pull-requests-limit: 3
     groups:
       payloadcms:
         patterns:
           - 'payload'
           - '@payloadcms/*'
+      all-other:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
     allow:
       - dependency-name: 'payload'
       - dependency-name: '@payloadcms/*'


### PR DESCRIPTION
## Description

Reduces dependabot noise by switching from weekly to monthly and grouping non-Payload updates into a single PR. 

So now we would get two PR groups:
- Payload updates
- Everything else grouped together

## Key Changes

- Change the schedule from weekly to monthly
- **`all-other` group** — batches all non-Payload minor/patch updates into one PR instead of individual PRs per package