### PR TITLE
Fix draft navigation reference picker

### DIFF
--- a/__tests__/server/collectionFilters.server.test.ts
+++ b/__tests__/server/collectionFilters.server.test.ts
@@ -1,0 +1,61 @@
+import { getTenantAndPublishedFilter } from '@/utilities/collectionFilters'
+
+const baseProps: Parameters<typeof getTenantAndPublishedFilter>[0] = {
+  data: {},
+  req: {
+    headers: new Headers(),
+  },
+  relationTo: 'pages',
+}
+
+describe('getTenantAndPublishedFilter', () => {
+  it('adds the published status filter for page references', () => {
+    expect(
+      getTenantAndPublishedFilter({
+        ...baseProps,
+        relationTo: 'pages',
+      }),
+    ).toEqual({
+      _status: {
+        equals: 'published',
+      },
+    })
+  })
+
+  it('preserves tenant scoping when filtering page references', () => {
+    expect(
+      getTenantAndPublishedFilter({
+        ...baseProps,
+        data: { tenant: 7 },
+        relationTo: 'posts',
+      }),
+    ).toEqual({
+      and: [
+        {
+          tenant: {
+            equals: 7,
+          },
+        },
+        {
+          _status: {
+            equals: 'published',
+          },
+        },
+      ],
+    })
+  })
+
+  it('does not add a draft status filter for built-in page references', () => {
+    expect(
+      getTenantAndPublishedFilter({
+        ...baseProps,
+        data: { tenant: 7 },
+        relationTo: 'builtInPages',
+      }),
+    ).toEqual({
+      tenant: {
+        equals: 7,
+      },
+    })
+  })
+})

--- a/__tests__/server/headerUtils.server.test.ts
+++ b/__tests__/server/headerUtils.server.test.ts
@@ -1,4 +1,5 @@
 import {
+  convertToNavLink,
   extractAllInternalUrls,
   findNavigationItemBySlug,
   getCanonicalUrlsFromNavigation,
@@ -731,6 +732,52 @@ describe('Header Utilities', () => {
     it('returns empty array when the tab is missing', () => {
       // NavTab is an optional field — confirm the function handles undefined gracefully
       expect(topLevelNavItem({ tab: undefined, label: 'Weather' })).toEqual([])
+    })
+  })
+
+  describe('convertToNavLink', () => {
+    it('does not render draft page references', () => {
+      const result = convertToNavLink({
+        type: 'internal',
+        reference: {
+          relationTo: 'pages',
+          value: {
+            id: 1,
+            slug: 'who-we-are',
+            title: 'Who We Are',
+            tenant: 1,
+            layout: [],
+            updatedAt: '2026-07-01T00:00:00.000Z',
+            createdAt: '2026-07-01T00:00:00.000Z',
+            _status: 'draft',
+          },
+        },
+      })
+
+      expect(result).toBeUndefined()
+    })
+
+    it('renders built-in page references without draft filtering', () => {
+      const result = convertToNavLink({
+        type: 'internal',
+        reference: {
+          relationTo: 'builtInPages',
+          value: {
+            id: 1,
+            title: 'Forecasts',
+            url: '/forecasts/avalanche',
+            tenant: 1,
+            updatedAt: '2026-07-01T00:00:00.000Z',
+            createdAt: '2026-07-01T00:00:00.000Z',
+          },
+        },
+      })
+
+      expect(result).toEqual({
+        type: 'internal',
+        label: 'Forecasts',
+        url: '/forecasts/avalanche',
+      })
     })
   })
 })

--- a/src/fields/linkField.ts
+++ b/src/fields/linkField.ts
@@ -1,5 +1,5 @@
 import { clearIrrelevantLinkValues } from '@/utilities/clearIrrelevantLinkValues'
-import { getTenantFilter } from '@/utilities/collectionFilters'
+import { getTenantAndPublishedFilter } from '@/utilities/collectionFilters'
 import { validateExternalUrl } from '@/utilities/validateUrl'
 import { Field, NamedGroupField, TextFieldSingleValidation } from 'payload'
 import { text } from 'payload/shared'
