### PR TITLE
Improve event slug generation: include date, number duplicates

### DIFF
--- a/__tests__/client/utilities/formatSlug.client.test.ts
+++ b/__tests__/client/utilities/formatSlug.client.test.ts
@@ -1,0 +1,48 @@
+import { formatDateForSlug, formatSlug } from '@/fields/slug/formatSlug'
+
+describe('formatSlug', () => {
+  it('kebab-cases a multi-word string', () => {
+    expect(formatSlug('REI Awareness Class')).toBe('rei-awareness-class')
+  })
+
+  it('strips characters that are not letters, numbers, or hyphens', () => {
+    expect(formatSlug("Backcountry Essentials Women's")).toBe('backcountry-essentials-womens')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(formatSlug('  Hello World  ')).toBe('hello-world')
+  })
+
+  it('leaves an already-kebab slug intact', () => {
+    expect(formatSlug('already-kebab-123')).toBe('already-kebab-123')
+  })
+
+  it('returns an empty string for null or empty input', () => {
+    expect(formatSlug(null)).toBe('')
+    expect(formatSlug('')).toBe('')
+  })
+})
+
+describe('formatDateForSlug', () => {
+  it('formats an ISO datetime string as YYYY-MM-DD (UTC)', () => {
+    expect(formatDateForSlug('2025-11-13T18:00:00.000Z')).toBe('2025-11-13')
+  })
+
+  it('formats a date-only string', () => {
+    expect(formatDateForSlug('2025-11-13')).toBe('2025-11-13')
+  })
+
+  it('formats a Date object', () => {
+    expect(formatDateForSlug(new Date(Date.UTC(2025, 10, 13)))).toBe('2025-11-13')
+  })
+
+  it('returns an empty string for an invalid date string', () => {
+    expect(formatDateForSlug('not-a-date')).toBe('')
+  })
+
+  it('returns an empty string for non-string, non-Date values', () => {
+    expect(formatDateForSlug(undefined)).toBe('')
+    expect(formatDateForSlug(null)).toBe('')
+    expect(formatDateForSlug(1731513600000)).toBe('')
+  })
+})

--- a/__tests__/e2e/admin/collections/events.e2e.spec.ts
+++ b/__tests__/e2e/admin/collections/events.e2e.spec.ts
@@ -1,0 +1,91 @@
+import { authTest, expect } from '../../fixtures/auth.fixture'
+import { AdminUrlUtil } from '../../helpers/admin-url'
+import { deleteDoc } from '../../helpers/create-doc'
+import { waitForFormReady } from '../../helpers/save-doc'
+import { setTenantCookie, TenantSlugs } from '../../helpers/tenant-cookie'
+
+const SERVER_URL = 'http://localhost:3000'
+const START_DATE = '2025-11-13T18:00:00.000Z'
+
+/**
+ * Creates a draft event (nwac) with a known title + start date and returns its id.
+ * `?draft=true` skips required-field validation; the slug is intentionally left blank
+ * so the auto-generate behavior can be exercised in the editor.
+ */
+async function createDraftEvent(page: import('@playwright/test').Page): Promise<number> {
+  const result = await page.evaluate(
+    async ({ startDate }) => {
+      const res = await fetch('/api/events?draft=true', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tenant: 2, // nwac
+          _status: 'draft',
+          title: 'E2E Awareness Class',
+          startDate,
+          type: 'awareness',
+        }),
+      })
+      return { ok: res.ok, status: res.status, body: await res.json() }
+    },
+    { startDate: START_DATE },
+  )
+
+  expect(
+    result.ok,
+    `create event failed (${result.status}): ${JSON.stringify(result.body)}`,
+  ).toBeTruthy()
+  return result.body.doc.id
+}
+
+authTest.describe('Events collection slug field', () => {
+  authTest.describe.configure({ mode: 'serial', timeout: 90000 })
+
+  authTest('shows the auto-generate description for the slug field', async ({ adminPage }) => {
+    const eventsUrl = new AdminUrlUtil(SERVER_URL, 'events')
+    await setTenantCookie(adminPage.context(), TenantSlugs.nwac)
+
+    await adminPage.goto(eventsUrl.list)
+    const eventId = await createDraftEvent(adminPage)
+
+    try {
+      await adminPage.goto(eventsUrl.edit(eventId))
+      await waitForFormReady(adminPage)
+
+      await expect(adminPage.locator('#field-slug')).toBeVisible({ timeout: 10000 })
+      // The custom SlugComponent must render admin.description itself; assert it's visible.
+      await expect(
+        adminPage.getByText('Duplicates get a numbered suffix.', { exact: false }),
+      ).toBeVisible()
+    } finally {
+      await deleteDoc(adminPage, 'events', eventId)
+    }
+  })
+
+  authTest('regenerate button builds the slug from title + start date', async ({ adminPage }) => {
+    const eventsUrl = new AdminUrlUtil(SERVER_URL, 'events')
+    await setTenantCookie(adminPage.context(), TenantSlugs.nwac)
+
+    await adminPage.goto(eventsUrl.list)
+    const eventId = await createDraftEvent(adminPage)
+
+    try {
+      await adminPage.goto(eventsUrl.edit(eventId))
+      await waitForFormReady(adminPage)
+
+      const slugInput = adminPage.locator('#field-slug')
+      await slugInput.fill('')
+
+      // The refresh button lives inside the slug field wrapper.
+      const slugFieldWrapper = adminPage
+        .locator('.field-type.relative')
+        .filter({ has: adminPage.locator('#field-slug') })
+      await slugFieldWrapper.locator('button').click()
+
+      // Slug is title kebab-cased + the start date (2025-11-13), matching the server hook.
+      await expect(slugInput).toHaveValue('e2e-awareness-class-2025-11-13')
+    } finally {
+      await deleteDoc(adminPage, 'events', eventId)
+    }
+  })
+})

