### PR TITLE
Stabilize flaky admin e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,12 @@ jobs:
 
   e2e:
     name: e2e
-    if: github.event_name == 'merge_group'
+    # TODO(fix/stabilize-admin-e2e): remove the head_ref clause before merging.
+    # Temporarily run e2e on this PR (normally it only runs in the merge queue)
+    # to validate the e2e stability changes in real CI.
+    if: >-
+      github.event_name == 'merge_group' ||
+      github.head_ref == 'fix/stabilize-admin-e2e'
     environment: Preview
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,12 +135,7 @@ jobs:
 
   e2e:
     name: e2e
-    # TODO(fix/stabilize-admin-e2e): remove the head_ref clause before merging.
-    # Temporarily run e2e on this PR (normally it only runs in the merge queue)
-    # to validate the e2e stability changes in real CI.
-    if: >-
-      github.event_name == 'merge_group' ||
-      github.head_ref == 'fix/stabilize-admin-e2e'
+    if: github.event_name == 'merge_group'
     environment: Preview
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/__tests__/e2e/admin/collections/mcp-api-keys.e2e.spec.ts
+++ b/__tests__/e2e/admin/collections/mcp-api-keys.e2e.spec.ts
@@ -22,8 +22,6 @@ authTest.describe('MCP API Keys', () => {
   authTest.describe('Access Control', () => {
     authTest('super admin can view the MCP API Keys list', async ({ adminPage }) => {
       await adminPage.goto(mcpApiKeysUrl.list)
-      await adminPage.waitForLoadState('networkidle')
-
       // Should see the collection list view (table or empty state)
       const heading = adminPage.locator('.collection-list__header, h1')
       await expect(heading).toBeVisible({ timeout: 10000 })
@@ -38,8 +36,6 @@ authTest.describe('MCP API Keys', () => {
         const page = await loginAs(role)
 
         await page.goto(mcpApiKeysUrl.list)
-        await page.waitForLoadState('networkidle')
-
         // Payload hides the collection from non-super-admins entirely,
         // rendering a "Not Found" page instead of the list view.
         await expect(page.locator('text=Nothing found')).toBeVisible({ timeout: 10000 })
@@ -52,8 +48,6 @@ authTest.describe('MCP API Keys', () => {
       const page = await loginAs('singleTenantAdmin')
 
       await page.goto(mcpApiKeysUrl.admin)
-      await page.waitForLoadState('networkidle')
-
       const navLink = page.locator(`nav a[href*="${CollectionSlugs.mcpApiKeys}"]`)
       await expect(navLink).not.toBeVisible()
     })

--- a/__tests__/e2e/admin/collections/tenants.e2e.spec.ts
+++ b/__tests__/e2e/admin/collections/tenants.e2e.spec.ts
@@ -19,10 +19,7 @@ authTest.describe('Tenants', () => {
 
     authTest('slug dropdown only shows unused slugs', async ({ adminPage }) => {
       await adminPage.goto(tenantsUrl.list)
-      await adminPage.waitForLoadState('networkidle')
-
       await adminPage.goto(tenantsUrl.create)
-      await adminPage.waitForLoadState('networkidle')
       await waitForFormReady(adminPage)
 
       const slugField = adminPage.locator('#field-slug')
@@ -36,7 +33,6 @@ authTest.describe('Tenants', () => {
 
     authTest('selecting a slug auto-fills the name field', async ({ adminPage }) => {
       await adminPage.goto(tenantsUrl.create)
-      await adminPage.waitForLoadState('networkidle')
       await waitForFormReady(adminPage)
 
       const slugField = adminPage.locator('#field-slug')
@@ -63,8 +59,6 @@ authTest.describe('Tenants', () => {
       'slug field shows current value and read-only on existing tenant',
       async ({ adminPage }) => {
         await adminPage.goto(tenantsUrl.list)
-        await adminPage.waitForLoadState('networkidle')
-
         const firstLink = adminPage.locator('table tbody tr td a').first()
         await firstLink.waitFor({ timeout: 15000 })
         await firstLink.click()
@@ -88,8 +82,6 @@ authTest.describe('Tenants', () => {
 
     authTest('shows custom confirmation modal with type-to-confirm', async ({ adminPage }) => {
       await adminPage.goto(tenantsUrl.list)
-      await adminPage.waitForLoadState('networkidle')
-
       // Click the first tenant to open edit view
       const firstLink = adminPage.locator('table tbody tr td a').first()
       await firstLink.waitFor({ timeout: 15000 })
@@ -132,8 +124,6 @@ authTest.describe('Tenants', () => {
 
     authTest('shows error when typing wrong name', async ({ adminPage }) => {
       await adminPage.goto(tenantsUrl.list)
-      await adminPage.waitForLoadState('networkidle')
-
       const firstLink = adminPage.locator('table tbody tr td a').first()
       await firstLink.waitFor({ timeout: 15000 })
       await firstLink.click()

--- a/__tests__/e2e/admin/onboarding-checklist.e2e.spec.ts
+++ b/__tests__/e2e/admin/onboarding-checklist.e2e.spec.ts
@@ -14,6 +14,11 @@ async function getChecklist(page: import('@playwright/test').Page) {
   const checklist = page.locator('.rounded-lg', { has: heading })
   await expect(checklist).toBeVisible({ timeout: 10000 })
 
+  // On a tenant edit page the body is gated behind a provisioning-status server
+  // action that renders a "Loading..." spinner until it resolves; wait for that
+  // to clear so the checklist is fully loaded. (No tenant on create = no loader.)
+  await checklist.getByText('Loading...').waitFor({ state: 'hidden', timeout: 20000 })
+
   return checklist
 }
 

--- a/__tests__/e2e/admin/tenant-selector/dashboard.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/dashboard.e2e.spec.ts
@@ -23,8 +23,6 @@ test.describe('Tenant selector on dashboard', () => {
     const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
     await page.goto(url.dashboard)
-    await page.waitForLoadState('networkidle')
-
     const isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(true)
 
@@ -43,8 +41,6 @@ test.describe('Tenant selector on dashboard', () => {
     const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
     await page.goto(url.dashboard)
-    await page.waitForLoadState('networkidle')
-
     const isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(true)
 
@@ -62,8 +58,6 @@ test.describe('Tenant selector on dashboard', () => {
     const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
     await page.goto(url.dashboard)
-    await page.waitForLoadState('networkidle')
-
     // Single-tenant users have only 1 option, so selector is hidden
     const isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(false)

--- a/__tests__/e2e/admin/tenant-selector/global-collections.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/global-collections.e2e.spec.ts
@@ -32,8 +32,6 @@ test.describe('Global Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.settings)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       const isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(true)
 
@@ -52,12 +50,8 @@ test.describe('Global Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.settings)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       // Select NWAC tenant
       await selectTenant(page, TenantNames.nwac)
-      await page.waitForLoadState('networkidle')
-
       // Verify tenant selector shows NWAC
       const selectedTenant = await getSelectedTenant(page)
       expect(selectedTenant).toBe(TenantNames.nwac)
@@ -77,13 +71,9 @@ test.describe('Global Collection', () => {
 
       // Go to list and click first document
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       const firstRow = page.locator('table tbody tr').first()
       if (await firstRow.isVisible()) {
         await firstRow.click()
-        await page.waitForLoadState('networkidle')
-
         const isVisible = await isTenantSelectorVisible(page)
         expect(isVisible).toBe(true)
 
@@ -100,13 +90,9 @@ test.describe('Global Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.settings)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       const firstRow = page.locator('table tbody tr').first()
       if (await firstRow.isVisible()) {
         await firstRow.click()
-        await page.waitForLoadState('networkidle')
-
         const selector = await getTenantSelector(page)
         if (selector) {
           // Check that clear indicator is not visible (isClearable should be false in document view)
@@ -129,23 +115,16 @@ test.describe('Global Collection', () => {
 
       // Navigate to list and select NWAC via UI
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
       await selectTenant(page, TenantNames.nwac)
-      await page.waitForLoadState('networkidle')
-
       // Click first document (should be NWAC's settings)
       const firstRow = page.locator('table tbody tr').first()
       if (await firstRow.isVisible()) {
         await firstRow.click()
-        await page.waitForLoadState('networkidle')
-
         // Get current URL before switching
         const urlBeforeSwitch = page.url()
 
         // Change tenant selector to Sawtooth
         await selectTenant(page, TenantNames.snfac)
-        await page.waitForLoadState('networkidle')
-
         // URL should have changed (redirected to SNFAC's settings document)
         const urlAfterSwitch = page.url()
         expect(urlAfterSwitch).not.toBe(urlBeforeSwitch)
@@ -169,8 +148,6 @@ test.describe('Global Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.navigations)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       // List view
       let isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(true)
@@ -182,8 +159,6 @@ test.describe('Global Collection', () => {
       const firstRow = page.locator('table tbody tr').first()
       if (await firstRow.isVisible()) {
         await firstRow.click()
-        await page.waitForLoadState('networkidle')
-
         isVisible = await isTenantSelectorVisible(page)
         expect(isVisible).toBe(true)
 
@@ -205,8 +180,6 @@ test.describe('Global Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.homePages)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       // List view
       let isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(true)
@@ -218,8 +191,6 @@ test.describe('Global Collection', () => {
       const firstRow = page.locator('table tbody tr').first()
       if (await firstRow.isVisible()) {
         await firstRow.click()
-        await page.waitForLoadState('networkidle')
-
         isVisible = await isTenantSelectorVisible(page)
         expect(isVisible).toBe(true)
 

--- a/__tests__/e2e/admin/tenant-selector/non-tenant.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/non-tenant.e2e.spec.ts
@@ -31,8 +31,6 @@ test.describe('Non-Tenant Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.users)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       // Tenant selector should be hidden
       const isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(false)
@@ -48,14 +46,10 @@ test.describe('Non-Tenant Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.users)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       // Click first user in list
       const firstRow = page.locator('table tbody tr').first()
       if (await firstRow.isVisible()) {
         await firstRow.click()
-        await page.waitForLoadState('networkidle')
-
         const isVisible = await isTenantSelectorVisible(page)
         expect(isVisible).toBe(false)
       }
@@ -73,24 +67,16 @@ test.describe('Non-Tenant Collection', () => {
 
       // Select NWAC tenant via UI on a tenant-scoped collection
       await page.goto(settingsUrl.list)
-      await page.waitForLoadState('networkidle')
       await selectTenant(page, TenantNames.nwac)
-      await page.waitForLoadState('networkidle')
-
       // Visit users collection and count rows
       await page.goto(usersUrl.list)
-      await page.waitForLoadState('networkidle')
       const nwacUserCount = await page.locator('table tbody tr').count()
 
       // Switch to SNFAC tenant via UI
       await page.goto(settingsUrl.list)
-      await page.waitForLoadState('networkidle')
       await selectTenant(page, TenantNames.snfac)
-      await page.waitForLoadState('networkidle')
-
       // Visit users collection again and count rows
       await page.goto(usersUrl.list)
-      await page.waitForLoadState('networkidle')
       const snfacUserCount = await page.locator('table tbody tr').count()
 
       // User count should be the same regardless of tenant (no filtering)
@@ -106,8 +92,6 @@ test.describe('Non-Tenant Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.tenants)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       const isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(false)
 
@@ -121,8 +105,6 @@ test.describe('Non-Tenant Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.globalRoles)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       const isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(false)
 
@@ -136,8 +118,6 @@ test.describe('Non-Tenant Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.globalRoleAssignments)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       const isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(false)
 
@@ -151,8 +131,6 @@ test.describe('Non-Tenant Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.courses)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       const isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(false)
 
@@ -166,8 +144,6 @@ test.describe('Non-Tenant Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.providers)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       const isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(false)
 
@@ -186,26 +162,19 @@ test.describe('Non-Tenant Collection', () => {
       // Visit tenant-scoped collection and select a tenant via UI
       const pagesUrl = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
       await page.goto(pagesUrl.list)
-      await page.waitForLoadState('networkidle')
       await selectTenant(page, TenantNames.dvac)
-      await page.waitForLoadState('networkidle')
-
       const cookieBeforeNonTenant = await getTenantCookie(page)
       expect(cookieBeforeNonTenant).toBeTruthy()
 
       // Navigate to non-tenant collection
       const usersUrl = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.users)
       await page.goto(usersUrl.list)
-      await page.waitForLoadState('networkidle')
-
       // Cookie should still be the same
       const cookieAfterNonTenant = await getTenantCookie(page)
       expect(cookieAfterNonTenant).toBe(cookieBeforeNonTenant)
 
       // Navigate back to tenant-scoped collection
       await page.goto(pagesUrl.list)
-      await page.waitForLoadState('networkidle')
-
       // Cookie should still be preserved
       const cookieAfterBack = await getTenantCookie(page)
       expect(cookieAfterBack).toBe(cookieBeforeNonTenant)

--- a/__tests__/e2e/admin/tenant-selector/payload-globals.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/payload-globals.e2e.spec.ts
@@ -28,8 +28,6 @@ test.describe('Payload Global', () => {
       const url = new AdminUrlUtil('http://localhost:3000', '')
 
       await page.goto(url.global(GlobalSlugs.a3Management))
-      await page.waitForLoadState('networkidle')
-
       const isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(false)
 
@@ -43,24 +41,16 @@ test.describe('Payload Global', () => {
 
       // Select NWAC tenant via UI
       await page.goto(settingsUrl.list)
-      await page.waitForLoadState('networkidle')
       await selectTenant(page, TenantNames.nwac)
-      await page.waitForLoadState('networkidle')
-
       // Visit global - should load successfully
       await page.goto(globalUrl.global(GlobalSlugs.a3Management))
-      await page.waitForLoadState('networkidle')
       await expect(page.locator('h1')).toContainText('A3 Management', { timeout: 10000 })
 
       // Switch to SNFAC tenant via UI
       await page.goto(settingsUrl.list)
-      await page.waitForLoadState('networkidle')
       await selectTenant(page, TenantNames.snfac)
-      await page.waitForLoadState('networkidle')
-
       // Visit global again - should still load successfully
       await page.goto(globalUrl.global(GlobalSlugs.a3Management))
-      await page.waitForLoadState('networkidle')
       await expect(page.locator('h1')).toContainText('A3 Management', { timeout: 10000 })
 
       await page.context().close()
@@ -73,8 +63,6 @@ test.describe('Payload Global', () => {
       const url = new AdminUrlUtil('http://localhost:3000', '')
 
       await page.goto(url.global(GlobalSlugs.nacWidgetsConfig))
-      await page.waitForLoadState('networkidle')
-
       const isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(false)
 
@@ -88,8 +76,6 @@ test.describe('Payload Global', () => {
       const url = new AdminUrlUtil('http://localhost:3000', '')
 
       await page.goto(url.global(GlobalSlugs.diagnostics))
-      await page.waitForLoadState('networkidle')
-
       const isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(false)
 
@@ -111,17 +97,12 @@ test.describe('Payload Global', () => {
 
       // Set a valid tenant cookie via UI
       await page.goto(settingsUrl.list)
-      await page.waitForLoadState('networkidle')
       await selectTenant(page, TenantNames.nwac)
-      await page.waitForLoadState('networkidle')
-
       const cookieBefore = await getTenantCookie(page)
       expect(cookieBefore).toBeTruthy()
 
       // Visit a global
       await page.goto(globalUrl.global(GlobalSlugs.a3Management))
-      await page.waitForLoadState('networkidle')
-
       // Selector should be hidden on globals
       const isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(false)
@@ -132,8 +113,6 @@ test.describe('Payload Global', () => {
 
       // Navigate to a tenant collection
       await page.goto(pagesUrl.list)
-      await page.waitForLoadState('networkidle')
-
       // Cookie should still be preserved
       const cookieAfterCollection = await getTenantCookie(page)
       expect(cookieAfterCollection).toBe(cookieBefore)

--- a/__tests__/e2e/admin/tenant-selector/role-based.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/role-based.e2e.spec.ts
@@ -23,8 +23,6 @@ test.describe('Super Admin', () => {
     const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
-
     const options = await getTenantOptions(page)
 
     // Super admin should see all seeded tenants
@@ -46,23 +44,18 @@ test.describe('Super Admin', () => {
     const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
-
     // Switch to NWAC
     await selectTenant(page, TenantNames.nwac)
-    await page.waitForLoadState('networkidle')
     let selected = await getSelectedTenant(page)
     expect(selected).toBe(TenantNames.nwac)
 
     // Switch to SNFAC
     await selectTenant(page, TenantNames.snfac)
-    await page.waitForLoadState('networkidle')
     selected = await getSelectedTenant(page)
     expect(selected).toBe(TenantNames.snfac)
 
     // Switch to DVAC
     await selectTenant(page, TenantNames.dvac)
-    await page.waitForLoadState('networkidle')
     selected = await getSelectedTenant(page)
     expect(selected).toBe(TenantNames.dvac)
 
@@ -78,21 +71,18 @@ test.describe('Super Admin', () => {
     // Access tenant collection
     const pagesUrl = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
     await page.goto(pagesUrl.list)
-    await page.waitForLoadState('networkidle')
     let isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(true)
 
     // Access non-tenant collection
     const usersUrl = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.users)
     await page.goto(usersUrl.list)
-    await page.waitForLoadState('networkidle')
     isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(false)
 
     // Access global roles (non-tenant)
     const rolesUrl = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.globalRoles)
     await page.goto(rolesUrl.list)
-    await page.waitForLoadState('networkidle')
     isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(false)
 
@@ -107,8 +97,6 @@ test.describe('Multi-Center Admin', () => {
     const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
-
     const options = await getTenantOptions(page)
 
     // Should see NWAC and SNFAC
@@ -131,17 +119,13 @@ test.describe('Multi-Center Admin', () => {
     const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
-
     // Switch to NWAC
     await selectTenant(page, TenantNames.nwac)
-    await page.waitForLoadState('networkidle')
     let selected = await getSelectedTenant(page)
     expect(selected).toBe(TenantNames.nwac)
 
     // Switch to SNFAC
     await selectTenant(page, TenantNames.snfac)
-    await page.waitForLoadState('networkidle')
     selected = await getSelectedTenant(page)
     expect(selected).toBe(TenantNames.snfac)
 
@@ -159,8 +143,6 @@ test.describe('Single-Center Admin', () => {
     const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
-
     // Tenant selector should be hidden when user has only 1 tenant
     const isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(false)
@@ -176,11 +158,8 @@ test.describe('Single-Center Admin', () => {
     const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
-
     // Cookie should be set to their tenant (nwac)
-    const cookie = await getTenantCookie(page)
-    expect(cookie).toBe(TenantSlugs.nwac)
+    await expect.poll(() => getTenantCookie(page)).toBe(TenantSlugs.nwac)
 
     await page.context().close()
   })
@@ -197,10 +176,7 @@ test.describe('Single-Center Admin', () => {
     for (const slug of collectionsToCheck) {
       const url = new AdminUrlUtil('http://localhost:3000', slug)
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
-      const cookie = await getTenantCookie(page)
-      expect(cookie).toBe(TenantSlugs.nwac)
+      await expect.poll(() => getTenantCookie(page)).toBe(TenantSlugs.nwac)
     }
 
     await page.context().close()
@@ -218,15 +194,12 @@ test.describe('Forecaster Role', () => {
     const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
-
     // Tenant selector should be hidden (only 1 tenant)
     const isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(false)
 
     // Cookie should be set to NWAC
-    const cookie = await getTenantCookie(page)
-    expect(cookie).toBe(TenantSlugs.nwac)
+    await expect.poll(() => getTenantCookie(page)).toBe(TenantSlugs.nwac)
 
     await page.context().close()
   })
@@ -243,15 +216,12 @@ test.describe('Staff Role', () => {
     const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
-
     // Tenant selector should be hidden (only 1 tenant)
     const isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(false)
 
     // Cookie should be set to NWAC
-    const cookie = await getTenantCookie(page)
-    expect(cookie).toBe(TenantSlugs.nwac)
+    await expect.poll(() => getTenantCookie(page)).toBe(TenantSlugs.nwac)
 
     await page.context().close()
   })

--- a/__tests__/e2e/admin/tenant-selector/sync-on-save.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/sync-on-save.e2e.spec.ts
@@ -84,7 +84,11 @@ async function createTenant(
 
   // Fill name after slug selection — AutoFillNameFromSlug overwrites name on slug change
   await page.locator('#field-name').fill(name)
-  await saveDocAndAssert(page)
+  // A successful create redirects to the new tenant's edit page. Wait for that
+  // rather than the success toast: creating a tenant immediately kicks off
+  // provisioning, whose own toast can replace the save toast before we see it.
+  await page.click('#action-save')
+  await page.waitForURL(/\/collections\/tenants\/\d+/, { timeout: 30000 })
 
   return slug
 }
@@ -131,10 +135,11 @@ test.describe('Tenant selector syncs on save', () => {
     try {
       slug = await createTenant(page, TEMP_TENANT_NAME)
 
-      // We're already on the edit page after creation — rename the tenant
+      // We're already on the edit page after creation — rename the tenant.
+      // Provisioning from the create may still be settling, so allow extra time.
       await waitForFormReady(page)
       await page.locator('#field-name').fill(UPDATED_TENANT_NAME)
-      await saveDocAndAssert(page)
+      await saveDocAndAssert(page, '#action-save', 'success', { timeout: 30000 })
 
       // Navigate to a tenant-scoped collection via client-side nav link (NOT page.goto)
       await openNav(page)

--- a/__tests__/e2e/admin/tenant-selector/tenant-cookie-edge-cases.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/tenant-cookie-edge-cases.e2e.spec.ts
@@ -32,8 +32,6 @@ test.describe('Tenant Cookie Edge Cases', () => {
 
     // Navigate to a tenant-required collection
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
-
     // Page should load without crashing and show the collection list
     await expect(page.locator('table')).toBeVisible({ timeout: 10000 })
 
@@ -63,8 +61,6 @@ test.describe('Tenant Cookie Edge Cases', () => {
 
     const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
-
     // Page should load without crashing
     await expect(page.locator('table')).toBeVisible({ timeout: 10000 })
 
@@ -94,18 +90,13 @@ test.describe('Tenant Cookie Edge Cases', () => {
 
     // Set tenant to DVAC
     await page.goto(pagesUrl.list)
-    await page.waitForLoadState('networkidle')
     await selectTenant(page, TenantNames.dvac)
-    await page.waitForLoadState('networkidle')
-
     // Cookie should be set after selecting a tenant (stores tenant slug)
     const cookieAfterSelect = await getTenantCookie(page)
     expect(cookieAfterSelect).toBeTruthy()
 
     // Navigate to another collection
     await page.goto(postsUrl.list)
-    await page.waitForLoadState('networkidle')
-
     // Cookie should persist with the same value
     const cookieAfterNav = await getTenantCookie(page)
     expect(cookieAfterNav).toBe(cookieAfterSelect)
@@ -128,20 +119,14 @@ test.describe('Tenant Cookie Edge Cases', () => {
 
     // Select a tenant via UI (sets cookie to tenant slug)
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
     await selectTenant(page, TenantNames.snfac)
-    await page.waitForLoadState('networkidle')
-
-    const cookie = await getTenantCookie(page)
-    expect(cookie).toBeTruthy()
+    await expect.poll(() => getTenantCookie(page)).toBeTruthy()
 
     // Clear the cookie
     await setTenantCookie(page, undefined)
 
     // Navigate to admin again - page should load without crashing
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
-
     await expect(page.locator('table')).toBeVisible({ timeout: 10000 })
 
     await page.context().close()
@@ -159,25 +144,17 @@ test.describe('Navigation & State Consistency', () => {
 
     // Select a tenant via UI
     await page.goto(url.list)
-    await page.waitForLoadState('networkidle')
     await selectTenant(page, TenantNames.nwac)
-    await page.waitForLoadState('networkidle')
-
     const firstRow = page.locator('table tbody tr').first()
     if (await firstRow.isVisible()) {
       await firstRow.click()
-      await page.waitForLoadState('networkidle')
-
       // Get the cookie while viewing the document
       const docTenantCookie = await getTenantCookie(page)
       expect(docTenantCookie).toBe(TenantSlugs.nwac)
 
       // Navigate away and back using browser history
       await page.goBack()
-      await page.waitForLoadState('networkidle')
       await page.goForward()
-      await page.waitForLoadState('networkidle')
-
       // Cookie should still be the same
       const cookieAfterReturn = await getTenantCookie(page)
       expect(cookieAfterReturn).toBe(docTenantCookie)
@@ -195,23 +172,17 @@ test.describe('Navigation & State Consistency', () => {
     // Start at tenant-required collection
     const pagesUrl = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
     await page.goto(pagesUrl.list)
-    await page.waitForLoadState('networkidle')
-
     let isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(true)
 
     // Navigate to non-tenant collection
     const usersUrl = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.users)
     await page.goto(usersUrl.list)
-    await page.waitForLoadState('networkidle')
-
     isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(false)
 
     // Navigate back to tenant collection
     await page.goto(pagesUrl.list)
-    await page.waitForLoadState('networkidle')
-
     isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(true)
 
@@ -228,8 +199,6 @@ test.describe('Dashboard View', () => {
     const page = await loginAs('superAdmin')
 
     await page.goto('/admin')
-    await page.waitForLoadState('networkidle')
-
     const isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(true)
 
@@ -247,15 +216,10 @@ test.describe('Dashboard View', () => {
     const page = await loginAs('superAdmin')
 
     await page.goto('/admin')
-    await page.waitForLoadState('networkidle')
-
     // Select Sawtooth Avalanche Center
     await selectTenant(page, TenantNames.snfac)
-    await page.waitForLoadState('networkidle')
-
     // Cookie should be set after selecting a tenant (stores tenant slug)
-    const cookie = await getTenantCookie(page)
-    expect(cookie).toBe(TenantSlugs.snfac)
+    await expect.poll(() => getTenantCookie(page)).toBe(TenantSlugs.snfac)
 
     await page.context().close()
   })
@@ -267,8 +231,6 @@ test.describe('Dashboard View', () => {
     const page = await loginAs('singleTenantAdmin')
 
     await page.goto('/admin')
-    await page.waitForLoadState('networkidle')
-
     // Single-tenant user shouldn't see the selector
     const isVisible = await isTenantSelectorVisible(page)
     expect(isVisible).toBe(false)

--- a/__tests__/e2e/admin/tenant-selector/tenant-required.e2e.spec.ts
+++ b/__tests__/e2e/admin/tenant-selector/tenant-required.e2e.spec.ts
@@ -33,8 +33,6 @@ test.describe('Tenant-Required Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       const isVisible = await isTenantSelectorVisible(page)
       expect(isVisible).toBe(true)
 
@@ -54,21 +52,16 @@ test.describe('Tenant-Required Collection', () => {
       const url = new AdminUrlUtil('http://localhost:3000', CollectionSlugs.pages)
 
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
-
       // Select NWAC tenant
       await selectTenant(page, TenantNames.nwac)
 
       // Wait for page to refresh/filter
-      await page.waitForLoadState('networkidle')
-
       // Verify tenant selector shows NWAC
       const selectedTenant = await getSelectedTenant(page)
       expect(selectedTenant).toBe(TenantNames.nwac)
 
       // Verify cookie was updated
-      const cookie = await getTenantCookie(page)
-      expect(cookie).toBe(TenantSlugs.nwac)
+      await expect.poll(() => getTenantCookie(page)).toBe(TenantSlugs.nwac)
 
       await page.context().close()
     })
@@ -82,17 +75,12 @@ test.describe('Tenant-Required Collection', () => {
 
       // Set tenant to NWAC first
       await page.goto(url.list)
-      await page.waitForLoadState('networkidle')
       await selectTenant(page, TenantNames.nwac)
-      await page.waitForLoadState('networkidle')
-
       // Get count of NWAC pages
       const nwacRows = await page.locator('table tbody tr').count()
 
       // Switch to SNFAC
       await selectTenant(page, TenantNames.snfac)
-      await page.waitForLoadState('networkidle')
-
       // Get count of SNFAC pages (should be different or at least reflect filtering)
       const snfacRows = await page.locator('table tbody tr').count()
 
@@ -118,16 +106,11 @@ test.describe('Tenant-Required Collection', () => {
 
         // Select a tenant first so the list is filtered
         await page.goto(url.list)
-        await page.waitForLoadState('networkidle')
         await selectTenant(page, TenantNames.nwac)
-        await page.waitForLoadState('networkidle')
-
         // Click the first document link in the list
         const firstLink = page.locator('table tbody tr td a').first()
         await expect(firstLink).toBeVisible()
         await firstLink.click()
-        await page.waitForLoadState('networkidle')
-
         const isVisible = await isTenantSelectorVisible(page)
         expect(isVisible).toBe(true)
 
@@ -144,10 +127,7 @@ test.describe('Tenant-Required Collection', () => {
 
         // Select NWAC via UI so the cookie has a valid tenant ID
         await page.goto(url.list)
-        await page.waitForLoadState('networkidle')
         await selectTenant(page, TenantNames.nwac)
-        await page.waitForLoadState('networkidle')
-
         const cookieBefore = await getTenantCookie(page)
         expect(cookieBefore).toBeTruthy()
 
@@ -155,8 +135,6 @@ test.describe('Tenant-Required Collection', () => {
         const firstLink = page.locator('table tbody tr td a').first()
         await expect(firstLink).toBeVisible()
         await firstLink.click()
-        await page.waitForLoadState('networkidle')
-
         // Cookie should still be set after navigating to the document
         const cookieAfter = await getTenantCookie(page)
         expect(cookieAfter).toBe(cookieBefore)
@@ -174,16 +152,11 @@ test.describe('Tenant-Required Collection', () => {
 
         // Select NWAC via UI
         await page.goto(url.list)
-        await page.waitForLoadState('networkidle')
         await selectTenant(page, TenantNames.nwac)
-        await page.waitForLoadState('networkidle')
-
         // Click the first document link
         const firstLink = page.locator('table tbody tr td a').first()
         await expect(firstLink).toBeVisible()
         await firstLink.click()
-        await page.waitForLoadState('networkidle')
-
         // Tenant selector should show NWAC (matching the filtered list)
         const selectorTenant = await getSelectedTenant(page)
         expect(selectorTenant).toBe(TenantNames.nwac)
@@ -204,13 +177,8 @@ test.describe('Tenant-Required Collection', () => {
 
         // Select NWAC tenant via UI before navigating to create
         await page.goto(url.list)
-        await page.waitForLoadState('networkidle')
         await selectTenant(page, TenantNames.nwac)
-        await page.waitForLoadState('networkidle')
-
         await page.goto(url.create)
-        await page.waitForLoadState('networkidle')
-
         const isVisible = await isTenantSelectorVisible(page)
         expect(isVisible).toBe(true)
 
@@ -230,13 +198,8 @@ test.describe('Tenant-Required Collection', () => {
 
         // Select NWAC tenant via UI before navigating to create
         await page.goto(url.list)
-        await page.waitForLoadState('networkidle')
         await selectTenant(page, TenantNames.nwac)
-        await page.waitForLoadState('networkidle')
-
         await page.goto(url.create)
-        await page.waitForLoadState('networkidle')
-
         // Tenant selector should show NWAC
         const selectedTenant = await getSelectedTenant(page)
         expect(selectedTenant).toBe(TenantNames.nwac)

--- a/__tests__/e2e/admin/view-document-button.e2e.spec.ts
+++ b/__tests__/e2e/admin/view-document-button.e2e.spec.ts
@@ -1,139 +1,111 @@
 import { authTest, expect } from '../fixtures/auth.fixture'
 import { AdminUrlUtil } from '../helpers/admin-url'
-import { saveDocAndAssert } from '../helpers/save-doc'
-import { setTenantCookie, TenantSlugs } from '../helpers/tenant-cookie'
+import { saveDocAndAssert, waitForFormReady } from '../helpers/save-doc'
+import { setTenantCookie, TenantIds, TenantSlugs } from '../helpers/tenant-cookie'
 
 const SERVER_URL = 'http://localhost:3000'
 
-authTest.describe('ViewDocumentButton on published documents', () => {
-  authTest.describe.configure({ timeout: 60000 })
+// Serial: the "hides" tests unpublish a shared seed doc, which would race the
+// "shows" tests if both ran in parallel against the same first-published doc.
+authTest.describe.configure({ mode: 'serial', timeout: 90000 })
 
+const SUCCESS_TOAST =
+  '.toast-success, .Toastify__toast--success, [data-sonner-toast][data-type="success"]'
+
+// First published doc id for a tenant, so tests navigate straight to the edit
+// view instead of racing the admin list render. Published docs are public-read.
+async function firstPublishedId(
+  page: import('@playwright/test').Page,
+  collection: 'posts' | 'pages',
+  tenantId: number,
+): Promise<number> {
+  const res = await page.request.get(
+    `${SERVER_URL}/api/${collection}?where[_status][equals]=published&where[tenant][equals]=${tenantId}&limit=1&depth=0`,
+  )
+  expect(res.ok(), `failed to query published ${collection}`).toBeTruthy()
+  const id = (await res.json()).docs?.[0]?.id
+  expect(id, `no published ${collection} found for tenant ${tenantId}`).toBeTruthy()
+  return id
+}
+
+authTest.describe('ViewDocumentButton on published documents', () => {
   authTest('shows live document button on a published post', async ({ adminPage }) => {
     const postsUrl = new AdminUrlUtil(SERVER_URL, 'posts')
-
     await setTenantCookie(adminPage.context(), TenantSlugs.nwac)
-    await adminPage.goto(`${postsUrl.list}?where[_status][equals]=published`)
 
-    // Use the first published post
-    const firstLink = adminPage.locator('table tbody tr td a').first()
-    await firstLink.waitFor({ timeout: 15000 })
-    await firstLink.click()
+    const postId = await firstPublishedId(adminPage, 'posts', Number(TenantIds.nwac))
+    await adminPage.goto(postsUrl.edit(postId))
 
-    // Wait for the document edit view to load
-    await adminPage.waitForURL(/\/collections\/posts\/\d+/)
-
-    // The live document button should be visible for published posts
-    await expect(adminPage.locator('#view-document-button')).toBeVisible({ timeout: 10000 })
+    await expect(adminPage.locator('#view-document-button')).toBeVisible()
   })
 
   authTest('shows live document button on a published page', async ({ adminPage }) => {
     const pagesUrl = new AdminUrlUtil(SERVER_URL, 'pages')
-
     await setTenantCookie(adminPage.context(), TenantSlugs.nwac)
-    await adminPage.goto(`${pagesUrl.list}?where[_status][equals]=published`)
 
-    // Use the first published post
-    const firstLink = adminPage.locator('table tbody tr td a').first()
-    await firstLink.waitFor({ timeout: 15000 })
-    await firstLink.click()
+    const pageId = await firstPublishedId(adminPage, 'pages', Number(TenantIds.nwac))
+    await adminPage.goto(pagesUrl.edit(pageId))
 
-    await adminPage.waitForURL(/\/collections\/pages\/\d+/)
-
-    await expect(adminPage.locator('#view-document-button')).toBeVisible({ timeout: 10000 })
+    await expect(adminPage.locator('#view-document-button')).toBeVisible()
   })
 })
 
 authTest.describe('ViewDocumentButton hidden on draft documents', () => {
-  authTest.describe.configure({ mode: 'serial', timeout: 90000 })
-
   // Track the document URL so afterEach can re-publish even if the test fails
   let unpublishedDocUrl: string | null = null
 
   authTest.afterEach(async ({ adminPage }) => {
     if (unpublishedDocUrl) {
       await adminPage.goto(unpublishedDocUrl)
-      await adminPage.waitForLoadState('networkidle')
+      await waitForFormReady(adminPage)
       await saveDocAndAssert(adminPage, '#action-save')
       unpublishedDocUrl = null
     }
   })
 
+  async function unpublishCurrentDoc(page: import('@playwright/test').Page) {
+    await page.locator('.doc-controls__popup .popup-button').click()
+    // Popup content is portaled to body, so use a global (unscoped) selector
+    const unpublishButton = page.getByRole('button', { name: 'Unpublish', exact: true })
+    await unpublishButton.waitFor({ timeout: 10000 })
+    await unpublishButton.click()
+    await page.locator('#confirm-action').click()
+
+    unpublishedDocUrl = page.url()
+    await expect(page.locator(SUCCESS_TOAST)).toBeVisible({ timeout: 15000 })
+  }
+
   authTest('hides live document button on a draft post', async ({ adminPage }) => {
     const postsUrl = new AdminUrlUtil(SERVER_URL, 'posts')
-
     await setTenantCookie(adminPage.context(), TenantSlugs.nwac)
-    await adminPage.goto(`${postsUrl.list}?where[_status][equals]=published`)
 
-    // Use the first published post
-    const firstLink = adminPage.locator('table tbody tr td a').first()
-    await firstLink.waitFor({ timeout: 15000 })
-    await firstLink.click()
-    await adminPage.waitForURL(/\/collections\/posts\/\d+/)
+    const postId = await firstPublishedId(adminPage, 'posts', Number(TenantIds.nwac))
+    await adminPage.goto(postsUrl.edit(postId))
+    await expect(adminPage.locator('#view-document-button')).toBeVisible()
 
-    await expect(adminPage.locator('#view-document-button')).toBeVisible({ timeout: 10000 })
+    await unpublishCurrentDoc(adminPage)
 
-    // Unpublish: open the doc controls popup (three dots menu) and click unpublish
-    await adminPage.locator('.doc-controls__popup .popup-button').click()
-    // Popup content is portaled to body, so use a global selector
-    const unpublishButton = adminPage.getByRole('button', { name: 'Unpublish', exact: true })
-    await unpublishButton.waitFor({ timeout: 5000 })
-    await unpublishButton.click()
-
-    await adminPage.locator('#confirm-action').click()
-
-    // Store the URL so afterEach can re-publish if we fail below
-    unpublishedDocUrl = adminPage.url()
-
-    // Wait for the unpublish success toast
-    await expect(
-      adminPage.locator(
-        '.toast-success, .Toastify__toast--success, [data-sonner-toast][data-type="success"]',
-      ),
-    ).toBeVisible({ timeout: 15000 })
-
-    // Reload to get the server-rendered state (button is server-side rendered)
+    // Button is server-rendered, so reload to re-read it
     await adminPage.reload()
-    await adminPage.waitForLoadState('networkidle')
+    await waitForFormReady(adminPage)
 
-    await expect(adminPage.locator('#view-document-button')).not.toBeVisible({ timeout: 10000 })
+    await expect(adminPage.locator('#view-document-button')).not.toBeVisible()
   })
 
   authTest('hides live document button on a draft page', async ({ adminPage }) => {
     const pagesUrl = new AdminUrlUtil(SERVER_URL, 'pages')
-
     await setTenantCookie(adminPage.context(), TenantSlugs.nwac)
-    await adminPage.goto(`${pagesUrl.list}?where[_status][equals]=published`)
 
-    // Use the first published page
-    const firstLink = adminPage.locator('table tbody tr td a').first()
-    await firstLink.waitFor({ timeout: 15000 })
-    await firstLink.click()
-    await adminPage.waitForURL(/\/collections\/pages\/\d+/)
+    const pageId = await firstPublishedId(adminPage, 'pages', Number(TenantIds.nwac))
+    await adminPage.goto(pagesUrl.edit(pageId))
+    await expect(adminPage.locator('#view-document-button')).toBeVisible()
 
-    await expect(adminPage.locator('#view-document-button')).toBeVisible({ timeout: 10000 })
+    await unpublishCurrentDoc(adminPage)
 
-    // Unpublish: open the doc controls popup (three dots menu) and click unpublish
-    await adminPage.locator('.doc-controls__popup .popup-button').click()
-    // Popup content is portaled to body, so use a global selector
-    const unpublishButton = adminPage.getByRole('button', { name: 'Unpublish', exact: true })
-    await unpublishButton.waitFor({ timeout: 5000 })
-    await unpublishButton.click()
-
-    await adminPage.locator('#confirm-action').click()
-
-    // Store the URL so afterEach can re-publish if we fail below
-    unpublishedDocUrl = adminPage.url()
-
-    await expect(
-      adminPage.locator(
-        '.toast-success, .Toastify__toast--success, [data-sonner-toast][data-type="success"]',
-      ),
-    ).toBeVisible({ timeout: 15000 })
-
-    // Reload to get the server-rendered state (button is server-side rendered)
+    // Button is server-rendered, so reload to re-read it
     await adminPage.reload()
-    await adminPage.waitForLoadState('networkidle')
+    await waitForFormReady(adminPage)
 
-    await expect(adminPage.locator('#view-document-button')).not.toBeVisible({ timeout: 10000 })
+    await expect(adminPage.locator('#view-document-button')).not.toBeVisible()
   })
 })

--- a/__tests__/e2e/auth.setup.ts
+++ b/__tests__/e2e/auth.setup.ts
@@ -1,16 +1,21 @@
 import { test as setup } from '@playwright/test'
 import { testUsers, type UserRole } from './fixtures/test-users'
-import { performLogin } from './helpers'
 import { authFile } from './helpers/auth-state'
 
-// Run setup logins serially to avoid overwhelming the dev server,
-// and with a longer timeout since each login involves form hydration.
-setup.describe.configure({ mode: 'serial', timeout: 60000 })
-
+// Authenticate via the REST login endpoint rather than driving the login form.
+// It sets the same `payload-token` cookie the UI flow does, but skips form
+// hydration (the main source of setup flakiness) and route compilation, so it's
+// far faster and more reliable. The login *form* itself is covered by
+// admin/login.e2e.spec.ts.
 for (const [role, user] of Object.entries(testUsers)) {
-  setup(`authenticate as ${role}`, async ({ page }) => {
-    await performLogin(page, user.email, user.password)
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    await page.context().storageState({ path: authFile(role as UserRole) })
+  setup(`authenticate as ${role}`, async ({ request }) => {
+    const res = await request.post('/api/users/login', {
+      data: { email: user.email, password: user.password },
+    })
+    if (!res.ok()) {
+      throw new Error(`API login failed for ${user.email} (${res.status()}): ${await res.text()}`)
+    }
+    // Persists the payload-token cookie set by the login response.
+    await request.storageState({ path: authFile(role as UserRole) })
   })
 }

--- a/__tests__/e2e/auth.setup.ts
+++ b/__tests__/e2e/auth.setup.ts
@@ -1,5 +1,5 @@
 import { test as setup } from '@playwright/test'
-import { testUsers, type UserRole } from './fixtures/test-users'
+import { testUsers, userRoles } from './fixtures/test-users'
 import { authFile } from './helpers/auth-state'
 
 // Authenticate via the REST login endpoint rather than driving the login form.
@@ -7,15 +7,16 @@ import { authFile } from './helpers/auth-state'
 // hydration (the main source of setup flakiness) and route compilation, so it's
 // far faster and more reliable. The login *form* itself is covered by
 // admin/login.e2e.spec.ts.
-for (const [role, user] of Object.entries(testUsers)) {
+for (const role of userRoles) {
   setup(`authenticate as ${role}`, async ({ request }) => {
+    const { email, password } = testUsers[role]
     const res = await request.post('/api/users/login', {
-      data: { email: user.email, password: user.password },
+      data: { email, password },
     })
     if (!res.ok()) {
-      throw new Error(`API login failed for ${user.email} (${res.status()}): ${await res.text()}`)
+      throw new Error(`API login failed for ${email} (${res.status()}): ${await res.text()}`)
     }
     // Persists the payload-token cookie set by the login response.
-    await request.storageState({ path: authFile(role as UserRole) })
+    await request.storageState({ path: authFile(role) })
   })
 }

--- a/__tests__/e2e/fixtures/tenant-selector.fixture.ts
+++ b/__tests__/e2e/fixtures/tenant-selector.fixture.ts
@@ -151,6 +151,12 @@ export const tenantSelectorTest = base.extend<TenantSelectorFixtures>({
         selectLocator: selector,
         option: tenantName,
       })
+
+      // Wait until the selection lands in the tenant cookie so callers read
+      // settled state. This is the deterministic signal that replaces the
+      // `waitForLoadState('networkidle')` that used to follow selectTenant.
+      const slug = Object.entries(TenantNames).find(([, name]) => name === tenantName)?.[0]
+      if (slug) await waitForTenantCookie(page, slug)
     }
     // eslint-disable-next-line react-hooks/rules-of-hooks -- Playwright's `use` is not a React hook
     await use(doSelectTenant)

--- a/__tests__/e2e/fixtures/test-users.ts
+++ b/__tests__/e2e/fixtures/test-users.ts
@@ -93,3 +93,19 @@ export function getTestUser(role: UserRole): TestUser {
 
 /** All user roles for parameterized tests */
 export const allUserRoles = Object.keys(testUsers)
+
+/**
+ * Typed list of every role. Iterate this (rather than Object.keys/entries,
+ * which TypeScript widens to `string`) when you need each role typed as
+ * `UserRole` without a cast.
+ */
+export const userRoles: readonly UserRole[] = [
+  'superAdmin',
+  'providerManager',
+  'multiTenantAdmin',
+  'singleTenantAdmin',
+  'singleTenantForecaster',
+  'singleTenantStaff',
+  'providerUser',
+  'multiProviderUser',
+]

--- a/__tests__/e2e/helpers/save-doc.ts
+++ b/__tests__/e2e/helpers/save-doc.ts
@@ -16,11 +16,11 @@ export async function saveDocAndAssert(
   options?: {
     /** If true, don't dismiss toasts after assertion */
     disableDismissAllToasts?: boolean
-    /** Timeout for waiting for toast (default: 10000) */
+    /** Timeout for waiting for toast (default: 15000) */
     timeout?: number
   },
 ): Promise<void> {
-  const timeout = options?.timeout ?? 10000
+  const timeout = options?.timeout ?? 15000
 
   const toastSelector =
     expectation === 'success'
@@ -53,7 +53,7 @@ export async function saveDocHotkeyAndAssert(
     timeout?: number
   },
 ): Promise<void> {
-  const timeout = options?.timeout ?? 10000
+  const timeout = options?.timeout ?? 15000
   const modifier = process.platform === 'darwin' ? 'Meta' : 'Control'
 
   await page.keyboard.press(`${modifier}+s`)

--- a/consistent-type-assertions.txt
+++ b/consistent-type-assertions.txt
@@ -1,4 +1,3 @@
-__tests__/e2e/auth.setup.ts
 __tests__/server/duplicatePageToTenant.server.test.ts
 __tests__/server/revalidateDocument.server.test.ts
 src/app/(frontend)/[center]/[...segments]/page.tsx

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
   workers: process.env.CI ? 4 : undefined,
   reporter: process.env.CI ? 'github' : 'html',
   timeout: 30000,
+  // The Payload admin can take more than Playwright's 5s default to settle under
+  // CI load, so give implicit assertion waits more headroom.
+  expect: { timeout: 10000 },
   use: {
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',


### PR DESCRIPTION
## Description

The merge-queue (`merge_group`) CI runs the admin Playwright e2e suite, and it has been failing intermittently across multiple PRs — on **different** admin tests each run (onboarding-checklist, tenant-selector, view-document-button, publishedAt). This is timing / shared-state / setup flakiness in the admin suite, not a regression in any one PR, and it currently blocks the merge queue for everyone.

This PR hardens the documented failure modes, removes the suite's biggest slowness/flakiness source (a UI-driven auth setup and pervasive `networkidle` waits), and temporarily enables e2e on this PR so the changes are validated in real CI.

## Related Issues

N/A — surfaced from repeated `merge_group` CI failures.

## Key Changes

**Stability fixes for the documented failures**
- **`playwright.config.ts`** — set `expect: { timeout: 10000 }`. Without a global expect timeout, implicit web-first assertions only got Playwright's 5s default, which the Payload admin routinely exceeds under load. This was the direct cause of the onboarding-checklist hard failure.
- **`onboarding-checklist`** — the `Needs action` section is gated behind the `checkProvisioningStatusAction` server action; `getChecklist` now waits for the `Loading...` spinner to clear before asserting.
- **`view-document-button`** — replace the `table tbody tr td a` list-render race with direct navigation to a published doc (id from the REST API), swap hang-prone `networkidle` waits for `waitForFormReady`, and run the file serially so the unpublish ("hides") tests don't race the "shows" tests on the same shared seed doc.
- **`tenant-selector/sync-on-save`** — creating a tenant redirects to its edit page, so wait for that redirect instead of the transient success toast (which auto-provisioning's own toast can replace).
- **`helpers/save-doc`** — bump the default save-toast timeout 10s → 15s.

**Faster, more reliable auth setup**
- **`auth.setup.ts`** — authenticate via `POST /api/users/login` instead of driving the login form for all 8 roles serially. It sets the same `payload-token` cookie but skips form hydration (the main source of setup flakiness) and route compilation. The logins now run in parallel: setup dropped from ~2 minutes (frequently timing out at 60s) to a few seconds. The login form itself stays covered by `admin/login.e2e.spec.ts`. A typed `userRoles` list (in `fixtures/test-users.ts`) keeps each role typed without a cast.

**Remove `networkidle` (~116 occurrences across 9 specs)**
- Playwright discourages `waitForLoadState('networkidle')`: in the admin SPA (background polling) the network rarely goes idle for 500ms, so it's both slow and flaky. Every one was redundant or replaceable:
  - The tenant-selector fixture helpers already wait for `.template-default--nav-hydrated`, so the preceding `networkidle` calls did nothing — removed.
  - `selectTenant` now waits for the selection to land in the tenant cookie (the signal the post-select `networkidle` approximated).
  - Cookie assertions that read right after a `goto` now use `expect.poll` so they retry until the client-set cookie settles.

**CI**
- **`.github/workflows/ci.yaml`** — temporarily gate the e2e job to also run on this branch (it normally runs only in the merge queue). ⚠️ Marked with a `TODO(fix/stabilize-admin-e2e)` and **must be removed before merge**.

## How to test

```bash
pnpm dev   # separate terminal
npx playwright test --project=admin --retries=0
```

Each affected spec passes in isolation with `--retries=0`. On this PR's first CI push the full **e2e job passed in CI** (production build, workers=4, retries=2). Unit suite (`pnpm test`) stays green (429 passed).

## Screenshots / Demo video

N/A (test/CI-only change).

## Migration Explanation

No migrations — test/config/CI changes only.

## Future enhancements / Questions

- **Remove the temporary e2e trigger** in `ci.yaml` before merging.
- The deeper root cause left unaddressed: `fullyParallel: true` + `workers: 4` all writing to a single shared `dev.db`, so write-heavy tests (tenant provisioning, unpublish/republish) contend on SQLite. The thorough fix is test-level data isolation or a DB-per-worker setup — a larger, separate piece of infra work. The hardening here plus CI `retries: 2` should keep the queue green in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)