### PR TITLE
Add PostHog impression and click tracking to sponsor banners

### DIFF
--- a/__tests__/client/components/SponsorLink.client.test.tsx
+++ b/__tests__/client/components/SponsorLink.client.test.tsx
@@ -1,0 +1,50 @@
+import { SponsorLink } from '@/blocks/Sponsors/components/SponsorLink'
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+const mockCaptureWithTenant = jest.fn()
+
+jest.mock('../../../src/utilities/useAnalytics', () => ({
+  useAnalytics: () => ({ captureWithTenant: mockCaptureWithTenant }),
+}))
+
+const sponsor = {
+  id: 7,
+  name: 'Acme Outfitters',
+  link: 'https://acme.example.com',
+}
+
+describe('SponsorLink', () => {
+  beforeEach(() => {
+    mockCaptureWithTenant.mockClear()
+  })
+
+  it('captures a sponsor_impression once on mount', () => {
+    render(
+      <SponsorLink sponsor={sponsor}>
+        <span>Acme Outfitters</span>
+      </SponsorLink>,
+    )
+
+    expect(mockCaptureWithTenant).toHaveBeenCalledTimes(1)
+    expect(mockCaptureWithTenant).toHaveBeenCalledWith('sponsor_impression', {
+      sponsor_id: '7',
+      sponsor_name: 'Acme Outfitters',
+    })
+  })
+
+  it('captures a sponsor_click when the link is clicked', () => {
+    render(
+      <SponsorLink sponsor={sponsor}>
+        <span>Acme Outfitters</span>
+      </SponsorLink>,
+    )
+
+    fireEvent.click(screen.getByRole('link'))
+
+    expect(mockCaptureWithTenant).toHaveBeenCalledWith('sponsor_click', {
+      sponsor_id: '7',
+      sponsor_name: 'Acme Outfitters',
+    })
+  })
+})

--- a/src/blocks/Sponsors/components/Banner.tsx
+++ b/src/blocks/Sponsors/components/Banner.tsx
@@ -1,14 +1,15 @@
 import { ImageMedia } from '@/components/Media/ImageMedia'
 import { Sponsor } from '@/payload-types'
+import { SponsorLink } from './SponsorLink'
 
 export const SponsorsBlockBanner = ({ sponsors }: { sponsors: Sponsor[] }) => {
   return sponsors?.map((sponsor, index) => (
-    <a href={sponsor.link} target="_blank" className="w-full" key={`${sponsor.id}_${index}`}>
+    <SponsorLink sponsor={sponsor} className="w-full" key={`${sponsor.id}_${index}`}>
       <ImageMedia
         imgClassName="w-full h-auto overflow-hidden"
         resource={sponsor.photo}
         sizes="100vw"
       />
-    </a>
+    </SponsorLink>
   ))
 }

--- a/src/blocks/Sponsors/components/Carousel.tsx
+++ b/src/blocks/Sponsors/components/Carousel.tsx
@@ -11,6 +11,7 @@ import { Sponsor } from '@/payload-types'
 import { getImageWidthFromMaxHeight } from '@/utilities/getImageWidthFromMaxHeight'
 import getTextColorFromBgColor from '@/utilities/getTextColorFromBgColor'
 import Autoplay from 'embla-carousel-autoplay'