--- a/__tests__/server/ensureUniqueSlug.server.test.ts
+++ b/__tests__/server/ensureUniqueSlug.server.test.ts
@@ -1,0 +1,151 @@
+import { ensureUniqueSlug } from '@/fields/slug/ensureUniqueSlug'
+
+// Minimal shape of the `where` clause ensureUniqueSlug builds, so the find mock can
+// resolve the candidate slug it's querying for.
+type WhereClause = {
+  and: Array<{
+    slug?: { equals?: string }
+    id?: { not_in?: string[] }
+    tenant?: { equals?: string }
+  }>
+}
+
+type CollectionField = { name: string; type: string; required?: boolean }
+
+type RunOptions = {
+  value?: unknown
+  data?: Record<string, unknown>
+  originalDoc?: Record<string, unknown>
+  existing?: Set<string>
+  user?: unknown
+  fields?: CollectionField[]
+}
+
+const eventOptions = {
+  generateFromField: 'title',
+  dateField: 'startDate',
+  autoSuffixOnDuplicate: true,
+}
+
+// ensureUniqueSlug only reads a handful of fields off its args, so the tests pass a minimal
+// mock. This helper keeps the type suppression on a single line (prettier-safe) and keeps the
+// call sites type-checked against the shape below.
+function asHookArgs(args: {
+  value: unknown
+  data: Record<string, unknown>
+  originalDoc: Record<string, unknown> | undefined
+  req: { user: unknown; payload: { find: jest.Mock } }
+  collection: {
+    slug: string
+    labels: { singular: string; plural: string }
+    fields: CollectionField[]
+  }
+}): Parameters<ReturnType<typeof ensureUniqueSlug>>[0] {
+  // @ts-expect-error - intentionally minimal FieldHook args shape for testing
+  return args
+}
+
+async function run(
+  options: Parameters<typeof ensureUniqueSlug>[0],
+  {
+    value = '',
+    data = {},
+    originalDoc = undefined,
+    existing = new Set<string>(),
+    user = { id: 'user-1' },
+    fields = [],
+  }: RunOptions = {},
+) {
+  const find = jest.fn(async ({ where }: { where: WhereClause }) => {
+    const slugCondition = where.and.find((condition) => condition.slug)
+    const candidate = slugCondition?.slug?.equals ?? ''
+    return { docs: existing.has(candidate) ? [{ id: 'existing-doc' }] : [] }
+  })
+
+  const collection = {
+    slug: 'events',
+    labels: { singular: 'Event', plural: 'Events' },
+    fields,
+  }
+
+  const hook = ensureUniqueSlug(options)
+  const result = await hook(
+    asHookArgs({ value, data, originalDoc, req: { user, payload: { find } }, collection }),
+  )
+  return { result, find }
+}
+
+describe('ensureUniqueSlug', () => {
+  it('auto-generates the slug from the source field and date when left blank', async () => {
+    const { result } = await run(eventOptions, {
+      value: '',
+      data: { title: 'Avalanche Awareness Class', startDate: '2025-11-13T18:00:00.000Z' },
+    })
+    expect(result).toBe('avalanche-awareness-class-2025-11-13')
+  })
+
+  it('appends a numbered suffix when the generated slug already exists', async () => {
+    const { result } = await run(eventOptions, {
+      data: { title: 'Avalanche Awareness Class', startDate: '2025-11-13T18:00:00.000Z' },
+      existing: new Set(['avalanche-awareness-class-2025-11-13']),
+    })
+    expect(result).toBe('avalanche-awareness-class-2025-11-13-2')
+  })
+
+  it('increments past consecutive existing suffixes', async () => {
+    const { result } = await run(eventOptions, {
+      data: { title: 'Avalanche Awareness Class', startDate: '2025-11-13T18:00:00.000Z' },
+      existing: new Set([
+        'avalanche-awareness-class-2025-11-13',
+        'avalanche-awareness-class-2025-11-13-2',
+      ]),
+    })
+    expect(result).toBe('avalanche-awareness-class-2025-11-13-3')
+  })
+
+  it('numbers an explicitly entered slug that collides (the duplicate-document case)', async () => {
+    const { result } = await run(eventOptions, {
+      value: 'avalanche-awareness-class-2025-11-13',
+      existing: new Set(['avalanche-awareness-class-2025-11-13']),
+    })
+    expect(result).toBe('avalanche-awareness-class-2025-11-13-2')
+  })
+
+  it('keeps an explicitly entered slug when it is unique', async () => {
+    const { result } = await run(eventOptions, { value: 'custom-slug' })
+    expect(result).toBe('custom-slug')
+  })
+
+  it('returns the value unchanged when blank and there is nothing to generate from', async () => {
+    const { result } = await run({}, { value: '' })
+    expect(result).toBe('')
+  })
+
+  it('throws on collision when auto-suffixing is disabled and a user is present', async () => {
+    await expect(
+      run(
+        { autoSuffixOnDuplicate: false },
+        { value: 'taken-slug', existing: new Set(['taken-slug']) },
+      ),
+    ).rejects.toThrow('Slug must be unique')
+  })
+
+  it('excludes the current document from the uniqueness check', async () => {
+    const { find } = await run(eventOptions, {
+      value: 'my-slug',
+      data: { id: 'doc-1' },
+    })
+    const where: WhereClause = find.mock.calls[0][0].where
+    expect(where.and).toContainEqual({ id: { not_in: ['doc-1'] } })
+  })
+
+  it('scopes the uniqueness check to the tenant when the collection requires one', async () => {
+    const { find } = await run(eventOptions, {
+      value: 'my-slug',
+      data: { tenant: 'tenant-1' },
+      fields: [{ name: 'tenant', type: 'relationship', required: true }],
+    })
+    const where: WhereClause = find.mock.calls[0][0].where
+    expect(where.and).toContainEqual({ tenant: { equals: 'tenant-1' } })
+  })
+})

