### PR TITLE
Fix column layout null validation and error display

### DIFF
--- a/__tests__/server/healColumnLayout.server.test.ts
+++ b/__tests__/server/healColumnLayout.server.test.ts
@@ -1,0 +1,94 @@
+import { healColumnLayout } from '@/blocks/Content/hooks/healColumnLayout'
+
+// Minimal mock for FieldHook args
+const createArgs = (overrides: Record<string, unknown>) =>
+  ({
+    collection: {} as never,
+    context: {},
+    data: {},
+    field: {} as never,
+    global: null,
+    indexPath: [],
+    operation: 'update',
+    originalDoc: {},
+    overrideAccess: false,
+    path: [],
+    previousSiblingDoc: {},
+    previousValue: undefined,
+    req: {} as never,
+    schemaPath: [],
+    siblingData: {},
+    siblingDocWithLocales: {},
+    siblingFields: [],
+    value: null,
+    blockData: undefined,
+    ...overrides,
+  }) as Parameters<typeof healColumnLayout>[0]
+
+describe('healColumnLayout', () => {
+  it('passes through valid layout values', () => {
+    const result = healColumnLayout(
+      createArgs({ value: '2_11', siblingData: { columns: [{}, {}] } }),
+    )
+    expect(result).toBe('2_11')
+  })
+
+  it('heals null to default layout', () => {
+    const result = healColumnLayout(createArgs({ value: null, siblingData: {} }))
+    expect(result).toBe('1_1')
+  })
+
+  it('heals undefined to default layout', () => {
+    const result = healColumnLayout(createArgs({ value: undefined, siblingData: {} }))
+    expect(result).toBe('1_1')
+  })
+
+  it('heals null to match current column count of 2', () => {
+    const result = healColumnLayout(createArgs({ value: null, siblingData: { columns: [{}, {}] } }))
+    expect(result).toBe('2_11')
+  })
+
+  it('heals null to match current column count of 3', () => {
+    const result = healColumnLayout(
+      createArgs({ value: null, siblingData: { columns: [{}, {}, {}] } }),
+    )
+    expect(result).toBe('3_111')
+  })
+
+  it('heals null to match current column count of 4', () => {
+    const result = healColumnLayout(
+      createArgs({ value: null, siblingData: { columns: [{}, {}, {}, {}] } }),
+    )
+    expect(result).toBe('4_1111')
+  })
+
+  it('heals invalid string value to default', () => {
+    const result = healColumnLayout(createArgs({ value: 'invalid', siblingData: {} }))
+    expect(result).toBe('1_1')
+  })
+
+  it('heals numeric value to default', () => {
+    const result = healColumnLayout(createArgs({ value: 42, siblingData: {} }))
+    expect(result).toBe('1_1')
+  })
+
+  it('passes through all valid layout values', () => {
+    const validLayouts = [
+      '1_1',
+      '2_11',
+      '2_12',
+      '2_21',
+      '3_111',
+      '3_112',
+      '3_121',
+      '3_211',
+      '4_1111',
+    ]
+    for (const layout of validLayouts) {
+      const colCount = parseInt(layout.split('_')[0])
+      const columns = Array.from({ length: colCount }, () => ({}))
+      const result = healColumnLayout(createArgs({ value: layout, siblingData: { columns } }))
+      expect(result).toBe(layout)
+    }
+  })
+})

--- a/__tests__/server/healColumnLayout.server.test.ts
+++ b/__tests__/server/healColumnLayout.server.test.ts
@@ -1,29 +1,15 @@
 import { healColumnLayout } from '@/blocks/Content/hooks/healColumnLayout'
 
