### PR TITLE
Fix URL validation rejecting long TLDs like .clothing

### DIFF
--- a/__tests__/client/utilities/validateUrl.client.test.ts
+++ b/__tests__/client/utilities/validateUrl.client.test.ts
@@ -67,4 +67,16 @@ describe('isValidFullUrl', () => {
   it('rejects a URL with a numeric TLD', () => {
     expect(isValidFullUrl('https://example.123')).toBe(false)
   })
+
+  it('accepts a URL with a long TLD like .clothing', () => {
+    expect(isValidFullUrl('https://www.woolly.clothing/')).toBe(true)
+  })
+
+  it('accepts a URL with .photography TLD', () => {
+    expect(isValidFullUrl('https://example.photography')).toBe(true)
+  })
+
+  it('accepts a URL with .international TLD', () => {
+    expect(isValidFullUrl('https://example.international')).toBe(true)
+  })
 })

--- a/src/utilities/validateUrl.ts
+++ b/src/utilities/validateUrl.ts
@@ -30,10 +30,10 @@ export const isValidFullUrl = (url?: string | null): boolean => {
       return false
     }
 
-    // Last part (TLD) must be 2-6 characters and contain only letters
-    // This covers common TLDs like .com, .org, .edu, .museum, etc.
+    // Last part (TLD) must be at least 2 characters and contain only letters
+    // Modern TLDs can be long (e.g., .clothing, .photography, .international)
     const tld = parts[parts.length - 1]
-    if (tld.length < 2 || tld.length > 6 || !/^[a-zA-Z]+$/.test(tld)) {
+    if (tld.length < 2 || !/^[a-zA-Z]+$/.test(tld)) {
       return false
     }
 


### PR DESCRIPTION
## Description

An editor ran into a validation error when entering `https://www.woolly.clothing/` in a sponsor link field. The URL validator capped TLDs at 6 characters, but modern TLDs like `.clothing` (8 chars), `.photography` (11 chars), and `.international` (13 chars) are valid.

## Related Issues

Reported by editor (no GitHub issue)

## Key Changes

- Removed the 6-character upper bound on TLD length in `src/utilities/validateUrl.ts`
- Retained the 2-character minimum and letters-only validation
- Added test cases for long TLDs (`.clothing`, `.photography`, `.international`)

## How to test

1. Go to any Sponsor in the admin panel
2. Enter `https://www.woolly.clothing/` in the link field
3. Save — should succeed without validation error
4. Run `pnpm test -- __tests__/client/utilities/validateUrl.client.test.ts`

## Screenshots / Demo video

N/A

## Migration Explanation

No migration needed — validation logic only.

## Future enhancements / Questions

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)