--- a/__tests__/server/slugField.server.test.ts
+++ b/__tests__/server/slugField.server.test.ts
@@ -1,0 +1,20 @@
+import { slugField } from '@/fields/slug'
+
+describe('slugField descriptions', () => {
+  it('explains auto-generation from the source field and date when enabled', () => {
+    const field = slugField('title', { autoGenerateFromDateField: 'startDate' })
+    expect(field.admin?.description).toBe(
+      'Leave blank to auto-generate from title + start date. Duplicates get a numbered suffix.',
+    )
+    // Auto-generated slugs may be left blank for the hook to fill in.
+    expect(field.required).toBe(false)
+  })
+
+  it('explains the manual-entry rules when auto-generation is off, using the source field name', () => {
+    const field = slugField('name')
+    expect(field.admin?.description).toBe(
+      'Auto-generated from name. Must be unique; lowercase letters, numbers, and hyphens only.',
+    )
+    expect(field.required).toBe(true)
+  })
+})

--- a/src/app/(frontend)/[center]/events/[slug]/page.tsx
+++ b/src/app/(frontend)/[center]/events/[slug]/page.tsx
@@ -42,7 +42,7 @@ export async function generateStaticParams() {
       payload.logger.error(`got number for event tenant`)
       continue
     }
-    if (event.tenant) {
+    if (event.tenant && event.slug) {
       params.push({ center: event.tenant.slug, slug: event.slug })
     }
   }

--- a/src/collections/Events/hooks/revalidateEvent.ts
+++ b/src/collections/Events/hooks/revalidateEvent.ts
@@ -13,17 +13,19 @@ const revalidate = async ({
   payload,
 }: {
   docId: number
-  slug: string
+  slug?: string | null
   tenantSlug: string
   payload: BasePayload
 }) => {
-  const preRewritePath = `/events/${slug}`
-  const eventRewritePath = `/${tenantSlug}${preRewritePath}`
+  if (slug) {
+    const preRewritePath = `/events/${slug}`
+    const eventRewritePath = `/${tenantSlug}${preRewritePath}`
 
-  payload.logger.info(`Revalidating paths: ${[preRewritePath, eventRewritePath].join(', ')}`)
+    payload.logger.info(`Revalidating paths: ${[preRewritePath, eventRewritePath].join(', ')}`)
 
-  revalidatePath(preRewritePath)
-  revalidatePath(eventRewritePath)
+    revalidatePath(preRewritePath)
+    revalidatePath(eventRewritePath)
+  }
 
   await revalidateDocumentReferences({ collection: 'events', id: docId })
 }

