### PR TITLE
Add migration naming and merge workflow docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,16 +391,17 @@ Never cast relationship fields - they can be resolved objects, unresolved IDs, o
 
 1. **Check if seed data needs updating** - If you add/change fields, update the seed script to include appropriate test data
 2. **Run the seed script** - After updating, run `pnpm seed` to verify it completes without errors
-3. **Generate a migration** - Run `pnpm payload migrate:create` for schema changes
+3. **Generate a migration** - Run `pnpm payload migrate:create <descriptive_name>` (always provide a descriptive name)
 4. **Check migration safety** - Run `pnpm migrate:check` to detect potentially destructive patterns
 5. **Review `/docs/migration-safety.md`** for guidance on safe migrations
+6. **Review `/docs/coding-guide.md#migrations`** for migration naming and merge workflow
 
 ### When Adding New Collections/Globals
 
 1. **Consider revalidation** - Reference `/docs/revalidation.md` to determine if revalidation hooks are needed
 2. **Add seed data** - Add seed data to the seed script when the schema is finished
 3. **Run the seed script** - Verify `pnpm seed:standalone` completes without errors
-4. **Generate a migration** - Run `pnpm payload migrate:create`
+4. **Generate a migration** - Run `pnpm payload migrate:create <descriptive_name>` (always provide a descriptive name)
 5. **Update type generation** - Run `pnpm generate:types` after schema changes
 
 ### When Adding New Blocks

--- a/docs/coding-guide.md
+++ b/docs/coding-guide.md
@@ -77,15 +77,19 @@ Descriptive names make it easy to understand what each migration does when scann
 
 ### Merging `main` When There Are New Migrations
 
-When you merge `main` into your feature branch and `main` has new migrations, you will get a conflict in `src/migrations/index.ts`. This is expected. Follow this process:
+When you merge `main` into your feature branch and `main` has new migrations, you **must recreate your branch's migrations** — even if there is no merge conflict. The critical reason: each migration's `.json` snapshot must reflect the full schema state at that point, including migrations from `main`. If you skip this step, the snapshot will be missing `main`'s migrations and won't accurately represent the database state.
 
-1. **Merge `main` into your branch** and resolve the conflict in `src/migrations/index.ts` by accepting all incoming changes
+If there **is** a conflict in `src/migrations/index.ts`, resolve it by accepting all incoming changes before proceeding.
+
+Follow this process:
+
+1. **Merge `main` into your branch** and resolve any other conflicts
 2. **Delete your branch's migration files** — remove the migration `.ts` file(s) and their corresponding `.json` snapshot(s) that your branch added
 3. **Remove your migration imports** from `src/migrations/index.ts` — keep only the migrations that came from `main`
