### PR TITLE
ci: seed preview database locally then bulk-import to Turso

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -75,6 +75,12 @@ jobs:
           DATABASE_URI: 'file:./preview-seed.db'
           PAYLOAD_SEED_PASSWORD: '${{ secrets.PAYLOAD_SEED_PASSWORD }}'
           PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
+          # Seeding now runs before `vercel env pull`, so the `.env` that
+          # `payload run` loads doesn't exist yet and this token has to be passed
+          # explicitly. Without it `vercelBlobStorage` is disabled and seeded
+          # uploads are written to the runner's disk instead of Vercel Blob,
+          # leaving every seeded image and document 404ing in the preview.
+          VERCEL_BLOB_READ_WRITE_TOKEN: '${{ secrets.VERCEL_BLOB_READ_WRITE_TOKEN }}'
       - name: Create the preview database from the seeded file
         # Bulk-import the seeded local DB into a fresh Turso DB in one operation.
         # We use `--from-dump` (plain SQL) rather than `--from-file`: the latter

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -90,9 +90,24 @@ jobs:
           sqlite3 ./preview-seed.db .dump > ./preview-seed.sql
 
           /home/runner/.turso/turso org switch nwac
-          if /home/runner/.turso/turso db show "${name}"; then
+
+          # Don't probe with `db show`: it exits non-zero both when the database
+          # is absent and when the API is merely unhealthy, so a transient error
+          # reads as "absent", skips the destroy, and then fails the create with
+          # "already exists". `db list` fails only on a real error, so treat any
+          # failure as fatal rather than guessing. Non-interactive `db list`
+          # walks every page and prints a table whose first column is the name.
+          if ! databases=$(/home/runner/.turso/turso db list); then
+            echo "Could not list Turso databases; refusing to guess whether ${name} exists." >&2
+            exit 1
+          fi
+
+          # Match the NAME column exactly; a substring match would target a
+          # different database whose name merely starts with this one.
+          if awk -v name="${name}" '$1 == name { found = 1 } END { exit !found }' <<<"${databases}"; then
             /home/runner/.turso/turso db destroy "${name}" --yes
           fi
+
           /home/runner/.turso/turso db create "${name}" --from-dump ./preview-seed.sql --wait
           /home/runner/.turso/turso db shell "${name}" .tables
         env:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -13,10 +13,12 @@ concurrency:
 jobs:
   deploy:
     if: ${{ github.event_name != 'merge_group' }}
-    # Kept on GitHub-hosted runners: the seed step writes thousands of rows to a
-    # remote Turso DB, and that long, latency-bound stream of round-trips
-    # reproducibly kills Blacksmith runners mid-seed. Revisit once seeding no
-    # longer does per-row remote writes — see NWACus/web#1143.
+    # Still on GitHub-hosted runners, but no longer out of necessity: seeding now
+    # writes to a local SQLite file that is bulk-imported into the fresh Turso
+    # preview DB in one operation, so it no longer streams the thousands of
+    # latency-bound round-trips that reproducibly killed Blacksmith runners
+    # mid-seed. Moving this job onto a Blacksmith runner is now a trivial
+    # follow-up — see NWACus/web#1143.
     runs-on: ubuntu-latest
     environment: Preview
     env:
@@ -26,7 +28,7 @@ jobs:
         run: curl -sSfL https://get.tur.so/install.sh | bash
         env:
           TURSO_INSTALL_SKIP_SIGNUP: 'true'
-      - name: Create a new database for the preview
+      - name: Compute the preview database name
         id: database
         run: |
           set -o errexit
@@ -46,13 +48,53 @@ jobs:
           echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
 
           name="payloadcms-preview-${ref}"