--- a/src/collections/Events/index.ts
+++ b/src/collections/Events/index.ts
@@ -183,7 +183,7 @@ export const Events: CollectionConfig = {
     },
 
     // Sidebar
-    slugField(),
+    slugField('title', { autoGenerateFromDateField: 'startDate' }),
     {
       name: 'type',
       type: 'select',

--- a/src/endpoints/seed/index.ts
+++ b/src/endpoints/seed/index.ts
@@ -907,7 +907,7 @@ export const seed = async ({
       payload,
       incremental,
       tenantsById,
-      (obj) => obj.slug,
+      (obj) => obj.slug ?? '',
       Object.values(tenants)
         .map((tenant): RequiredDataFromCollectionSlug<'events'>[] => {
           return getEventsData(

--- a/src/fields/slug/SlugComponent.tsx
+++ b/src/fields/slug/SlugComponent.tsx
@@ -2,7 +2,14 @@
 import { TextFieldClientProps } from 'payload'
 import React, { useCallback } from 'react'
 
-import { Button, FieldLabel, TextInput, useField, useFormFields } from '@payloadcms/ui'
+import {
+  Button,
+  FieldDescription,
+  FieldLabel,
+  TextInput,
+  useField,
+  useFormFields,
+} from '@payloadcms/ui'
 
 import { RefreshCw } from 'lucide-react'
 import { formatDateForSlug, formatSlug } from './formatSlug'
@@ -20,6 +27,7 @@ export const SlugComponent = ({
   readOnly: readOnlyFromProps,
 }: SlugComponentProps) => {
   const { label } = field
+  const description = field?.admin?.description
 
   const { value, setValue } = useField<string>({ path: path || field.name })
   const { value: currentSlug } = useField<string>({ path: 'slug' })
@@ -66,6 +74,8 @@ export const SlugComponent = ({
         path={path || field.name}
         readOnly={Boolean(readOnly)}
       />
+
+      {description && <FieldDescription description={description} path={path || field.name} />}
     </div>
   )
 }

--- a/src/fields/slug/SlugComponent.tsx
+++ b/src/fields/slug/SlugComponent.tsx
@@ -5,15 +5,17 @@ import React, { useCallback } from 'react'
 import { Button, FieldLabel, TextInput, useField, useFormFields } from '@payloadcms/ui'
 
 import { RefreshCw } from 'lucide-react'
-import { formatSlug } from './formatSlug'
+import { formatDateForSlug, formatSlug } from './formatSlug'
 
 type SlugComponentProps = {
   fieldToUse: string
+  dateField?: string
 } & TextFieldClientProps
 
 export const SlugComponent = ({
   field,
   fieldToUse,
+  dateField,
   path,
   readOnly: readOnlyFromProps,
 }: SlugComponentProps) => {
@@ -22,21 +24,25 @@ export const SlugComponent = ({
   const { value, setValue } = useField<string>({ path: path || field.name })
   const { value: currentSlug } = useField<string>({ path: 'slug' })
 
-  // Get the current value of the title field
-  const targetFieldValue = useFormFields(([fields]) => {
-    const value = fields[fieldToUse]?.value
-    return typeof value === 'string' ? value : ''
+  // Read the source field and the optional date as primitive strings so the subscription stays
+  // referentially stable across renders.
+  const baseSlug = useFormFields(([fields]) => {
+    const fieldValue = fields[fieldToUse]?.value
+    return typeof fieldValue === 'string' ? formatSlug(fieldValue) : ''
   })
+  const dateSlug = useFormFields(([fields]) =>
+    dateField ? formatDateForSlug(fields[dateField]?.value) : '',
+  )
 
   const handleGenerate = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault()
-      const newSlug = formatSlug(targetFieldValue)
-      if (targetFieldValue && newSlug !== currentSlug) {
-        setValue(formatSlug(targetFieldValue))
+      const newSlug = [baseSlug, dateSlug].filter(Boolean).join('-')
+      if (newSlug && newSlug !== currentSlug) {
+        setValue(newSlug)
       }
     },
-    [targetFieldValue, currentSlug, setValue],
+    [baseSlug, dateSlug, currentSlug, setValue],
   )
   const readOnly = readOnlyFromProps || false
 

--- a/src/fields/slug/SlugComponent.tsx
+++ b/src/fields/slug/SlugComponent.tsx
@@ -1,6 +1,7 @@
 'use client'
+import { cn } from '@/utilities/ui'
 import { TextFieldClientProps } from 'payload'
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import {
   Button,
@@ -32,6 +33,8 @@ export const SlugComponent = ({
   const { value, setValue } = useField<string>({ path: path || field.name })
   const { value: currentSlug } = useField<string>({ path: 'slug' })
 
+  const [spinning, setSpinning] = useState(false)
+
   // Read the source field and the optional date as primitive strings so the subscription stays
   // referentially stable across renders.
   const baseSlug = useFormFields(([fields]) => {
@@ -45,6 +48,8 @@ export const SlugComponent = ({
   const handleGenerate = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault()
+      setSpinning(true)
+      window.setTimeout(() => setSpinning(false), 300)
       const newSlug = [baseSlug, dateSlug].filter(Boolean).join('-')
       if (newSlug && newSlug !== currentSlug) {
         setValue(newSlug)
@@ -60,11 +65,11 @@ export const SlugComponent = ({
         <FieldLabel htmlFor={`field-${path}`} label={label} required />
 
         <Button
-          className="absolute right-0 bottom-[0.4em] z-[1] m-0 pb-[0.3125rem]"
+          className="absolute right-1 top-9 z-[1] m-0 p-1 bg-[var(--theme-input-bg)]"
           buttonStyle="icon-label"
           onClick={handleGenerate}
         >
-          <RefreshCw className="w-4" />
+          <RefreshCw className={cn('w-4', spinning && 'animate-spin [animation-duration:300ms]')} />
         </Button>
       </div>
 

--- a/src/fields/slug/ensureUniqueSlug.ts
+++ b/src/fields/slug/ensureUniqueSlug.ts
@@ -2,7 +2,7 @@ import type { FieldHook, Where } from 'payload'
 
 import { APIError } from 'payload'
 import invariant from 'tiny-invariant'
-import { formatSlug } from './formatSlug'
+import { formatDateForSlug, formatSlug } from './formatSlug'
 
 type EnsureUniqueSlugOptions = {
   // Field to auto-generate the slug from when it's left blank (e.g. 'title').
@@ -12,20 +12,6 @@ type EnsureUniqueSlugOptions = {
   dateField?: string
   // Resolve duplicate slugs by appending `-2`, `-3`, ... instead of throwing an error.
   autoSuffixOnDuplicate?: boolean
-}
-
-// Formats a date value as `YYYY-MM-DD` (UTC) for use in a slug; returns '' if not a valid date.
-const formatDateForSlug = (value: unknown): string => {
-  if (typeof value !== 'string' && !(value instanceof Date)) {
-    return ''
-  }
-
-  const date = new Date(value)
-  if (isNaN(date.getTime())) {
-    return ''
-  }
-
-  return date.toISOString().slice(0, 10)
 }
 
 export const ensureUniqueSlug =

--- a/src/fields/slug/ensureUniqueSlug.ts
+++ b/src/fields/slug/ensureUniqueSlug.ts
@@ -2,66 +2,110 @@ import type { FieldHook, Where } from 'payload'
 
 import { APIError } from 'payload'
 import invariant from 'tiny-invariant'
+import { formatSlug } from './formatSlug'
 
-export const ensureUniqueSlug: FieldHook = async (props) => {
-  const { data, originalDoc, req, value, collection } = props
-
-  invariant(
-    !!collection,
-    'Collection config missing in ensureUniqueSlug FieldHook. This is likely a misuse of the slug field.',
-  )
-
-  const tenantField = collection.fields.find((field) => 'name' in field && field.name === 'tenant')
-  const collectionHasTenantField = !!tenantField
-  const tenantFieldRequired =
-    tenantField && 'required' in tenantField && tenantField.required === true
-
-  const incomingTenantID = data?.tenant?.id ? data?.tenant.id : data?.tenant
-  const currentTenantID = originalDoc?.tenant?.id ? originalDoc.tenant.id : originalDoc?.tenant
-  const tenantIDToMatch = incomingTenantID || currentTenantID
-
-  // Don't validate if slug hasn't been generated yet
-  if (!value) {
-    return value
-  }
-
-  const conditions: Where[] = [
-    {
-      slug: {
-        equals: value,
-      },
-    },
-  ]
-
-  if (data?.id || originalDoc.id) {
-    conditions.push({
-      id: {
-        not_in: [data?.id || originalDoc.id],
-      },
-    })
-  }
-
-  if (collectionHasTenantField && tenantFieldRequired && tenantIDToMatch) {
-    conditions.push({
-      tenant: {
-        equals: tenantIDToMatch,
-      },
-    })
-  }
-
-  const duplicateDocumentsRes = await req.payload.find({
-    collection: collection.slug,
-    where: {
-      and: conditions,
-    },
-  })
-
-  if (duplicateDocumentsRes.docs.length > 0 && req.user) {
-    throw new APIError(
-      `A ${collection.labels.singular} with the slug "${value}" already exists. Slug must be unique${collectionHasTenantField ? ' per avalanche center' : ''}.`,
-      400,
-    )
-  }
-
-  return value
+type EnsureUniqueSlugOptions = {
+  // Field to auto-generate the slug from when it's left blank (e.g. 'title').
+  generateFromField?: string
+  // Date field folded into the auto-generated slug as `-YYYY-MM-DD` (e.g. 'startDate').
+  // Lets many same-named events (e.g. "Avalanche Awareness Class") get distinct, meaningful slugs.
+  dateField?: string
+  // Resolve duplicate slugs by appending `-2`, `-3`, ... instead of throwing an error.
+  autoSuffixOnDuplicate?: boolean
 }
+
+// Formats a date value as `YYYY-MM-DD` (UTC) for use in a slug; returns '' if not a valid date.
+const formatDateForSlug = (value: unknown): string => {
+  if (typeof value !== 'string' && !(value instanceof Date)) {
+    return ''
+  }
+
+  const date = new Date(value)
+  if (isNaN(date.getTime())) {
+    return ''
+  }
+
+  return date.toISOString().slice(0, 10)
+}
+
+export const ensureUniqueSlug =
+  (options: EnsureUniqueSlugOptions = {}): FieldHook =>
+  async (props) => {
+    const { data, originalDoc, req, value, collection } = props
+
+    invariant(
+      !!collection,
+      'Collection config missing in ensureUniqueSlug FieldHook. This is likely a misuse of the slug field.',
+    )
+
+    const tenantField = collection.fields.find(
+      (field) => 'name' in field && field.name === 'tenant',
+    )
+    const collectionHasTenantField = !!tenantField
+    const tenantFieldRequired =
+      tenantField && 'required' in tenantField && tenantField.required === true
+
+    const incomingTenantID = data?.tenant?.id ? data?.tenant.id : data?.tenant
+    const currentTenantID = originalDoc?.tenant?.id ? originalDoc.tenant.id : originalDoc?.tenant
+    const tenantIDToMatch = incomingTenantID || currentTenantID
+
+    const currentID = data?.id || originalDoc?.id
+
+    // Determine the desired slug: use the entered value, or auto-generate from the
+    // configured source field (+ date) when it's been left blank.
+    let desiredSlug = typeof value === 'string' ? value : ''
+    if (!desiredSlug && options.generateFromField) {
+      const source = data?.[options.generateFromField]
+      const base = typeof source === 'string' ? formatSlug(source) : ''
+      const dateSuffix = options.dateField ? formatDateForSlug(data?.[options.dateField]) : ''
+      desiredSlug = [base, dateSuffix].filter(Boolean).join('-')
+    }
+
+    // Don't validate if there is no slug yet
+    if (!desiredSlug) {
+      return value
+    }
+
+    const slugExists = async (candidate: string): Promise<boolean> => {
+      const conditions: Where[] = [{ slug: { equals: candidate } }]
+
+      if (currentID) {
+        conditions.push({ id: { not_in: [currentID] } })
+      }
+
+      if (collectionHasTenantField && tenantFieldRequired && tenantIDToMatch) {
+        conditions.push({ tenant: { equals: tenantIDToMatch } })
+      }
+
+      const res = await req.payload.find({
+        collection: collection.slug,
+        where: { and: conditions },
+        limit: 1,
+        depth: 0,
+      })
+
+      return res.docs.length > 0
+    }
+
+    if (!(await slugExists(desiredSlug))) {
+      return desiredSlug
+    }
+
+    // Slug collides with an existing document
+    if (options.autoSuffixOnDuplicate) {
+      let counter = 2
+      while (await slugExists(`${desiredSlug}-${counter}`)) {
+        counter++
+      }
+      return `${desiredSlug}-${counter}`
+    }
+
+    if (req.user) {
+      throw new APIError(
+        `A ${collection.labels.singular} with the slug "${desiredSlug}" already exists. Slug must be unique${collectionHasTenantField ? ' per avalanche center' : ''}.`,
+        400,
+      )
+    }
+
+    return desiredSlug
+  }

--- a/src/fields/slug/formatSlug.ts
+++ b/src/fields/slug/formatSlug.ts
@@ -10,6 +10,20 @@ export const formatSlug = (val: string | null): string => {
     .toLowerCase()
 }
 
+// Formats a date value as `YYYY-MM-DD` (UTC) for use in a slug; returns '' if not a valid date.
+export const formatDateForSlug = (value: unknown): string => {
+  if (typeof value !== 'string' && !(value instanceof Date)) {
+    return ''
+  }
+
+  const date = new Date(value)
+  if (isNaN(date.getTime())) {
+    return ''
+  }
+
+  return date.toISOString().slice(0, 10)
+}
+
 export const formatSlugHook =
   (fallback: string): FieldHook =>
   ({ data, operation, value }) => {

--- a/src/fields/slug/index.ts
+++ b/src/fields/slug/index.ts
@@ -10,26 +10,50 @@ export const setDuplicateSlug: FieldHook = async ({ value }) => {
   return `${value}-copy`
 }
 
-export const slugField = (fieldToUse: string = 'title'): TextField => ({
-  name: 'slug',
-  type: 'text',
-  index: true,
-  label: 'Slug',
-  required: true,
-  hooks: {
-    beforeDuplicate: [setDuplicateSlug],
-    beforeValidate: [ensureUniqueSlug],
-  },
-  validate: validateSlug,
-  admin: {
-    position: 'sidebar',
-    components: {
-      Field: {
-        path: '@/fields/slug/SlugComponent#SlugComponent',
-        clientProps: {
-          fieldToUse,
+type SlugFieldOptions = {
+  // When set, the slug auto-generates from `${fieldToUse}` plus this date field (as `-YYYY-MM-DD`)
+  // whenever it's left blank, and duplicates are resolved by appending `-2`, `-3`, ... instead of
+  // erroring. Used for collections like events where many documents share the same title.
+  autoGenerateFromDateField?: string
+}
+
+export const slugField = (
+  fieldToUse: string = 'title',
+  options: SlugFieldOptions = {},
+): TextField => {
+  const autoGenerate = !!options.autoGenerateFromDateField
+
+  return {
+    name: 'slug',
+    type: 'text',
+    index: true,
+    label: 'Slug',
+    // When auto-generating, the slug may be left blank — the hook fills it in before validation.
+    required: !autoGenerate,
+    hooks: {
+      beforeDuplicate: [setDuplicateSlug],
+      beforeValidate: [
+        ensureUniqueSlug({
+          generateFromField: autoGenerate ? fieldToUse : undefined,
+          dateField: options.autoGenerateFromDateField,
+          autoSuffixOnDuplicate: autoGenerate,
+        }),
+      ],
+    },
+    validate: validateSlug,
+    admin: {
+      position: 'sidebar',
+      description: autoGenerate
+        ? 'Leave blank to auto-generate from the title and start date. Duplicates are numbered automatically.'
+        : undefined,
+      components: {
+        Field: {
+          path: '@/fields/slug/SlugComponent#SlugComponent',
+          clientProps: {
+            fieldToUse,
+          },
         },
       },
     },
-  },
-})
+  }
+}

--- a/src/fields/slug/index.ts
+++ b/src/fields/slug/index.ts
@@ -51,6 +51,7 @@ export const slugField = (
           path: '@/fields/slug/SlugComponent#SlugComponent',
           clientProps: {
             fieldToUse,
+            dateField: options.autoGenerateFromDateField,
           },
         },
       },

--- a/src/fields/slug/index.ts
+++ b/src/fields/slug/index.ts
@@ -31,7 +31,9 @@ export const slugField = (
     // When auto-generating, the slug may be left blank — the hook fills it in before validation.
     required: !autoGenerate,
     hooks: {
-      beforeDuplicate: [setDuplicateSlug],
+      // Auto-generating slugs copy verbatim on duplicate so ensureUniqueSlug resolves the
+      // collision with a numbered suffix (-2, -3, …). Manual slugs append `-copy` to stay valid.
+      beforeDuplicate: autoGenerate ? [] : [setDuplicateSlug],
       beforeValidate: [
         ensureUniqueSlug({
           generateFromField: autoGenerate ? fieldToUse : undefined,
@@ -44,8 +46,8 @@ export const slugField = (
     admin: {
       position: 'sidebar',
       description: autoGenerate
-        ? 'Leave blank to auto-generate from the title and start date. Duplicates are numbered automatically.'
-        : undefined,
+        ? `Leave blank to auto-generate from ${fieldToUse} + start date. Duplicates get a numbered suffix.`
+        : `Auto-generated from ${fieldToUse}. Must be unique; lowercase letters, numbers, and hyphens only.`,
       components: {
         Field: {
           path: '@/fields/slug/SlugComponent#SlugComponent',

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -920,7 +920,10 @@ export interface Event {
     };
     [k: string]: unknown;
   } | null;
-  slug: string;
+  /**
+   * Leave blank to auto-generate from the title and start date. Duplicates are numbered automatically.
+   */
+  slug?: string | null;
   type: 'event' | 'awareness' | 'field-class';
   eventGroups?: (number | EventGroup)[] | null;
   eventTags?: (number | EventTag)[] | null;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -417,6 +417,9 @@ export interface Page {
     description?: string | null;
   };
   publishedAt?: string | null;
+  /**
+   * Auto-generated from title. Must be unique; lowercase letters, numbers, and hyphens only.
+   */
   slug: string;
   tenant: number | Tenant;
   documentReferences?:
@@ -503,6 +506,9 @@ export interface Tag {
     hasNextPage?: boolean;
     totalDocs?: number;
   };
+  /**
+   * Auto-generated from title. Must be unique; lowercase letters, numbers, and hyphens only.
+   */
   slug: string;
   contentHash?: string | null;
   updatedAt: string;
@@ -545,6 +551,9 @@ export interface Post {
   showDate?: boolean | null;
   tags?: (number | Tag)[] | null;
   relatedPosts?: (number | Post)[] | null;
+  /**
+   * Auto-generated from title. Must be unique; lowercase letters, numbers, and hyphens only.
+   */
   slug: string;
   documentReferences?:
     | {
@@ -772,6 +781,9 @@ export interface EventGroup {
     hasNextPage?: boolean;
     totalDocs?: number;
   };
+  /**
+   * Auto-generated from title. Must be unique; lowercase letters, numbers, and hyphens only.
+   */
   slug: string;
   contentHash?: string | null;
   updatedAt: string;
@@ -921,7 +933,7 @@ export interface Event {
     [k: string]: unknown;
   } | null;
   /**
-   * Leave blank to auto-generate from the title and start date. Duplicates are numbered automatically.
+   * Leave blank to auto-generate from title + start date. Duplicates get a numbered suffix.
    */
   slug?: string | null;
   type: 'event' | 'awareness' | 'field-class';
@@ -964,6 +976,9 @@ export interface EventTag {
     hasNextPage?: boolean;
     totalDocs?: number;
   };
+  /**
+   * Auto-generated from title. Must be unique; lowercase letters, numbers, and hyphens only.
+   */
   slug: string;
   contentHash?: string | null;
   updatedAt: string;
@@ -1778,6 +1793,9 @@ export interface Provider {
     hasNextPage?: boolean;
     totalDocs?: number;
   };
+  /**
+   * Auto-generated from name. Must be unique; lowercase letters, numbers, and hyphens only.
+   */
   slug: string;
   /**
    * This email will be used for email notifications. Defaults to the contact email if not specified.
@@ -1893,6 +1911,9 @@ export interface Course {
     | 'America/Los_Angeles'
     | 'America/Anchorage'
     | 'Pacific/Honolulu';
+  /**
+   * Auto-generated from title. Must be unique; lowercase letters, numbers, and hyphens only.
+   */
   slug: string;
   courseType: 'rec-1' | 'rec-2' | 'pro-1' | 'pro-2' | 'rescue' | 'awareness-external';
   modeOfTravel?: ('ski' | 'splitboard' | 'motorized' | 'snowshoe')[] | null;


### PR DESCRIPTION
## Description

Improves auto-generated slugs for collections with many same-named documents (notably **events** — ~150 share the title "Avalanche Awareness Class"). Slugs now reliably include the start date and resolve duplicates with a numbered suffix, and the admin UI's regenerate button matches the server behavior. Also fixes a bug where the date never made it into the slug if an editor touched the slug field.

## Related Issues

- Closes #1100 (slug naming convention)
- Breadcrumb readability is tracked separately in #728 (slugs no longer need to be human-readable once breadcrumbs render the title)

## Key Changes

- **Regenerate button now mirrors the server hook** (`SlugComponent`): it composes `title + -YYYY-MM-DD` instead of title-only. Previously the date logic only ran when the slug was left blank, so clicking ↻ (or otherwise populating the field) silently dropped the date.
- **`formatDateForSlug` moved to `formatSlug.ts`** so the client component and server hook share one definition.
- **Duplicates use numbers, not `-copy`** for auto-generating fields: on the Payload "Duplicate" action the slug copies verbatim and `ensureUniqueSlug` bumps it to `-2`, `-3`, … (matching the field description). Manual-slug collections keep `-copy`.
- **Clearer, concise field descriptions** explaining how the slug is generated.
- **Tests** for `formatSlug` / `formatDateForSlug` and the `ensureUniqueSlug` hook (auto-generation, numbered suffixes, collision errors, current-doc + tenant scoping).

## How to test

1. Create an event with a title and start date; leave the slug blank and save → slug is `…-YYYY-MM-DD`.
2. Edit the same event, clear the slug, click the ↻ refresh icon → it regenerates **with** the date.
3. Duplicate an event → new slug ends in `-2` (not `-copy`).
4. `pnpm test`, `pnpm tsc`, `pnpm lint` all pass.

## Screenshots / Demo video
<img width="384" height="122" alt="Kapture 2026-06-18 at 18 24 25" src="https://github.com/user-attachments/assets/a2692efc-2aab-4ee8-a72b-09939bff5d0c" />

## Migration Explanation

No schema change — slug generation is hook/UI logic only. No migration required.

## Future enhancements / Questions

- Manual-slug collections still append `-copy` on duplicate; happy to extend numbered suffixes to them too if preferred.
- A future option could fold a "host" field into the slug (e.g. `rei-…`) if event titles stay generic.