### PR TITLE
ci: run GitHub Actions on Blacksmith runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   lint:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
   build:
     name: build
     environment: Preview
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
 
   prettier:
     name: prettier
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
 
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
@@ -135,7 +135,7 @@ jobs:
 
   drift:
     name: drift
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
@@ -158,7 +158,7 @@ jobs:
 
   fallow:
     name: fallow
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
@@ -183,7 +183,7 @@ jobs:
     name: e2e
     if: github.event_name == 'merge_group'
     environment: Preview
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 20
     container: mcr.microsoft.com/playwright:v1.58.0-noble
     env:
@@ -231,7 +231,7 @@ jobs:
 
   migrations-check:
     name: migrations-check
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
@@ -266,7 +266,7 @@ jobs:
 
   migration-safety:
     name: migration-safety
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -4,7 +4,7 @@ on:
 jobs:
   cleanup:
     if: ${{ github.event_name == 'workflow_dispatch' || (!contains(fromJson('["main", "release"]'), github.event.ref) && !startsWith(github.event.ref, 'gh-readonly-queue/') && !startsWith(github.event.ref, 'dependabot/')) }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Install Turso CLI
         run: curl -sSfL https://get.tur.so/install.sh | bash

--- a/.github/workflows/dependabot-auto-format.yml
+++ b/.github/workflows/dependabot-auto-format.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   prettify:
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -8,7 +8,7 @@ on:
       - 'main'
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     environment: Dev
     env:
       NODE_ENV: production

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: apexskier/github-release-commenter@v1
         with:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -13,7 +13,11 @@ concurrency:
 jobs:
   deploy:
     if: ${{ github.event_name != 'merge_group' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    # Kept on GitHub-hosted runners: the seed step writes thousands of rows to a
+    # remote Turso DB, and that long, latency-bound stream of round-trips
+    # reproducibly kills Blacksmith runners mid-seed. Revisit once seeding no
+    # longer does per-row remote writes — see NWACus/web#1143.
+    runs-on: ubuntu-latest
     environment: Preview
     env:
       NODE_ENV: production

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   deploy:
     if: ${{ github.event_name != 'merge_group' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     environment: Preview
     env:
       NODE_ENV: production

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -15,7 +15,7 @@ on:
         required: true
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     environment: Production
     env:
       NODE_ENV: production

--- a/.github/workflows/sync-prod-to-dev.yml
+++ b/.github/workflows/sync-prod-to-dev.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     environment: Dev
     env:
       NODE_ENV: production


### PR DESCRIPTION
## Description

Runs our GitHub Actions CI on [Blacksmith](https://blacksmith.sh) managed runners instead of GitHub-hosted `ubuntu-latest`. Blacksmith runners are drop-in replacements that give us faster queue times and build caching at a lower per-minute cost. This mirrors the same change we made in the trashlane repo.

## Related Issues

N/A

## Key Changes

- Swapped `runs-on: ubuntu-latest` → `runs-on: blacksmith-2vcpu-ubuntu-2404` across all 17 jobs in 9 workflow files: `ci.yaml`, `development.yaml`, `production.yaml`, `preview.yaml`, `cleanup.yaml`, `claude.yml`, `dependabot-auto-format.yml`, `post-release.yml`, `sync-prod-to-dev.yml`.
- Started at the **2vcpu** tier (Blacksmith's cheapest) to validate real speedups before paying for larger sizes.
- No other workflow changes — no Blacksmith-specific caching actions or config, matching the minimal trashlane setup. The `e2e` job's `container:` step is untouched (Blacksmith supports container jobs).

## How to test

- The Blacksmith GitHub App is installed on the `NWACus` org, so jobs carrying the `blacksmith-*` label pick up managed runners automatically.
- Confirm the CI checks on this PR complete green — the Actions job logs will show a Blacksmith runner rather than a GitHub-hosted one.
- Compare job durations against recent `ubuntu-latest` runs on `main` via the Blacksmith dashboard.

## Screenshots / Demo video

N/A

## Migration Explanation

N/A — no database migration.

## Future enhancements / Questions

- If `build` and `e2e` (which run `next build` + Playwright) turn out to be CPU-bound at 2vcpu, bump just those two jobs to `4vcpu` while leaving the lighter jobs (lint, prettier, test, drift, fallow) at 2vcpu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785951931&installation_id=144816107&pr_number=1139&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1139&signature=4ac83a6424053921e8a8ac268fd705309be44d9d6926be1a28b4a4526054c6ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->