+          echo "name=${name}" >> "${GITHUB_OUTPUT}"
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v4
+      - name: 🏗 Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: pnpm
+      - name: 📦 Install dependencies
+        run: pnpm ii
+        shell: bash
+      - name: Seed a local SQLite database
+        # Seed against a local file instead of streaming thousands of per-row
+        # writes to remote Turso. This is the same fast path the CI build job
+        # uses: NODE_ENV is overridden off `production` so the SQLite adapter
+        # runs in push mode and builds the current schema directly from the
+        # Payload config (running migrations from zero isn't viable — a data
+        # migration reads collections whose block tables a later migration
+        # adds). The resulting schema matches what the deployed preview expects.
+        run: pnpm seed:standalone
+        env:
+          NODE_ENV: development
+          DATABASE_URI: 'file:./preview-seed.db'
+          PAYLOAD_SEED_PASSWORD: '${{ secrets.PAYLOAD_SEED_PASSWORD }}'
+          PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
+      - name: Create the preview database from the seeded file
+        # Bulk-import the seeded local DB into a fresh Turso DB in one operation.
+        # We use `--from-dump` (plain SQL) rather than `--from-file`: the latter
+        # requires WAL mode and mis-parses valid WAL databases on sqlite3 >= 3.50
+        # (tursodatabase/turso-cli#1030), whereas a `.dump` is runner-agnostic.
+        run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
+          name="${{ steps.database.outputs.name }}"
+
+          sqlite3 ./preview-seed.db .dump > ./preview-seed.sql
+
           /home/runner/.turso/turso org switch nwac
           if /home/runner/.turso/turso db show "${name}"; then
             /home/runner/.turso/turso db destroy "${name}" --yes
           fi
-          /home/runner/.turso/turso db create "${name}" --wait
+          /home/runner/.turso/turso db create "${name}" --from-dump ./preview-seed.sql --wait
           /home/runner/.turso/turso db shell "${name}" .tables
-          echo "name=${name}" >> "${GITHUB_OUTPUT}"
         env:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
       - name: Record database connection URI and token
@@ -66,18 +108,6 @@ jobs:
           echo "token=$(/home/runner/.turso/turso db tokens create "${{ steps.database.outputs.name }}")" >> "${GITHUB_OUTPUT}"
         env:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
-      - name: 🏗 Setup repo
-        uses: actions/checkout@v4
-      - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
-          cache: pnpm
-      - name: 📦 Install dependencies
-        run: pnpm ii
-        shell: bash
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Generate preview domain names
@@ -105,19 +135,6 @@ jobs:
         run: echo -n "${{ steps.domains.outputs.preview_alias }}" | vercel env add NEXT_PUBLIC_ROOT_DOMAIN preview ${{ github.head_ref }} --no-sensitive --force --token=${{ secrets.VERCEL_TOKEN }}
       - name: Pull Vercel Environment Variables into .env file
         run: vercel env pull --yes --environment=preview --git-branch="${{ github.head_ref }}" --token=${{ secrets.VERCEL_TOKEN }} .env
-      - name: Run database migrations
-        run: pnpm migrate
-        env:
-          DATABASE_URI: '${{ steps.connection.outputs.uri }}'
-          DATABASE_AUTH_TOKEN: '${{ steps.connection.outputs.token }}'
-          PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
-      - name: Seed the database
-        run: pnpm seed:standalone
-        env:
-          DATABASE_URI: '${{ steps.connection.outputs.uri }}'
-          DATABASE_AUTH_TOKEN: '${{ steps.connection.outputs.token }}'
-          PAYLOAD_SEED_PASSWORD: '${{ secrets.PAYLOAD_SEED_PASSWORD }}'
-          PAYLOAD_SECRET: '${{ secrets.PAYLOAD_SECRET }}'
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --git-branch="${{ github.head_ref }}" --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -13,13 +13,7 @@ concurrency:
 jobs:
   deploy:
     if: ${{ github.event_name != 'merge_group' }}
-    # Still on GitHub-hosted runners, but no longer out of necessity: seeding now
-    # writes to a local SQLite file that is bulk-imported into the fresh Turso
-    # preview DB in one operation, so it no longer streams the thousands of
-    # latency-bound round-trips that reproducibly killed Blacksmith runners
-    # mid-seed. Moving this job onto a Blacksmith runner is now a trivial
-    # follow-up — see NWACus/web#1143.
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     environment: Preview
     env:
       NODE_ENV: production


