### PR TITLE
Fix publish date reverting when editors update it

### DIFF
--- a/__tests__/server/populatePublishedAt.server.test.ts
+++ b/__tests__/server/populatePublishedAt.server.test.ts
@@ -1,0 +1,129 @@
+import { populatePublishedAt } from '@/hooks/populatePublishedAt'
+
+// Builds a minimal mock of the hook args; only the fields the hook actually reads are provided
+function createArgs(overrides: {
+  operation: 'create' | 'update'
+  data: Record<string, unknown>
+  req: { data: Record<string, unknown> }
+  originalDoc?: Record<string, unknown>
+}): Parameters<typeof populatePublishedAt>[0] {
+  // @ts-expect-error - partial mock; only data, operation, originalDoc, and req.data are used by the hook
+  return {
+    context: {},
+    originalDoc: {},
+    ...overrides,
+  }
+}
+
+describe('populatePublishedAt', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-01-15T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('create operation', () => {
+    it('auto-sets publishedAt to now when not provided', () => {
+      const result = populatePublishedAt(
+        createArgs({
+          operation: 'create',
+          data: { title: 'Test Post' },
+          req: { data: { title: 'Test Post' } },
+        }),
+      )
+
+      expect(result).toEqual({
+        title: 'Test Post',
+        publishedAt: new Date('2026-01-15T12:00:00Z'),
+      })
+    })
+
+    it('preserves user-provided publishedAt on create', () => {
+      const userDate = '2025-12-01T10:00:00Z'
+      const result = populatePublishedAt(
+        createArgs({
+          operation: 'create',
+          data: { title: 'Test Post', publishedAt: userDate },
+          req: { data: { title: 'Test Post', publishedAt: userDate } },
+        }),
+      )
+
+      expect(result).toEqual({
+        title: 'Test Post',
+        publishedAt: userDate,
+      })
+    })
+  })
+
+  describe('update operation', () => {
+    it('preserves user-provided publishedAt on update', () => {
+      const userDate = '2025-06-15T09:00:00Z'
+      const result = populatePublishedAt(
+        createArgs({
+          operation: 'update',
+          data: { title: 'Updated Post', publishedAt: userDate },
+          req: { data: { title: 'Updated Post', publishedAt: userDate } },
+          originalDoc: { _status: 'published', publishedAt: '2025-01-01T00:00:00Z' },
+        }),
+      )
+
+      expect(result).toEqual({
+        title: 'Updated Post',
+        publishedAt: userDate,
+      })
+    })
+
+    it('auto-sets publishedAt to now when not provided on update', () => {
+      const result = populatePublishedAt(
+        createArgs({
+          operation: 'update',
+          data: { title: 'Updated Post' },
+          req: { data: { title: 'Updated Post' } },
+          originalDoc: { _status: 'draft' },
+        }),
+      )
+
+      expect(result).toEqual({
+        title: 'Updated Post',
+        publishedAt: new Date('2026-01-15T12:00:00Z'),
+      })
+    })
+
+    it('clears publishedAt when transitioning from published to draft', () => {
+      const result = populatePublishedAt(
+        createArgs({
+          operation: 'update',
+          data: { title: 'Post', _status: 'draft', publishedAt: '2025-01-01T00:00:00Z' },
+          req: { data: { _status: 'draft', publishedAt: '2025-01-01T00:00:00Z' } },
+          originalDoc: { _status: 'published', publishedAt: '2025-01-01T00:00:00Z' },
+        }),
+      )
+
+      expect(result).toEqual({
+        title: 'Post',
+        _status: 'draft',
+        publishedAt: null,
+      })
+    })
+
+    it('does not clear publishedAt when already a draft', () => {
+      const result = populatePublishedAt(
+        createArgs({
+          operation: 'update',
+          data: { title: 'Post', _status: 'draft' },
+          req: { data: { _status: 'draft' } },
+          originalDoc: { _status: 'draft' },
+        }),
+      )
+
+      expect(result).toEqual({
+        title: 'Post',
+        _status: 'draft',
+        publishedAt: new Date('2026-01-15T12:00:00Z'),
+      })
+    })
+  })
+})

--- a/src/hooks/populatePublishedAt.ts
+++ b/src/hooks/populatePublishedAt.ts
@@ -6,27 +6,32 @@ export const populatePublishedAt: CollectionBeforeChangeHook = ({
   originalDoc,
   req,
 }) => {
+  // On create: auto-set publishedAt if not provided
   if (operation === 'create' && req.data && !req.data.publishedAt) {
-    const now = new Date()
     return {
       ...data,
-      publishedAt: now,
+      publishedAt: new Date(),
     }
   }
 
-  if (operation === 'update') {
-    let publishedAtDate
-    if (req.data && !req.data.publishedAt) {
-      publishedAtDate = new Date()
+  if (operation === 'update' && req.data) {
+    // When transitioning from published to draft, clear the date
+    if (req.data._status === 'draft' && originalDoc._status === 'published') {
+      return {
+        ...data,
+        publishedAt: null,
+      }
     }
-    if (req.data && req.data._status === 'draft' && originalDoc._status === 'published') {
-      publishedAtDate = null
-    }
-    return {
-      ...data,
-      publishedAt: publishedAtDate,
+
+    // If no publishedAt provided, auto-set to now
+    if (!req.data.publishedAt) {
+      return {
+        ...data,
+        publishedAt: new Date(),
+      }
     }
   }
 
+  // Otherwise, preserve whatever is in data (including user-provided dates)
   return data
 }


### PR DESCRIPTION
## Description

When an editor updated the publish date on a post, it reverted to the original date on save. The `populatePublishedAt` hook always overwrote `publishedAt` — when the user provided their own date, the overwrite variable was `undefined`, clobbering the user's input.

## Related Issues

Fixes #1087

## Key Changes

- Restructured `src/hooks/populatePublishedAt.ts` to use early returns
- The hook now only overrides `publishedAt` when it explicitly needs to (auto-set on create, auto-set when missing on update, or clear on publish-to-draft transition)
- When the user provides a date, `data` passes through unchanged
- Added 6 unit tests covering all code paths

## How to test

1. Create a post with a publish date
2. Edit the post, change the publish date to a different date
3. Save — the new date should persist
4. Change status from published to draft — date should clear
5. Run `pnpm test -- __tests__/server/populatePublishedAt.server.test.ts`

## Screenshots / Demo video

N/A

## Migration Explanation

No migration needed — hook logic only.

## Future enhancements / Questions

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)