### PR TITLE
Consolidate triage label vocabulary

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,5 +1,5 @@
 ---
 name: Blank issue
 about: Create a new issue from scratch
-labels: NEW
+labels: needs-triage
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a bug
 title: ''
-labels: bug, NEW
+labels: bug, needs-triage
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/claude-task.md
+++ b/.github/ISSUE_TEMPLATE/claude-task.md
@@ -2,7 +2,7 @@
 name: Claude Task
 about: Request a code change that Claude can implement
 title: ''
-labels: claude
+labels: ready-for-agent
 assignees: ''
 ---
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,17 +1,43 @@
 # Triage Labels
 
-The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker, and documents the rest of the label vocabulary so agent-assisted triage and reality stay in sync.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
-| -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
-| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+## Canonical triage roles
 
-When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+The five **state** roles map one-to-one to labels of the same name. Every triaged issue carries exactly one state label plus exactly one category label.
 
-Of these, only `wontfix` currently exists as a GitHub label. The `triage` skill will create the other four (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`) the first time it needs them — or you can pre-create them with `gh label create <name>`.
+| Canonical role    | Label in our tracker | Meaning                                  |
+| ----------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`    | Requires human implementation            |
+| `wontfix`         | `wontfix`            | Will not be actioned                     |
 
-Edit the right-hand column to match whatever vocabulary you actually use.
+The two **category** roles are `bug` and `enhancement`. Tech-debt work is an `enhancement` carrying the `tech debt` modifier, not a third category.
+
+## Other labels
+
+These are not triage states, but they coexist with them on issues:
+
+| Label               | Kind      | Meaning                                                                    |
+| ------------------- | --------- | ------------------------------------------------------------------------- |
+| `good first issue`  | modifier  | Suitable for an open-source contributor; pair with an agent-style brief.   |
+| `tech debt`         | modifier  | Internal quality work; applied alongside `enhancement`.                    |
+| `blocked`           | modifier  | Blocked by a dependency or other change; orthogonal to state.             |
+| `payload-workaround`| modifier  | Tracks a workaround to revisit when the upstream Payload fix lands.        |
+| `tenant:<slug>`     | scoping   | Specific to one avalanche center (e.g. `tenant:nwac`). New slugs created on demand. |
+| `dependencies`      | PR label  | Dependabot dependency-update PRs. Not part of issue triage.               |
+| `javascript`        | PR label  | Dependabot JavaScript PRs. Not part of issue triage.                       |
+
+## Auto-labeling on arrival
+
+Issue templates stamp a starting state so the untriaged bucket never silently regrows:
+
+- **Bug report** → `bug`, `needs-triage`
+- **Blank issue** → `needs-triage`
+- **Claude Task** → `ready-for-agent` (a maintainer-authored Claude task is fully specified by construction)
+
+## History
+
+This vocabulary was consolidated in PRD [#1132](https://github.com/NWACus/web/issues/1132). Legacy labels were migrated (`NEW` → `needs-triage`, `needs user feedback` → `needs-info`, `needs-investigation` → `needs-triage`) and retired labels removed (`question`, `quick fix`, `urgent`, `area:admin`, `area:frontend`, `area:backend`, `area:infra`). `NWAC Specific` was renamed to `tenant:nwac`.


### PR DESCRIPTION
## Description

Implements the label-wiring portion of PRD #1132: points the issue templates at the canonical triage states and rewrites the triage-labels doc to describe the actual label set. The tracker-side label operations (create/rename/migrate/delete) and the Phase 1 backlog sweep were applied directly via the GitHub API and are not part of this diff — see the PRD and the summary below.

## Related Issues

Part of #1132

## Key Changes

- `bug_report.md`: `bug, NEW` → `bug, needs-triage`
- `blank.md`: `NEW` → `needs-triage`
- `claude-task.md`: `claude` (a label that did not exist, silently dropped by GitHub) → `ready-for-agent`
- `docs/agents/triage-labels.md`: rewritten to document the 14-label vocabulary (5 states, 2 categories, `tenant:<slug>`, modifiers, Dependabot PR labels), auto-labeling behavior, and the migration history.

## How to test

Open a new issue from each template and confirm the applied labels: Bug report → `bug` + `needs-triage`; Blank → `needs-triage`; Claude Task → `ready-for-agent`. All three referenced labels now exist in the repo.

## Migration Explanation

No database migration. Tracker label state was reconciled out-of-band: created `needs-triage`/`needs-info`/`ready-for-agent`/`ready-for-human`; renamed `NWAC Specific` → `tenant:nwac`; migrated `NEW`→`needs-triage`, `needs user feedback`→`needs-info`, `needs-investigation`→`needs-triage`; deleted `question`, `quick fix`, `urgent`, and the four `area:*` labels.

## Future enhancements / Questions

Phase 2 (deep triage of the `needs-triage` backlog into `ready-for-agent`/`ready-for-human`/`wontfix`) is tracked by the plan in #1132 and happens in later triage sessions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785951770&installation_id=144816107&pr_number=1138&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1138&signature=f13fbc8b60c9bcd1ccf518b6e81b143abc06faa1327f828de6d2823764280721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->