### PR TITLE
Add Conductor parallel-workspace port isolation

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,15 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+# Per-workspace setup + run for Conductor (conductor.build) parallel workspaces.
+# Both scripts are inert for teammates who don't use Conductor — they only run
+# inside a Conductor workspace. See scripts/conductor/ and docs/conductor.md.
+#
+# No `file_include_globs` is set: Conductor's default `.env*` copy already carries
+# the gitignored `.env` (secrets + DATABASE_URI) into each new workspace. The
+# generated .conductor/ports.env is deliberately NOT copied — it's regenerated with
+# unique per-workspace ports on every launch (and is gitignored).
+
+[scripts]
+setup    = "scripts/conductor/setup.sh"
+run      = "scripts/conductor/run.sh"
+run_mode = "concurrent"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ tsconfig.tsbuildinfo
 # Fallow runtime cache
 .fallow/
 
+# Conductor per-workspace ports (regenerated each launch; keep settings.toml tracked)
+.conductor/ports.env
+
 # AI
 .cursor
 .claude/*

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -1,0 +1,41 @@
+# Conductor parallel workspaces
+
+[Conductor](https://conductor.build) runs several isolated workspaces of this repo at once — each in its own git worktree with its own `dev.db`. This doc explains the per-workspace port isolation we added and why it's a no-op for anyone not using Conductor.
+
+## TL;DR for teammates who don't use Conductor
+
+**Nothing changes for you.** `pnpm dev` still serves `http://localhost:3000`, the debugger still attaches on `9229`, and `pnpm seed` is unchanged. The Conductor files (`.conductor/settings.toml`, `scripts/conductor/*`) only run when Conductor invokes them, and the one shared edit — the `dev` script — falls back to the exact same ports when its env vars are unset:
+
+```jsonc
+// package.json — identical behavior when PORT / INSPECT_PORT are unset
+"dev": "cross-env NODE_OPTIONS=\"${NODE_OPTIONS} --no-deprecation --inspect=${INSPECT_PORT:-9229}\" next dev --port ${PORT:-3000}"
+```
+
+## What Conductor does per workspace
+
+The base `CONDUCTOR_PORT` that Conductor assigns is **not** globally unique, so two workspaces can collide. We defend against that with a free-block probe instead of trusting the hint blindly.
+
+- **`setup` hook → `scripts/conductor/setup.sh`** (runs every launch, idempotent):
+  1. `pnpm install`
+  2. Probe upward from `CONDUCTOR_PORT` for 2 consecutive free ports (checking OS listeners + any docker-published ports), preferring the port previously chosen so the workspace URL stays stable. Write `.conductor/ports.env`.
+  3. Seed the DB **only if `dev.db` is absent** (first launch) via `pnpm seed:standalone` → login `admin@avy.com` / `localpass`.
+- **`run` hook → `scripts/conductor/run.sh`**: loads `.conductor/ports.env` and `exec pnpm dev`.
+
+`.conductor/ports.env` holds `PORT`, `INSPECT_PORT`, and `NEXT_PUBLIC_ROOT_DOMAIN=localhost:$PORT`. Setting `NEXT_PUBLIC_ROOT_DOMAIN` to match the chosen port is what keeps middleware tenant resolution and Payload CORS/CSRF consistent when the port shifts. The file is gitignored and regenerated each launch, so never edit it by hand.
+
+### The probe
+
+`scripts/conductor/probe.sh` exposes `find_free_block <hint> <size>`, which scans upward from `<hint>` for the first run of `<size>` consecutive free ports. It works with or without docker. Quick manual check (safe, read-only):
+
+```bash
+bash -c 'source scripts/conductor/probe.sh; find_free_block 3000 2'
+```
+
+With a dev server already on 3000 this prints the next free base (e.g. `3002`).
+
+## Notes / limits
+
+- **Secrets:** Conductor's default copy pattern (`.env*`) carries the gitignored `.env` into each workspace automatically, so we set no `file_include_globs`.
+- **DB seed** uses `seed:standalone` (in-process, no temp server, no `sqlite3` CLI dependency). To re-seed a workspace, delete its `dev.db*` and relaunch.
+- **Subdomains** (`nwac.localhost:$PORT`) rely on the machine-global `/etc/hosts` entries you already have; they're port-independent.
+- **Not isolated:** the Playwright e2e suite (hardcoded `localhost:3000` in specs) and the standalone `pnpm email:dev` (3001) are not part of the Conductor run flow.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
-    "dev": "cross-env NODE_OPTIONS=\"${NODE_OPTIONS} --no-deprecation --inspect\" next dev",
+    "dev": "cross-env NODE_OPTIONS=\"${NODE_OPTIONS} --no-deprecation --inspect=${INSPECT_PORT:-9229}\" next dev --port ${PORT:-3000}",
     "dev:prod": "cross-env NODE_OPTIONS=--no-deprecation rm -rf .next && pnpm build && pnpm start",
     "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",
     "generate:types": "cross-env NODE_OPTIONS=--no-deprecation payload generate:types",

--- a/scripts/conductor/probe.sh
+++ b/scripts/conductor/probe.sh
@@ -1,0 +1,61 @@
+# shellcheck shell=bash
+# Canonical free-block port probe for Conductor (conductor.build) workspaces.
+# Sourced (no shebang); requires bash for C-style for-loops and `local`.
+#
+# Source this file, then call `find_free_block <hint> <size> [own_project] [max_scan]`.
+# It scans upward from <hint> for the first run of <size> consecutive ports that
+# are ALL free, and echoes the base port of that run (exit 1 if none found).
+#
+# "Free" means: no OS TCP listener AND not published by any docker container —
+# EXCEPT containers belonging to <own_project> (your own COMPOSE_PROJECT_NAME),
+# which are treated as yours so re-running setup on a healthy stack doesn't churn.
+#
+# Why both checks: non-Conductor tools (a host Postgres, the Supabase CLI stack)
+# squat ports without participating in CONDUCTOR_PORT offsets. The OS check finds
+# bare listeners; the docker check finds published host ports even when lsof races
+# (the `{"5432/tcp":[]}` no-binding failure mode).
+#
+# macOS/BSD + Linux compatible. Requires: lsof; docker is optional.
+
+# port_in_use PORT [OWN_COMPOSE_PROJECT]
+#   returns 0 (in use) if a FOREIGN listener/container holds PORT, else 1.
+port_in_use() {
+  local port="$1" own="${2:-}"
+
+  # 1) docker-published host ports (authoritative for our compose stacks)
+  if command -v docker >/dev/null 2>&1; then
+    local owners
+    owners="$(docker ps --format '{{.Names}}'$'\t''{{.Ports}}' 2>/dev/null \
+      | awk -v pat=":${port}->" 'index($0, pat) {print $1}')"
+    if [ -n "$owners" ]; then
+      # FOREIGN if any owning container is not part of our own project.
+      if [ -z "$own" ] || printf '%s\n' "$owners" | grep -qv "^${own}"; then
+        return 0
+      fi
+      # All owners are ours → the port is ours, not a conflict.
+      return 1
+    fi
+  fi
+
+  # 2) bare OS TCP listener (host Postgres, Supabase CLI, stray dev server, …)
+  lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1 && return 0
+
+  return 1
+}
+
+# find_free_block HINT SIZE [OWN_COMPOSE_PROJECT] [MAX_SCAN]
+#   echoes base port of the first free run of SIZE ports at/after HINT.
+find_free_block() {
+  local hint="$1" size="$2" own="${3:-}" max_scan="${4:-500}"
+  local base="$hint" tries=0 p ok
+  while [ "$tries" -lt "$max_scan" ]; do
+    ok=1
+    for ((p = base; p < base + size; p++)); do
+      if port_in_use "$p" "$own"; then ok=0; break; fi
+    done
+    if [ "$ok" -eq 1 ]; then echo "$base"; return 0; fi
+    base=$((p + 1)) # jump past the colliding port, not just +1
+    tries=$((tries + 1))
+  done
+  return 1
+}

--- a/scripts/conductor/run.sh
+++ b/scripts/conductor/run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Conductor (conductor.build) `run` hook. Loads the per-workspace ports chosen by
+# setup.sh (PORT, INSPECT_PORT, NEXT_PUBLIC_ROOT_DOMAIN) and starts the dev server.
+# The `dev` script reads ${PORT:-3000} / ${INSPECT_PORT:-9229}, and Next.js inlines
+# the exported NEXT_PUBLIC_ROOT_DOMAIN (process env beats .env), keeping the origin,
+# CORS/CSRF and tenant routing consistent with the chosen port.
+#
+# Backward-compatible: with no ports.env (a non-Conductor checkout), this falls
+# through to a plain `pnpm dev` on the default 3000/9229.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ -f "$REPO_ROOT/.conductor/ports.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$REPO_ROOT/.conductor/ports.env"
+  set +a
+fi
+
+exec pnpm dev

--- a/scripts/conductor/setup.sh
+++ b/scripts/conductor/setup.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Conductor (conductor.build) `setup` hook — runs on every workspace launch, so it
+# MUST be idempotent. It:
+#   1. installs deps (fast when node_modules is warm),
+#   2. probes a free, stable port block from the CONDUCTOR_PORT hint and writes
+#      .conductor/ports.env (consumed by run.sh),
+#   3. seeds the local SQLite DB ONLY on first launch (when dev.db is absent).
+#
+# Fully backward-compatible: when CONDUCTOR_PORT is unset (a teammate not using
+# Conductor never runs this), it defaults to the normal 3000/9229 ports.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+# shellcheck source=scripts/conductor/probe.sh
+source "$REPO_ROOT/scripts/conductor/probe.sh"
+
+BLOCK_SIZE=2 # offset 0 = next dev HTTP port, offset 1 = Node --inspect port
+PORTS_FILE="$REPO_ROOT/.conductor/ports.env"
+
+# 1) deps — idempotent; a no-op when already installed
+pnpm install
+
+# 2) choose a free, stable port block
+if [ -n "${CONDUCTOR_PORT:-}" ]; then
+  HINT="$CONDUCTOR_PORT"
+  # Prefer the previously-chosen port so the workspace URL stays stable across restarts.
+  if [ -f "$PORTS_FILE" ]; then
+    PREV="$(grep -E '^PORT=' "$PORTS_FILE" 2>/dev/null | cut -d= -f2 || true)"
+    [ -n "$PREV" ] && HINT="$PREV"
+  fi
+  if ! BASE="$(find_free_block "$HINT" "$BLOCK_SIZE")"; then
+    echo "conductor: ERROR — no free ${BLOCK_SIZE}-port block from $HINT" >&2
+    exit 1
+  fi
+  [ "$BASE" != "$HINT" ] && echo "conductor: shifted off $HINT -> $BASE (collision)"
+  PORT="$BASE"
+  INSPECT_PORT="$((BASE + 1))"
+else
+  # Non-Conductor safety net — never reached inside a Conductor workspace.
+  PORT=3000
+  INSPECT_PORT=9229
+fi
+
+mkdir -p "$REPO_ROOT/.conductor"
+cat >"$PORTS_FILE" <<EOF
+PORT=$PORT
+INSPECT_PORT=$INSPECT_PORT
+NEXT_PUBLIC_ROOT_DOMAIN=localhost:$PORT
+EOF
+echo "conductor: PORT=$PORT INSPECT_PORT=$INSPECT_PORT (localhost:$PORT)"
+
+# 3) first-run seed only — never wipe an existing workspace DB on relaunch
+if [ ! -f "$REPO_ROOT/dev.db" ]; then
+  echo "conductor: no dev.db — seeding (first launch)…"
+  # Match the documented WAL journal mode if the sqlite3 CLI is available (best-effort;
+  # seed:standalone works without it — Payload push-mode creates the DB regardless).
+  command -v sqlite3 >/dev/null 2>&1 && sqlite3 "$REPO_ROOT/dev.db" 'PRAGMA journal_mode=WAL;' >/dev/null
+  # Seed with the workspace's own origin so any URL derivation matches the port.
+  set -a
+  # shellcheck source=/dev/null
+  . "$PORTS_FILE"
+  set +a
+  pnpm seed:standalone
+else
+  echo "conductor: dev.db present — skipping seed"
+fi


### PR DESCRIPTION
I use Conductor quite a bit these days so this is just setting the repo up for using Conductor. 

## Description

Wire the repo for [Conductor](https://conductor.build) parallel workspaces with per-workspace port isolation, kept fully backward-compatible with the normal dev setup. When `CONDUCTOR_PORT` is unset (any teammate not using Conductor), behavior is byte-for-byte unchanged: `pnpm dev` still serves `localhost:3000` and the debugger attaches on `9229`.

Conductor runs several isolated worktrees of this repo at once, each with its own `dev.db`. Two workspaces can be assigned colliding base ports, so we don't trust the `CONDUCTOR_PORT` hint blindly — we probe upward for the first free block and pin the workspace's origin (`NEXT_PUBLIC_ROOT_DOMAIN`) to the chosen port so middleware tenant resolution and Payload CORS/CSRF stay consistent.

## Related Issues

None.

## Key Changes

- **`scripts/conductor/probe.sh`** — free-block port probe. `find_free_block <hint> <size>` scans upward for the first run of consecutive free ports, checking both OS TCP listeners and docker-published host ports (so a stray Postgres/Supabase stack can't silently squat a port).
- **`scripts/conductor/setup.sh`** — `setup` hook (runs every launch, idempotent): `pnpm install`, probe a stable free block from `CONDUCTOR_PORT` (preferring the previously chosen port so the workspace URL is stable across restarts), write `.conductor/ports.env`, and seed `dev.db` **only on first launch** (never wipes an existing workspace DB).
- **`scripts/conductor/run.sh`** — `run` hook: sources `.conductor/ports.env` and `exec pnpm dev`.
- **`.conductor/settings.toml`** — registers the setup/run hooks (`run_mode = concurrent`); relies on Conductor's default `.env*` copy for secrets, so no `file_include_globs`.
- **`package.json`** — parameterize the `dev` script: `next dev --port ${PORT:-3000}` and `--inspect=${INSPECT_PORT:-9229}`. Byte-identical when the vars are unset.
- **`.gitignore`** — ignore the generated `.conductor/ports.env` (regenerated per launch).
- **`docs/conductor.md`** — explains the setup and why it's a no-op for non-Conductor teammates.

## How to test

Non-Conductor path (unchanged):

```bash
pnpm dev   # still localhost:3000, debugger on 9229
```

Probe (safe, read-only):

```bash
bash -c 'source scripts/conductor/probe.sh; find_free_block 3000 2'
# prints 3000 if free; with a dev server on 3000, prints the next free base (e.g. 3002)
```

Conductor path: launch a workspace and confirm `.conductor/ports.env` is written with a free `PORT`/`INSPECT_PORT` and a matching `NEXT_PUBLIC_ROOT_DOMAIN`, that the dev server binds that port, and that a first-launch seed populates `dev.db` (subsequent launches skip the seed). Verified end-to-end on a real workspace (`PORT=55110`): probe + `ports.env` written, seed populated the DB (4 tenants / 19 users / 112 pages), and the `.env`-copied `localhost:3000` is correctly overridden by the exported port (Next's env loader doesn't overwrite already-set `process.env` vars).

## Screenshots / Demo video

N/A — tooling/infra only.

## Migration Explanation

No schema or migration changes.

## Future enhancements / Questions

- The Playwright e2e suite (hardcoded `localhost:3000`) and standalone `pnpm email:dev` (3001) are not part of the Conductor run flow and remain non-isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
