### PR TITLE
Payette (PAC) onboarding -- theme and next.config update

### DIFF
--- a/drift.lock
+++ b/drift.lock
@@ -343,7 +343,7 @@ sig = "1109f2020067761a"
 [[bindings]]
 doc = "docs/error-tracking.md"
 target = "next.config.js"
-sig = "3fd5fe0f09863f05"
+sig = "68597c16ef37fc12"
 
 [[bindings]]
 doc = "docs/error-tracking.md"
@@ -458,17 +458,17 @@ sig = "a4824faf89f4051e"
 [[bindings]]
 doc = "docs/onboarding.md"
 target = "next.config.js"
-sig = "3fd5fe0f09863f05"
+sig = "68597c16ef37fc12"
 
 [[bindings]]
 doc = "docs/onboarding.md"
 target = "src/app/(frontend)/colors.css"
-sig = "456dbff677ffff49"
+sig = "15e0c2130028a5ab"
 
 [[bindings]]
 doc = "docs/onboarding.md"
 target = "src/app/api/[center]/og/centerColorMap.ts"
-sig = "79343386aa4a9ca1"
+sig = "73076591cf7c80aa"
 
 [[bindings]]
 doc = "docs/onboarding.md"

--- a/next.config.js
+++ b/next.config.js
@@ -38,6 +38,10 @@ const nextConfig = {
         hostname: 'www.sawtoothavalanche.com',
         protocol: PROTOCOL,
       },
+      {
+        hostname: 'payetteavalanche.org',
+        protocol: PROTOCOL,
+      },
     ],
   },
   reactStrictMode: true,

--- a/src/app/(frontend)/colors.css
+++ b/src/app/(frontend)/colors.css
@@ -198,6 +198,48 @@
   --nav-underline: var(--callout);
 }
 
+/* Payette Avalanche Center */
+.pac {
+  /* PAC BRAND COLORS */
+  --teal: hsl(178 83% 35%); /* rgb(15 166 162) - primary accent from links/logo */
+  --slate: hsl(210 9% 14%); /* rgb(32 35 38) - body text / dark */
+  --slate-gray: hsl(0 0% 22%); /* rgb(55 55 55) - footer */
+  /*--------------------------*/
+
+  --brand-50: hsl(178 60% 96%);
+  --brand-100: hsl(178 64% 90%);
+  --brand-200: hsl(178 68% 78%);
+  --brand-300: hsl(178 73% 60%);
+  --brand-400: hsl(178 79% 44%);
+  --brand-500: var(--teal);
+  --brand-600: hsl(178 83% 29%);
+  --brand-700: hsl(181 58% 22%);
+  --brand-800: hsl(198 22% 18%);
+  --brand-900: var(--slate);
+  --brand-950: hsl(210 12% 10%);
+
+  --primary: var(--teal);
+  --primary-hover: hsla(178 83% 35% / 0.85);
+
+  --secondary: var(--slate);
+  --secondary-hover: hsla(210 9% 14% / 0.85);
+  --secondary-foreground: hsl(0 0% 98%);
+
+  --header: hsl(0 0% 100%);
+  --header-foreground: var(--slate);
+  --header-foreground-highlight: var(--brand-700);
+
+  --footer: var(--slate-gray);
+  --footer-foreground: hsl(0 0% 100%);
+  --header-foreground-highlight: var(--brand-700);
+
+  --callout: var(--teal);
+  --callout-hover: hsla(178 83% 35% / 0.85);
+  --callout-foreground: hsl(0 0% 100%);
+
+  --nav-underline: var(--teal);
+}
+
 .a3 {
   /* A3 BRAND COLORS */
   --mountain-slate: hsl(220 25% 20%); /* RGB: 38 / 46 / 63 */

--- a/src/app/api/[center]/og/centerColorMap.ts
+++ b/src/app/api/[center]/og/centerColorMap.ts
@@ -17,6 +17,10 @@ export const centerColorMap = {
     header: 'hsl(0 0% 100%)',
     headerForeground: 'hsl(240 10% 3.9%)',
   },
+  pac: {
+    header: 'hsl(0 0% 100%)',
+    headerForeground: 'hsl(210 9% 14%)',
+  },
   default: {
     header: 'hsl(0 0% 100%)',
     headerForeground: 'hsl(240 10% 3.9%)',


### PR DESCRIPTION
## Description

Adding Payette's domain to our next.js config and adding a theme for them. 

## Related Issues

N/A

## Key Changes

- Adds payetteavalanche.org to next.config.js
- Adds theme to `src/app/(frontend)/colors.css`
- Adds colors to `centerColorMap` in `src/app/api/[center]/og/centerColorMap.ts` (header colors)

## How to test

Visually confirm colors look good in preview environment. 

## Screenshots / Demo video

## Migration Explanation

No migration needed.

## Future enhancements / Questions

I wonder if we should just add all known avalanche center domains to our next.config.js ahead of time...

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786646583&installation_id=144816107&pr_number=1153&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1153&signature=7c25e9a1202a4648d14c7bb32caecd30a3e254bc506b5664f40e3aeb04a5725b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->