@@ -65,7 +65,7 @@ const buildLinkFields = ({
     label: 'Select page or post',
     relationTo: ['pages', 'builtInPages', 'posts'],
     required: true,
-    filterOptions: getTenantFilter,
+    filterOptions: getTenantAndPublishedFilter,
   }
 
   const urlField: Field = {

--- a/src/utilities/collectionFilters.ts
+++ b/src/utilities/collectionFilters.ts
@@ -1,11 +1,32 @@
 import { FilterOptionsProps, Where } from 'payload'
 import { getTenantSlugFromCookie } from './tenancy/getTenantFromCookie'
 
+const draftableLinkCollections = new Set(['pages', 'posts'])
+
+type TenantFilterProps = {
+  data: FilterOptionsProps['data']
+  req: Pick<FilterOptionsProps['req'], 'headers'>
+}
+
+type TenantPublishedFilterProps = TenantFilterProps & Pick<FilterOptionsProps, 'relationTo'>
+type TenantIdFilterProps = TenantFilterProps & Pick<FilterOptionsProps, 'id'>
+
+const combineFilters = (...filters: Where[]): Where => {
+  const activeFilters = filters.filter((filter) => Object.keys(filter).length > 0)
+
+  if (activeFilters.length === 0) return {}
+  if (activeFilters.length === 1) return activeFilters[0]
+
+  return {
+    and: activeFilters,
+  }
+}
+
 export const getImageTypeFilter = () => ({
   mimeType: { contains: 'image' },
 })
 
-export const getTenantFilter = ({ data, req }: FilterOptionsProps): Where => {
+export const getTenantFilter = ({ data, req }: TenantFilterProps): Where => {
   // If the document already has a tenant relationship set, use that
   if (data.tenant) {
     return {
@@ -28,7 +49,19 @@ export const getTenantFilter = ({ data, req }: FilterOptionsProps): Where => {
   return {}
 }
 
-export const getTenantAndIdFilter = ({ id, data, req }: FilterOptionsProps): Where => {
+export const getTenantAndPublishedFilter = (props: TenantPublishedFilterProps): Where => {
+  const tenantFilter = getTenantFilter(props)
+
+  if (!draftableLinkCollections.has(props.relationTo)) return tenantFilter
+
+  return combineFilters(tenantFilter, {
+    _status: {
+      equals: 'published',
+    },
+  })
+}
+
+export const getTenantAndIdFilter = ({ id, data, req }: TenantIdFilterProps): Where => {
   const idFilter = { id: { not_in: [id] } }
 
   // If the document already has a tenant relationship set, use that


### PR DESCRIPTION
## Description

Fixes #1084 by taking the simpler "exclude drafts" path from the issue brief.

The navigation relationship picker now keeps the existing tenant scoping and adds `_status = published` only when Payload is loading `pages` or `posts` options. `builtInPages` are left with the original tenant-only filter because they do not have draft state.

## Related Issues

Fixes #1084

## Key Changes

- Added `getTenantAndPublishedFilter` for polymorphic navigation references.
- Switched the shared link relationship field to use that filter.
- Added regression coverage for:
  - published-only filtering on pages/posts,
  - preserving tenant scoping,
  - leaving built-in page references unaffected,
  - existing live-site behavior that drops draft page references.

## How to test

- `pnpm run lint-staged`
- `pnpm run tsc`
- `pnpm test`
- `pnpm drift:check`
- `pnpm fallow:audit --ci`
- `.husky/check-migrations`

## Screenshots / Demo video

Not included; this is a relationship picker filtering change with unit coverage.

## Migration Explanation

No migration needed.

## Future enhancements / Questions

The draft badge approach from the issue would still be a richer UX, but it requires a custom Payload relationship field component. This PR keeps the change small by excluding drafts from the picker.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785971039&installation_id=144816107&pr_number=1142&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1142&signature=5d95193e5c176dc2e2e5ce011de18fa13c4a816f13991d911975e6cb68bf2f9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->