### PR TITLE
Show City, State at a glance in events viewer

### DIFF
--- a/__tests__/client/components/LocationPopover.client.test.tsx
+++ b/__tests__/client/components/LocationPopover.client.test.tsx
@@ -1,0 +1,43 @@
+import { LocationPopover } from '@/components/EventPreview/LocationPopover'
+import type { Event } from '@/payload-types'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+const buildLocation = (
+  overrides: Partial<NonNullable<Event['location']>> = {},
+): NonNullable<Event['location']> => ({
+  isVirtual: false,
+  placeName: 'Snoqualmie Pass Trailhead',
+  city: 'Snoqualmie Pass',
+  state: 'WA',
+  ...overrides,
+})
+
+describe('LocationPopover', () => {
+  it('shows City, State at a glance without opening the popover', () => {
+    render(<LocationPopover location={buildLocation()} />)
+
+    expect(screen.getByText('Snoqualmie Pass Trailhead')).toBeInTheDocument()
+    expect(screen.getByText('Snoqualmie Pass, WA')).toBeInTheDocument()
+  })
+
+  it('shows only the city when no state is set', () => {
+    render(<LocationPopover location={buildLocation({ state: null })} />)
+
+    expect(screen.getByText('Snoqualmie Pass')).toBeInTheDocument()
+  })
+
+  it('shows only the state when no city is set', () => {
+    render(<LocationPopover location={buildLocation({ city: null })} />)
+
+    expect(screen.getByText('WA')).toBeInTheDocument()
+  })
+
+  it('omits the City, State line when neither city nor state is set', () => {
+    render(<LocationPopover location={buildLocation({ city: null, state: null })} />)
+
+    // Only the placeName should remain as visible location text
+    expect(screen.getByText('Snoqualmie Pass Trailhead')).toBeInTheDocument()
+    expect(screen.queryByText(/,/)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/EventPreview/LocationPopover.tsx
+++ b/src/components/EventPreview/LocationPopover.tsx
@@ -16,56 +16,65 @@ type LocationPopoverProps = {
 export const LocationPopover = ({ location }: LocationPopoverProps) => {
   const [isLocationOpen, setIsLocationOpen] = useState(false)
 
+  const cityState = [location.city, location.state].filter(Boolean).join(', ')
+
   return (
-    <Popover open={isLocationOpen} onOpenChange={setIsLocationOpen}>
-      <PopoverTrigger className="min-w-0 max-w-full">
-        <div className="flex items-center gap-1.5 min-w-0 text-muted-foreground">
-          <MapPin className="h-4 w-4 mt-0.5 " />
-          <p className="whitespace-nowrap overflow-hidden text-ellipsis min-w-0 text-sm ">
-            {location.placeName}
-          </p>
-          <ChevronDown
-            className={cn(
-              'h-4 w-4 flex-shrink-0 transition-transform duration-200',
-              isLocationOpen && 'rotate-180',
-            )}
-          />
-        </div>
-      </PopoverTrigger>
-      <PopoverContent align="start" className="p-3 text-sm w-auto min-w-[200px]">
-        <div className="select-text mb-2">
-          {location.address && <div>{location.address}</div>}
-          <div>
-            {location.city && `${location.city}, `}
-            {location.state && `${location.state} `}
-            {location.zip}
+    <div className="flex flex-col min-w-0">
+      <Popover open={isLocationOpen} onOpenChange={setIsLocationOpen}>
+        <PopoverTrigger className="min-w-0 max-w-full">
+          <div className="flex items-center gap-1.5 min-w-0 text-muted-foreground">
+            <MapPin className="h-4 w-4 mt-0.5 " />
+            <p className="whitespace-nowrap overflow-hidden text-ellipsis min-w-0 text-sm ">
+              {location.placeName}
+            </p>
+            <ChevronDown
+              className={cn(
+                'h-4 w-4 flex-shrink-0 transition-transform duration-200',
+                isLocationOpen && 'rotate-180',
+              )}
+            />
           </div>
-        </div>
-        <div className="flex gap-2">
-          <CopyButton
-            text={[
-              location.address,
-              [location.city, location.state, location.zip].filter(Boolean).join(' '),
-            ]
-              .filter(Boolean)
-              .join(', ')}
-            className="flex items-center gap-1 text-xs hover:text-foreground transition-colors"
-          />
-          <a
-            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
-              [location.address, location.city, location.state, location.zip]
+        </PopoverTrigger>
+        <PopoverContent align="start" className="p-3 text-sm w-auto min-w-[200px]">
+          <div className="select-text mb-2">
+            {location.address && <div>{location.address}</div>}
+            <div>
+              {location.city && `${location.city}, `}
+              {location.state && `${location.state} `}
+              {location.zip}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <CopyButton
+              text={[
+                location.address,
+                [location.city, location.state, location.zip].filter(Boolean).join(' '),
+              ]
                 .filter(Boolean)
-                .join(', '),
-            )}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 text-xs hover:text-foreground transition-colors"
-          >
-            <ExternalLink className="h-3 w-3" />
-            Open in Maps
-          </a>
-        </div>
-      </PopoverContent>
-    </Popover>
+                .join(', ')}
+              className="flex items-center gap-1 text-xs hover:text-foreground transition-colors"
+            />
+            <a
+              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+                [location.address, location.city, location.state, location.zip]
+                  .filter(Boolean)
+                  .join(', '),
+              )}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-xs hover:text-foreground transition-colors"
+            >
+              <ExternalLink className="h-3 w-3" />
+              Open in Maps
+            </a>
+          </div>
+        </PopoverContent>
+      </Popover>
+      {cityState && (
+        <p className="text-sm text-muted-foreground pl-[22px] whitespace-nowrap overflow-hidden text-ellipsis">
+          {cityState}
+        </p>
+      )}
+    </div>
   )
 }


### PR DESCRIPTION
## Description

In the public events viewer, each event's location was shown as the venue **place name** with a caret popover. City and State were only visible *after* opening the popover, so users couldn't tell where an event was happening while scanning the list.

This adds an always-visible `City, State` line directly beneath the location trigger, matching the layout requested in #1098:

```
Date, Time
Skill Level
Location (place name with caret dropdown for full address)
City, State
```

## Related Issues

Fixes #1098

## Key Changes

- `src/components/EventPreview/LocationPopover.tsx` — wrap the popover in a column container and render a `City, State` line beneath the trigger. Gracefully falls back to city-only or state-only, and is omitted entirely when neither is set. The full address (street, city, state, zip, copy, and "Open in Maps") remains available in the popover.
- `__tests__/client/components/LocationPopover.client.test.tsx` — new client tests covering the city+state, city-only, state-only, and neither cases.

## How to test

1. Visit a center's `/events` page with events that have a physical location (e.g. `nwac.localhost:3000/events`).
2. Confirm each event shows the venue place name with the caret, and a `City, State` line directly beneath it — without clicking the caret.
3. Open the caret popover and confirm the full address / copy / Open in Maps still work.
4. Virtual events are unaffected (they render the "Virtual Event" badge instead of a location).

Automated: `pnpm test` (529 passing, including the new `LocationPopover` tests), `pnpm tsc`, `pnpm lint`.

## Screenshots / Demo video

_N/A — see "How to test" above._

## Migration Explanation

No schema or migration changes; this is a presentational change only.

## Future enhancements / Questions

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s7MJjeP8Mr3KRiRA22WwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016s7MJjeP8Mr3KRiRA22WwJ)_