-// Minimal mock for FieldHook args
-const createArgs = (overrides: Record<string, unknown>) =>
-  ({
-    collection: {} as never,
-    context: {},
-    data: {},
-    field: {} as never,
-    global: null,
-    indexPath: [],
-    operation: 'update',
-    originalDoc: {},
-    overrideAccess: false,
-    path: [],
-    previousSiblingDoc: {},
-    previousValue: undefined,
-    req: {} as never,
-    schemaPath: [],
-    siblingData: {},
-    siblingDocWithLocales: {},
-    siblingFields: [],
-    value: null,
-    blockData: undefined,
+// Builds a minimal mock of the hook args; only value and siblingData are used by the hook
+function createArgs(overrides: {
+  value: unknown
+  siblingData: Record<string, unknown>
+}): Parameters<typeof healColumnLayout>[0] {
+  // @ts-expect-error - partial mock; only value and siblingData are used by the hook
+  return {
     ...overrides,
-  }) as Parameters<typeof healColumnLayout>[0]
+  }
+}
 
 describe('healColumnLayout', () => {
   it('passes through valid layout values', () => {

--- a/src/blocks/Content/config.ts
+++ b/src/blocks/Content/config.ts
@@ -21,6 +21,7 @@ import { MediaBlock } from '../Media/config'
 import { SingleBlogPostBlock } from '../SingleBlogPost/config'
 import { SingleEventBlock } from '../SingleEvent/config'
 import { SponsorsBlock } from '../Sponsors/config'
+import { healColumnLayout } from './hooks/healColumnLayout'
 
 const validateColumnLayout: SelectFieldValidation = (value, args) => {
   const { siblingData } = args
@@ -36,7 +37,6 @@ const validateColumnLayout: SelectFieldValidation = (value, args) => {
     const selectedColCount = parseInt(value.split('_')[0])
 
     if (selectedColCount !== numOfCols) {
-      // TODO - figure out why error is not showing with custom field
       return `Selected layout requires ${selectedColCount} column${selectedColCount !== 1 ? 's' : ''}, but ${numOfCols} column${numOfCols !== 1 ? 's' : ''} exist${numOfCols === 1 ? 's' : ''}`
     }
   }
@@ -96,6 +96,9 @@ export const ContentBlock: Block = {
         },
       },
       validate: validateColumnLayout,
+      hooks: {
+        beforeChange: [healColumnLayout],
+      },
     },
     {
       type: 'ui',

--- a/src/blocks/Content/hooks/healColumnLayout.ts
+++ b/src/blocks/Content/hooks/healColumnLayout.ts
@@ -1,0 +1,31 @@
+import type { FieldHook } from 'payload'
+
+// Valid layout values and their column counts
+const VALID_LAYOUTS = ['1_1', '2_11', '2_12', '2_21', '3_111', '3_112', '3_121', '3_211', '4_1111']
+const DEFAULT_LAYOUT = '1_1'
+
+/**
+ * Self-heals null or invalid layout values to a sensible default.
+ * This fixes pages seeded with null layout values that would otherwise
+ * fail validation with no way for editors to fix them in the UI.
+ */
+export const healColumnLayout: FieldHook = ({ value, siblingData }) => {
+  // If value is already valid, pass through
+  if (typeof value === 'string' && VALID_LAYOUTS.includes(value)) {
+    return value
+  }
+
+  // Try to pick a layout matching the current column count
+  if (
+    siblingData &&
+    typeof siblingData === 'object' &&
+    'columns' in siblingData &&
+    Array.isArray(siblingData.columns)
+  ) {
+    const numCols = siblingData.columns.length
+    const match = VALID_LAYOUTS.find((l) => parseInt(l.split('_')[0]) === numCols)
+    if (match) return match
+  }
+
+  return DEFAULT_LAYOUT
+}

--- a/src/components/ColumnLayoutPicker/index.tsx
+++ b/src/components/ColumnLayoutPicker/index.tsx
@@ -28,7 +28,7 @@ const ColumnLayoutPicker = (props: ColumnLayoutPickerProps) => {
   )
 
   const { path, field } = props
-  const { value, setValue } = useField<string>({ path })
+  const { value, setValue, showError, errorMessage } = useField<string>({ path })
   const [layoutSelection, setLayoutSelection] = useState(value || '1_1')
 
   const parentPath = path.split(`.${field.name}`)[0]
@@ -58,6 +58,19 @@ const ColumnLayoutPicker = (props: ColumnLayoutPickerProps) => {
       }
     }
   }, [numColumns, layoutSelection, setValue, layoutOptions])
+
+  // When value is null/undefined (e.g., from bad seed data), auto-heal in the UI
+  useEffect(() => {
+    if (!value && numColumns && numColumns > 0) {
+      const validOption = layoutOptions.find(
+        (opt) => parseInt(opt.value.split('_')[0]) === numColumns,
+      )
+      if (validOption) {
+        setValue(validOption.value)
+        setLayoutSelection(validOption.value)
+      }
+    }
+  }, [value, numColumns, setValue, layoutOptions])
 
   if (numColumns === 0) return null
 
@@ -94,6 +107,7 @@ const ColumnLayoutPicker = (props: ColumnLayoutPickerProps) => {
         })}
       </ToggleGroup>
       <div className="field-description">Options update based on the number of columns.</div>
+      {showError && <div className="mt-2 text-sm text-red-500">{errorMessage}</div>}
     </div>
   )
 }


### PR DESCRIPTION
## Description

Pages created during the initial production seed had `null` values for their content block layout fields. This caused a validation error on save, and the custom `ColumnLayoutPicker` component didn't display the error or allow fixing the value.

## Related Issues

Fixes #1086

## Key Changes

- **Self-healing hook** (`src/blocks/Content/hooks/healColumnLayout.ts`): A `beforeChange` field hook that auto-fixes null/invalid layout values to a sensible default matching the current column count
- **Error display** (`src/components/ColumnLayoutPicker/index.tsx`): The custom component now uses `showError`/`errorMessage` from Payload's `useField` hook to display validation errors inline
- **UI auto-heal**: Added a `useEffect` that detects null values on mount and auto-selects a valid layout option matching the column count
- Removed the TODO comment about error display since it's now fixed
- Added 9 unit tests for the healing hook

## How to test

1. If you have a page with a null column layout (from early seed data), open it in the admin panel
2. The layout picker should auto-select a valid option
3. Save — should succeed without validation error
4. Run `pnpm test -- __tests__/server/healColumnLayout.server.test.ts`

## Screenshots / Demo video

https://www.loom.com/share/d8d56a158c404736b0a8adea17a15dea

## Migration Explanation

No migration needed — hook and UI logic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)