### PR TITLE
Fix cleanup workflow failing on merge-queue and dependabot branches

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -3,7 +3,7 @@ on:
   delete:
 jobs:
   cleanup:
-    if: ${{ github.event_name == 'workflow_dispatch' || (!contains(fromJson('["main", "release"]'), github.event.ref)) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (!contains(fromJson('["main", "release"]'), github.event.ref) && !startsWith(github.event.ref, 'gh-readonly-queue/') && !startsWith(github.event.ref, 'dependabot/')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Install Turso CLI
@@ -42,8 +42,7 @@ jobs:
             /home/runner/.turso/turso db destroy --yes "${name}"
             echo "[INFO] Successfully deleted database ${name}"
           else
-            echo "[ERROR] Database ${name} does not exist, expected it to be there for cleanup"
-            exit 1
+            echo "[WARN] Database ${name} does not exist, nothing to delete"
           fi
         env:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}


### PR DESCRIPTION
## Description

The `cleanup` workflow runs on every branch `delete` event and expected a preview database to exist for the deleted branch, exiting `1` otherwise. Merge-queue (`gh-readonly-queue/*`) and Dependabot branches never get a preview database — [`preview.yaml`](.github/workflows/preview.yaml) only creates one for PR head branches, and Dependabot PRs don't have access to the `Preview` environment secrets. So deleting those branches always failed cleanup.

Recent failing runs:
- [run 27154801923](https://github.com/NWACus/web/actions/runs/27154801923) — `gh-readonly-queue/main/pr-1088-...`
- [run 26062554277](https://github.com/NWACus/web/actions/runs/26062554277) — `dependabot/npm_and_yarn/protobufjs-...`

## Related Issues

N/A

## Key Changes

- Skip the cleanup job entirely for `gh-readonly-queue/*` and `dependabot/*` branches, which never have preview resources to clean up.
- Treat a missing preview database as a non-fatal warning instead of a hard failure, so any other branch without a DB no longer breaks cleanup.

## How to test

- Merge a PR through the merge queue and confirm the resulting `gh-readonly-queue/*` branch deletion no longer triggers a failing cleanup run.
- Close/merge a Dependabot PR and confirm its branch deletion no longer fails cleanup.
- Normal feature branches with a preview DB still get cleaned up as before.

## Screenshots / Demo video

N/A

## Migration Explanation

N/A

## Future enhancements / Questions

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)