+import { SponsorLink } from './SponsorLink'
 
 export const SponsorsBlockCarousel = ({
   backgroundColor,
@@ -55,13 +56,13 @@ export const SponsorsBlockCarousel = ({
               className={`${carouselItemClass} flex aspect-square items-center justify-center p-6 max-h-[200px]`}
               key={`${sponsor.id}_${index}`}
             >
-              <a href={sponsor.link} target="_blank" rel="noopener noreferrer">
+              <SponsorLink sponsor={sponsor}>
                 <ImageMedia
                   imgClassName="w-full h-auto max-h-[200px] overflow-hidden"
                   resource={sponsor.photo}
                   sizes={getImageWidthFromMaxHeight(sponsor.photo, 200)}
                 />
-              </a>
+              </SponsorLink>
             </CarouselItem>
           ))}
         </CarouselContent>

--- a/src/blocks/Sponsors/components/SponsorLink.tsx
+++ b/src/blocks/Sponsors/components/SponsorLink.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { Sponsor } from '@/payload-types'
+import { useAnalytics } from '@/utilities/useAnalytics'
+import { useEffect, useRef } from 'react'
+
+type Props = {
+  sponsor: Pick<Sponsor, 'id' | 'name' | 'link'>
+  className?: string
+  children: React.ReactNode
+}
+
+/**
+ * Wraps a sponsor banner in a tracked link. Fires a `sponsor_impression` PostHog event
+ * once when the banner mounts and a `sponsor_click` event on click (both tagged with the
+ * active tenant via useAnalytics).
+ */
+export function SponsorLink({ sponsor, className, children }: Props) {
+  const { captureWithTenant } = useAnalytics()
+  const impressionSent = useRef(false)
+
+  const eventProperties = {
+    sponsor_id: String(sponsor.id),
+    sponsor_name: sponsor.name,
+  }
+
+  useEffect(() => {
+    if (impressionSent.current) return
+    impressionSent.current = true
+    captureWithTenant('sponsor_impression', eventProperties)
+    // Fire exactly once per mount; sponsor identity is stable for the lifetime of this link
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <a
+      href={sponsor.link}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+      onClick={() => captureWithTenant('sponsor_click', eventProperties)}
+    >
+      {children}
+    </a>
+  )
+}

--- a/src/blocks/Sponsors/components/SponsorLink.tsx
+++ b/src/blocks/Sponsors/components/SponsorLink.tsx
@@ -10,11 +10,6 @@ type Props = {
   children: React.ReactNode
 }
 
-/**
- * Wraps a sponsor banner in a tracked link. Fires a `sponsor_impression` PostHog event
- * once when the banner mounts and a `sponsor_click` event on click (both tagged with the
- * active tenant via useAnalytics).
- */
 export function SponsorLink({ sponsor, className, children }: Props) {
   const { captureWithTenant } = useAnalytics()
   const impressionSent = useRef(false)
@@ -28,7 +23,6 @@ export function SponsorLink({ sponsor, className, children }: Props) {
     if (impressionSent.current) return
     impressionSent.current = true
     captureWithTenant('sponsor_impression', eventProperties)
-    // Fire exactly once per mount; sponsor identity is stable for the lifetime of this link
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/src/blocks/Sponsors/components/Static.tsx
+++ b/src/blocks/Sponsors/components/Static.tsx
@@ -1,6 +1,7 @@
 import { ImageMedia } from '@/components/Media/ImageMedia'
 import { cssVariables } from '@/cssVariables'
 import { Sponsor } from '@/payload-types'
+import { SponsorLink } from './SponsorLink'
 
 const { breakpoints } = cssVariables
 
@@ -28,13 +29,13 @@ export const SponsorsBlockStatic = ({ sponsors }: { sponsors: Sponsor[] }) => {
       {typeof sponsors === 'object' &&
         sponsors.map((sponsor, index: number) => (
           <div className={`${colSpanName} p-4 md:px-8`} key={`${sponsor.id}_${index}`}>
-            <a href={sponsor.link} target="_blank">
+            <SponsorLink sponsor={sponsor}>
               <ImageMedia
                 imgClassName="w-full h-auto overflow-hidden"
                 resource={sponsor.photo}
                 sizes={sizes}
               />
-            </a>
+            </SponsorLink>
           </div>
         ))}
     </>


### PR DESCRIPTION
## Description

Adds PostHog analytics to sponsor banners so we can measure impressions and clicks per sponsor and per tenant. Previously sponsor banners were plain `<a>` tags with no tracking.

## Related Issues
Fixes #389 

## Key Changes

- New `SponsorLink` client component that wraps a sponsor banner in a tracked link:
  - Fires `sponsor_impression` once on mount
  - Fires `sponsor_click` on click
  - Both events tagged with `sponsor_id`, `sponsor_name`, and the active tenant (via `captureWithTenant`)
- Replaced the raw `<a href={sponsor.link}>` in the **Banner**, **Carousel**, and **Static** sponsor block variants with `SponsorLink`.
- No change to the outbound URL — `href` is still `sponsor.link`. (UTM attribution, if a sponsor needs it, belongs in the CMS `link` field rather than auto-generated here.)

## How to test

1. Render a page with each sponsor block variant (Banner, Carousel, Static).
2. Confirm the banner still links out to the sponsor URL in a new tab.
3. In PostHog, verify a `sponsor_impression` event fires on load and a `sponsor_click` fires on click, each carrying `sponsor_id`, `sponsor_name`, and tenant properties.

## Screenshots / Demo video

N/A — no visual change.

## Migration Explanation

No migration — no schema changes.

## Future enhancements / Questions

- Should impressions be debounced/deduped across rapid remounts (e.g. carousel re-renders) beyond the current once-per-mount guard?
