### PR TITLE
Filter out content with future publishedAt dates from frontend

### DIFF
--- a/__tests__/client/utilities/relationships.client.test.ts
+++ b/__tests__/client/utilities/relationships.client.test.ts
@@ -44,6 +44,26 @@ describe('isValidPublishedRelationship', () => {
     expect(isValidPublishedRelationship({ id: 1, _status: 'draft' })).toBe(false)
   })
 
+  it('returns true for a published object with a past publishedAt', () => {
+    expect(
+      isValidPublishedRelationship({
+        id: 1,
+        _status: 'published',
+        publishedAt: '2020-01-01T00:00:00.000Z',
+      }),
+    ).toBe(true)
+  })
+
+  it('returns false for a published object with a future publishedAt', () => {
+    expect(
+      isValidPublishedRelationship({
+        id: 1,
+        _status: 'published',
+        publishedAt: '2999-01-01T00:00:00.000Z',
+      }),
+    ).toBe(false)
+  })
+
   it('returns false for a number (unresolved ID)', () => {
     expect(isValidPublishedRelationship(42)).toBe(false)
   })

--- a/__tests__/server/publishedFilter.server.test.ts
+++ b/__tests__/server/publishedFilter.server.test.ts
@@ -1,0 +1,27 @@
+import { publishedFilter } from '@/utilities/publishedFilter'
+
+describe('publishedFilter', () => {
+  it('requires a published status', () => {
+    const where = publishedFilter()
+    expect(where.and?.[0]).toEqual({ _status: { equals: 'published' } })
+  })
+
+  it('excludes documents with a future publishedAt and allows missing dates', () => {
+    const before = new Date().toISOString()
+    const dateClause = publishedFilter().and?.[1]
+    const after = new Date().toISOString()
+
+    const orClauses = dateClause && 'or' in dateClause ? dateClause.or : undefined
+    const publishedAtField = orClauses?.[0]?.publishedAt
+    const lessThanEqual =
+      publishedAtField && !Array.isArray(publishedAtField)
+        ? publishedAtField.less_than_equal
+        : undefined
+
+    expect(typeof lessThanEqual).toBe('string')
+    if (typeof lessThanEqual === 'string') {
+      expect(lessThanEqual >= before && lessThanEqual <= after).toBe(true)
+    }
+    expect(orClauses?.[1]).toEqual({ publishedAt: { exists: false } })
+  })
+})

--- a/src/app/(frontend)/[center]/(sitemaps)/pages-sitemap.xml/route.ts
+++ b/src/app/(frontend)/[center]/(sitemaps)/pages-sitemap.xml/route.ts
@@ -4,6 +4,7 @@ import {
   getCanonicalUrlsFromNavigation,
 } from '@/components/Header/utils'
 import { getURL } from '@/utilities/getURL'
+import { publishedFilter } from '@/utilities/publishedFilter'
 import config from '@payload-config'
 import { getServerSideSitemap } from 'next-sitemap'
 import { unstable_cache } from 'next/cache'
@@ -31,12 +32,14 @@ const getPagesSitemap = (center: string) =>
         limit: 1000,
         pagination: false,
         where: {
-          _status: {
-            equals: 'published',
-          },
-          'tenant.slug': {
-            equals: center,
-          },
+          and: [
+            publishedFilter(),
+            {
+              'tenant.slug': {
+                equals: center,
+              },
+            },
+          ],
         },
         select: {
           slug: true,

--- a/src/app/(frontend)/[center]/(sitemaps)/posts-sitemap.xml/route.ts
+++ b/src/app/(frontend)/[center]/(sitemaps)/posts-sitemap.xml/route.ts
@@ -1,4 +1,5 @@
 import { getURL } from '@/utilities/getURL'
+import { publishedFilter } from '@/utilities/publishedFilter'
 import config from '@payload-config'
 import { getServerSideSitemap } from 'next-sitemap'
 import { unstable_cache } from 'next/cache'
@@ -23,12 +24,14 @@ const getPostsSitemap = (center: string) =>
         limit: 1000,
         pagination: false,
         where: {
-          _status: {
-            equals: 'published',
-          },
-          'tenant.slug': {
-            equals: center,
-          },
+          and: [
+            publishedFilter(),
+            {
+              'tenant.slug': {
+                equals: center,
+              },
+            },
+          ],
         },
         select: {
           slug: true,

--- a/src/app/(frontend)/[center]/[...segments]/page.tsx
+++ b/src/app/(frontend)/[center]/[...segments]/page.tsx
@@ -27,7 +27,6 @@ export async function generateStaticParams() {
       tenant: true,
       slug: true,
     },
-    // Only use published documents that have reached their publish date
     where: publishedFilter(),
   })
 