-4. **Recreate your migrations** — run `pnpm payload migrate:create <descriptive_name>` again. This generates new migration files with timestamps that are ordered **after** the ones from `main`, and a snapshot that reflects the current schema state
-5. **Verify** — check that `src/migrations/index.ts` has all migrations in correct chronological order and that your migrations were recreated as expected
+4. **Recreate your migrations** — run `pnpm payload migrate:create <descriptive_name>` again. This generates new migration files with timestamps that are ordered **after** the ones from `main`, and a snapshot that reflects the current schema state (including `main`'s migrations)
+5. **Verify** — check that `src/migrations/index.ts` has all migrations in correct chronological order and that your new `.json` snapshot includes `main`'s migrations
 
-This ensures migrations always run in the right order and each migration's snapshot accurately reflects the schema state at that point.
+The most important output of the recreation is the `.json` snapshot file. The `.ts` migration file will typically be identical to the original, but it's simplest to regenerate both.
 
 ## Safely handling relationship fields
 

--- a/docs/coding-guide.md
+++ b/docs/coding-guide.md
@@ -77,13 +77,13 @@ Descriptive names make it easy to understand what each migration does when scann
 
 ### Merging `main` When There Are New Migrations
 
-When you merge `main` into your feature branch and `main` has new migrations, you will get a conflict in `src/migrations/index.ts`. This is expected. **Do not create an empty migration just to update the snapshot.** Instead, follow this process:
+When you merge `main` into your feature branch and `main` has new migrations, you will get a conflict in `src/migrations/index.ts`. This is expected. Follow this process:
 
-1. **Merge `main` into your branch** and resolve the conflict in `src/migrations/index.ts` by accepting all migrations from both sides
+1. **Merge `main` into your branch** and resolve the conflict in `src/migrations/index.ts` by accepting all incoming changes
 2. **Delete your branch's migration files** — remove the migration `.ts` file(s) and their corresponding `.json` snapshot(s) that your branch added
 3. **Remove your migration imports** from `src/migrations/index.ts` — keep only the migrations that came from `main`
 4. **Recreate your migrations** — run `pnpm payload migrate:create <descriptive_name>` again. This generates new migration files with timestamps that are ordered **after** the ones from `main`, and a snapshot that reflects the current schema state
-5. **Verify** — check that `src/migrations/index.ts` has all migrations in correct chronological order
+5. **Verify** — check that `src/migrations/index.ts` has all migrations in correct chronological order and that your migrations were recreated as expected
 
 This ensures migrations always run in the right order and each migration's snapshot accurately reflects the schema state at that point.
 

--- a/docs/coding-guide.md
+++ b/docs/coding-guide.md
@@ -59,8 +59,33 @@ Start by copying `src/collections/collection-template.ts` into a new file in `sr
 4. **Generate types** — Run `pnpm generate:types` to update TypeScript types
 5. **Add seed data** — Add representative test data to the seed script once the schema is finalized
 6. **Run the seed script** — Verify `pnpm seed` completes without errors
-7. **Generate a migration** — Run `pnpm payload migrate:create` and review the output. See `/docs/migration-safety.md` to make sure your migration won't cause unintended data loss
+7. **Generate a migration** — Run `pnpm payload migrate:create <descriptive_name>` and review the output. See `/docs/migration-safety.md` and the [Migrations](#migrations) section below
 8. **Expose via MCP (if appropriate)** — If this collection should be queryable by AI tools, add it to the MCP plugin config in `src/plugins/index.ts`. See `/docs/mcp-server.md` for details
+
+## Migrations
+
+### Naming Migrations
+
+When generating a migration with `pnpm payload migrate:create`, **always provide a descriptive custom name** that summarizes the schema change. For example:
+
+```bash
+pnpm payload migrate:create add_sponsors_block
+pnpm payload migrate:create remove_embed_block_height
+```
+
+Descriptive names make it easy to understand what each migration does when scanning `src/migrations/index.ts` or the migration files on disk.
+
+### Merging `main` When There Are New Migrations
+
+When you merge `main` into your feature branch and `main` has new migrations, you will get a conflict in `src/migrations/index.ts`. This is expected. **Do not create an empty migration just to update the snapshot.** Instead, follow this process:
+
+1. **Merge `main` into your branch** and resolve the conflict in `src/migrations/index.ts` by accepting all migrations from both sides
+2. **Delete your branch's migration files** — remove the migration `.ts` file(s) and their corresponding `.json` snapshot(s) that your branch added
+3. **Remove your migration imports** from `src/migrations/index.ts` — keep only the migrations that came from `main`
+4. **Recreate your migrations** — run `pnpm payload migrate:create <descriptive_name>` again. This generates new migration files with timestamps that are ordered **after** the ones from `main`, and a snapshot that reflects the current schema state
+5. **Verify** — check that `src/migrations/index.ts` has all migrations in correct chronological order
+
+This ensures migrations always run in the right order and each migration's snapshot accurately reflects the schema state at that point.
 
 ## Safely handling relationship fields
 


### PR DESCRIPTION
## Summary
- Add a **Migrations** section to the coding guide documenting two practices:
  - Always provide a descriptive name when running `pnpm payload migrate:create`
  - How to properly resolve migration conflicts when merging `main` into a feature branch (delete your migrations, recreate them so they're ordered after main's)
- Update `CLAUDE.md` migration references to include the descriptive name argument and link to the new docs section