### PR TITLE
fix: tolerate NAC API failures when building forecast zone static params

### DIFF
--- a/src/app/(frontend)/[center]/forecasts/avalanche/[zone]/page.tsx
+++ b/src/app/(frontend)/[center]/forecasts/avalanche/[zone]/page.tsx
@@ -31,11 +31,21 @@ export async function generateStaticParams() {
   const params: PathArgs[] = []
 
   for (const tenant of tenantsRes.docs) {
-    const activeForecastZones = await getActiveForecastZones(tenant.slug)
+    // A NAC API failure for one center must not abort the whole build. Skip this
+    // center's zones on error; with dynamicParams = false they 404 until the next
+    // successful build rather than rendering on-demand.
+    try {
+      const activeForecastZones = await getActiveForecastZones(tenant.slug)
 
-    activeForecastZones.forEach(({ slug: zoneSlug }) =>
-      params.push({ center: tenant.slug, zone: zoneSlug }),
-    )
+      activeForecastZones.forEach(({ slug: zoneSlug }) =>
+        params.push({ center: tenant.slug, zone: zoneSlug }),
+      )
+    } catch (err) {
+      payload.logger.error(
+        { err, center: tenant.slug },
+        `Failed to resolve forecast zones for ${tenant.slug}; skipping its zone params`,
+      )
+    }
   }
 
   return params


### PR DESCRIPTION
## Description

The production build aborts when the live NAC API returns a 403 (or is otherwise unavailable). `generateStaticParams` for `/[center]/forecasts/avalanche/[zone]` calls `getActiveForecastZones(tenant.slug)` — which hits `api.avalanche.org` — once per tenant, with no error handling. A single failed request rejects the promise and Next fails the whole build:

```
NACError: NAC API request failed with status 403
url: https://api.avalanche.org/v2/public/avalanche-center/SNFAC
→ Failed to collect page data for /[center]/forecasts/avalanche/[zone]
→ Build error occurred
```

This has been failing CI builds intermittently (e.g. the #1113 merge-queue run) whenever NAC throttles/blocks the CI runner IP — unrelated to whatever branch is building.

## Key Changes

- **`src/app/(frontend)/[center]/forecasts/avalanche/[zone]/page.tsx`** — wrap the per-tenant `getActiveForecastZones` call in try/catch. On failure, log via `payload.logger` and skip that center's zone params instead of throwing.

## Tradeoff

The route is `dynamicParams = false`, so a center whose zones are skipped during a NAC outage will 404 those zone pages until the next successful build/deploy, rather than rendering on-demand. That's deliberate: one center's zones being temporarily missing is far better than the entire site failing to build. Other centers build normally.

## How to test

- `pnpm tsc` and `pnpm lint` pass.
- A build where NAC returns 403 for one center now completes, logging `Failed to resolve forecast zones for <center>` and omitting that center's zone params, instead of aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