--- a/src/app/(frontend)/[center]/[...segments]/page.tsx
+++ b/src/app/(frontend)/[center]/[...segments]/page.tsx
@@ -10,6 +10,7 @@ import { cache } from 'react'
 import { RenderBlocks } from '@/blocks/RenderBlocks'
 import { generateMetaForPage } from '@/utilities/generateMeta'
 import { normalizePath } from '@/utilities/path'
+import { publishedFilter } from '@/utilities/publishedFilter'
 import { resolveTenant } from '@/utilities/tenancy/resolveTenant'
 
 export const dynamic = 'force-static'
@@ -26,12 +27,8 @@ export async function generateStaticParams() {
       tenant: true,
       slug: true,
     },
-    // Only use published documents (not added by default)
-    where: {
-      _status: {
-        equals: 'published',
-      },
-    },
+    // Only use published documents that have reached their publish date
+    where: publishedFilter(),
   })
 
   const params: PathArgs[] = []
@@ -142,11 +139,7 @@ const queryPageBySlug = cache(async ({ center, slug }: { center: string; slug: s
   ]
 
   if (!draft) {
-    conditions.push({
-      _status: {
-        equals: 'published',
-      },
-    })
+    conditions.push(publishedFilter())
   }
 
   const result = await payload.find({

--- a/src/app/(frontend)/[center]/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/[slug]/page.tsx
@@ -29,7 +29,6 @@ export async function generateStaticParams() {
       tenant: true,
       slug: true,
     },
-    // Only use published documents that have reached their publish date
     where: publishedFilter(),
   })
 

--- a/src/app/(frontend)/[center]/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/[slug]/page.tsx
@@ -12,6 +12,7 @@ import type { Page as PageType } from '@/payload-types'
 
 import { RenderBlocks } from '@/blocks/RenderBlocks'
 import { generateMetaForPage } from '@/utilities/generateMeta'
+import { publishedFilter } from '@/utilities/publishedFilter'
 import { resolveTenant } from '@/utilities/tenancy/resolveTenant'
 
 export const dynamic = 'force-static'
@@ -28,12 +29,8 @@ export async function generateStaticParams() {
       tenant: true,
       slug: true,
     },
-    // Only use published documents (not added by default)
-    where: {
-      _status: {
-        equals: 'published',
-      },
-    },
+    // Only use published documents that have reached their publish date
+    where: publishedFilter(),
   })
 
   const params: PathArgs[] = []