### PR DESCRIPTION
## Description

Seeding a preview DB ran `pnpm seed:standalone` against **remote** Turso, turning each of Payload's thousands of `create()` calls into a network round-trip. That was slow, highly variable, and unreliable enough on higher-latency runners to drop the connection mid-seed — which is why `preview` was the one workflow pinned to GitHub-hosted runners (0f20936b).

Now it seeds a **local** SQLite file and bulk-imports it into the fresh Turso DB in one operation. Same end state, ~3× faster overall, and runner-agnostic, so the job returns to Blacksmith.

| | Before (5 runs, `ubuntu-latest`) | After (Blacksmith) |
| --- | --- | --- |
| DB prep (migrate + seed) | 307–660s | **37s** |
| Build | 217–224s | 160s |
| **Total job** | **648–1006s** (med 969s) | **299s** |

5 samples before vs 1 after, so totals are approximate; the DB-path gap is far larger than run-to-run noise. Most of the win is DB prep (~16×); the faster build is the runner.

## Related Issues

Refs #1143

## Key Changes

- **Seed locally, in push mode** (`file:./preview-seed.db`, `NODE_ENV` off `production`) so the schema is built from the Payload config — the same path CI's `build` job uses. Migrating from zero isn't viable here: the `20260505_..._backfill_document_references` data migration queries collections via the Local API using the *current* config, hitting block tables a *later* migration adds. The old remote path had this problem too.
- **Import via `turso db create --from-dump`**, not `--from-file`/`db import`, which require WAL mode and mis-parse valid WAL databases on sqlite3 ≥ 3.50 ([turso-cli#1030](https://github.com/tursodatabase/turso-cli/issues/1030)). Drops the two remote-Turso steps; Vercel wiring, build, deploy and aliasing are unchanged.
- **Fix a latent existence-probe bug** (own commit). `turso db show` exits non-zero both when a DB is absent *and* when the API is unhealthy, so a transient 504 read as "absent", skipped the destroy, then failed the create with `already exists`. It fired on this branch. Now probes with `db list` (fails only on real errors), treats failure as fatal, and matches the `NAME` column exactly. ⚠️ **This bug is on `main` today** and will keep breaking preview runs during any Turso hiccup until this merges.
- **Pass `VERCEL_BLOB_READ_WRITE_TOKEN` to the seed** (own commit). Seeding now precedes `vercel env pull`, so the `.env` `payload run` loads doesn't exist yet; without the token `vercelBlobStorage` silently disables and seeded uploads hit the runner's disk — every seeded image would 404 **while the workflow still passed**. Under `NODE_ENV=development` the prefix resolves to `local` and is stored per row, and the static handler reads that stored prefix back, so uploads and rows stay consistent.
- **Back to `blacksmith-2vcpu-ubuntu-2404`**, reverting 0f20936b now its cause is gone. This was the last workflow off Blacksmith.

## How to test

Verified on run [31053934408](https://github.com/NWACus/web/actions/runs/31053934408) (Blacksmith, 299s, green):

- Import works, and the **destroy path was exercised** — the DB already existed, so `db list` found it and destroyed it before importing (a green run with it absent wouldn't prove this).
- **Uploads really reach Vercel Blob**: media docs carry `"prefix":"local"` (only written when the plugin is enabled) and `/api/media/file/snfac-acme-corp.webp` returns `200`, `8112 bytes`, `image/webp` — matching the DB's `filesize`.
- `sqlite3` (3.45.1) ships in the `ubuntu-2404` image `ubuntu-latest` already resolved to.

## Screenshots / Demo video

n/a

## Migration Explanation

None — workflow-only.

## Future enhancements / Questions

- `/home/runner/.turso/turso` is hardcoded here and in `cleanup.yaml` / `sync-prod-to-dev.yml`; putting the install dir on `PATH` once would be tidier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785995669&installation_id=144816107&pr_number=1144&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1144&signature=b51b6e19f160f122feb83f4408ed2e9516c5c06e3bb88c15e78a94d54011ecb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