@@ -140,11 +137,7 @@ const queryPageBySlug = cache(async ({ center, slug }: { center: string; slug: s
   ]
 
   if (!draft) {
-    conditions.push({
-      _status: {
-        equals: 'published',
-      },
-    })
+    conditions.push(publishedFilter())
   }
 
   const result = await payload.find({

--- a/src/app/(frontend)/[center]/blog/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/blog/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { draftMode } from 'next/headers'
 import { getPayload, Where } from 'payload'
 
 import { generateMetaForPost } from '@/utilities/generateMeta'
+import { publishedFilter } from '@/utilities/publishedFilter'
 
 export const dynamic = 'force-static'
 export const dynamicParams = true
@@ -25,12 +26,8 @@ export async function generateStaticParams() {
       tenant: true,
       slug: true,
     },
-    // Only use published documents (not added by default)
-    where: {
-      _status: {
-        equals: 'published',
-      },
-    },
+    // Only use published documents that have reached their publish date
+    where: publishedFilter(),
   })
 
   const params: PathArgs[] = []
@@ -130,11 +127,7 @@ const queryPostBySlug = async ({ center, slug }: { center: string; slug: string 
   ]
 
   if (!draft) {
-    conditions.push({
-      _status: {
-        equals: 'published',
-      },
-    })
+    conditions.push(publishedFilter())
   }
 
   const result = await payload.find({

--- a/src/app/(frontend)/[center]/blog/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/blog/[slug]/page.tsx
@@ -26,7 +26,6 @@ export async function generateStaticParams() {
       tenant: true,
       slug: true,
     },
-    // Only use published documents that have reached their publish date
     where: publishedFilter(),
   })
 

--- a/src/utilities/getCachedHomePage.ts
+++ b/src/utilities/getCachedHomePage.ts
@@ -1,4 +1,5 @@
 import { HomePage } from '@/payload-types'
+import { publishedFilter } from '@/utilities/publishedFilter'
 import configPromise from '@payload-config'
 import { unstable_cache } from 'next/cache'
 import { getPayload, Where } from 'payload'
@@ -17,11 +18,7 @@ export const getCachedHomePage = (center: string, draft: boolean = false) =>
       ]
 
       if (!draft) {
-        conditions.push({
-          _status: {
-            equals: 'published',
-          },
-        })
+        conditions.push(publishedFilter())
       }
 
       const homePageRes = await payload.find({

--- a/src/utilities/publishedFilter.ts
+++ b/src/utilities/publishedFilter.ts
@@ -1,0 +1,29 @@
+import type { Where } from 'payload'
+
+// Where clause matching published documents whose publishedAt is not in the future.
+// Documents without a publishedAt are treated as published immediately.
+export function publishedFilter(): Where {
+  return {
+    and: [
+      {
+        _status: {
+          equals: 'published',
+        },
+      },
+      {
+        or: [
+          {
+            publishedAt: {
+              less_than_equal: new Date().toISOString(),
+            },
+          },
+          {
+            publishedAt: {
+              exists: false,
+            },
+          },
+        ],
+      },
+    ],
+  }
+}

--- a/src/utilities/publishedFilter.ts
+++ b/src/utilities/publishedFilter.ts
@@ -1,7 +1,7 @@
 import type { Where } from 'payload'
 
-// Where clause matching published documents whose publishedAt is not in the future.
-// Documents without a publishedAt are treated as published immediately.
+// Published documents whose publishedAt is not in the future.
+// Documents without a publishedAt are included.
 export function publishedFilter(): Where {
   return {
     and: [

--- a/src/utilities/queries/getPosts.ts
+++ b/src/utilities/queries/getPosts.ts
@@ -1,6 +1,7 @@
 import { POSTS_LIMIT } from '@/constants/defaults'
 import type { Post } from '@/payload-types'
 import config from '@/payload.config'
+import { publishedFilter } from '@/utilities/publishedFilter'
 import * as Sentry from '@sentry/nextjs'
 import type { Where } from 'payload'
 import { getPayload } from 'payload'
@@ -35,11 +36,7 @@ export async function getPosts(params: GetPostsParams): Promise<GetPostsResult> 
           equals: center,
         },
       },
-      {
-        _status: {
-          equals: 'published',
-        },
-      },
+      publishedFilter(),
     ]
 
     if (tags) {

--- a/src/utilities/relationships.ts
+++ b/src/utilities/relationships.ts
@@ -36,12 +36,13 @@ export function isValidRelationship<T extends { id: string | number }>(
  * }
  */
 export function isValidPublishedRelationship<
-  T extends { id: string | number; _status?: string | null },
+  T extends { id: string | number; _status?: string | null; publishedAt?: string | null },
 >(relationship: T | number | null | undefined): relationship is T {
   return (
     typeof relationship === 'object' &&
     relationship !== null &&
-    (!relationship._status || relationship._status === 'published')
+    (!relationship._status || relationship._status === 'published') &&
+    (!relationship.publishedAt || relationship.publishedAt <= new Date().toISOString())
   )
 }
 


### PR DESCRIPTION
## Description

Published Posts, Pages, and HomePages with a `publishedAt` date in the future were being rendered on the frontend. This adds a shared `publishedFilter()` where clause that requires `_status === 'published'` AND a `publishedAt` that is not in the future (documents without a `publishedAt` are treated as published immediately), and applies it across all frontend queries.

## Related Issues

Fixes #1092

## Key Changes

- Add shared `publishedFilter()` where clause in `src/utilities/publishedFilter.ts`
- Apply it to all frontend Posts, Pages, and HomePages queries, sitemaps, and `generateStaticParams`
- Exclude future-published items from `filterValidPublishedRelationships` (related/static posts)
- Add server tests for `publishedFilter()` and a client test for the relationship filter

## How to test

1. Create a Post/Page with `_status: published` and a `publishedAt` set in the future.
2. Confirm it does not render on the frontend, does not appear in sitemaps, and is not in related/static post lists.
3. Confirm published content with a past or missing `publishedAt` still renders.

## Screenshots / Demo video

N/A

## Migration Explanation

No migration — query-level change only.

## Future enhancements / Questions

None.
