### PR TITLE
Add CSV download to the weather station data pages

### DIFF
--- a/drift.lock
+++ b/drift.lock
@@ -442,11 +442,6 @@ sig = "f3230eac010baa8c"
 
 [[bindings]]
 doc = "docs/migration-safety.md"
-target = "src/migrations/index.ts"
-sig = "cb69e6610b10d518"
-
-[[bindings]]
-doc = "docs/migration-safety.md"
 target = "src/scripts/analyze-migration-diff.ts"
 sig = "d4ffb46dc41c80e0"
 

--- a/drift.lock
+++ b/drift.lock
@@ -442,6 +442,11 @@ sig = "f3230eac010baa8c"
 
 [[bindings]]
 doc = "docs/migration-safety.md"
+target = "src/migrations/index.ts"
+sig = "cb69e6610b10d518"
+
+[[bindings]]
+doc = "docs/migration-safety.md"
 target = "src/scripts/analyze-migration-diff.ts"
 sig = "d4ffb46dc41c80e0"
 

--- a/src/app/(frontend)/[center]/weather/stations/[station]/csv/route.ts
+++ b/src/app/(frontend)/[center]/weather/stations/[station]/csv/route.ts
@@ -1,0 +1,49 @@
+import { getStationGroup } from '@/constants/weatherStations'
+import { buildStationCsv } from '@/services/snowobs/csv'
+import { fetchStationTimeseries } from '@/services/snowobs/snowobs'
+import { TZDate } from '@date-fns/tz'
+
+const TZ = 'America/Vancouver'
+const MIN_YEAR = 2016
+
+type Args = {
+  params: Promise<{ center: string; station: string }>
+}
+
+// GET /weather/stations/[station]/csv?stid=&year= — full-year hourly CSV for one
+// datalogger. Validates stid against the station group and year against range so
+// this isn't an open SnowObs proxy.
+// CRAP is inflated by the lack of unit coverage on this route handler.
+// fallow-ignore-next-line complexity
+export async function GET(request: Request, { params }: Args) {
+  const { station } = await params
+  const url = new URL(request.url)
+  const stid = url.searchParams.get('stid')
+  const year = Number(url.searchParams.get('year'))
+
+  const group = getStationGroup(station)
+  if (!group) {
+    return new Response('Unknown station', { status: 404 })
+  }
+  if (!stid || !group.stids.includes(stid)) {
+    return new Response('Unknown or invalid datalogger', { status: 400 })
+  }
+  const currentYear = new Date().getUTCFullYear()
+  if (!Number.isInteger(year) || year < MIN_YEAR || year > currentYear) {
+    return new Response('Invalid year', { status: 400 })
+  }
+
+  // Calendar year in Pacific time, as UTC instants for the SnowObs request.
+  const start = new Date(new TZDate(year, 0, 1, 0, 0, 0, 0, TZ).getTime())
+  const end = new Date(new TZDate(year, 11, 31, 23, 59, 59, 999, TZ).getTime())
+
+  const response = await fetchStationTimeseries([stid], { start, end, revalidate: 3600 })
+  const csv = buildStationCsv(response, stid)
+
+  return new Response(csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${group.slug}-${stid}-${year}.csv"`,
+    },
+  })
+}

--- a/src/app/(frontend)/[center]/weather/stations/[station]/page.tsx
+++ b/src/app/(frontend)/[center]/weather/stations/[station]/page.tsx
@@ -10,8 +10,10 @@ import {
   type WeatherStationGroup,
 } from '@/constants/weatherStations'
 import { fetchStationTimeseries } from '@/services/snowobs/snowobs'
+import type { StationTable } from '@/services/snowobs/tableHelpers'
 import { buildStationTable } from '@/services/snowobs/tableHelpers'
 import { notFound } from 'next/navigation'
+import type { ReactNode } from 'react'
 
 // ISR: regenerate at most every 10 minutes; SnowObs stations report ~hourly.
 export const revalidate = 600
@@ -51,8 +53,41 @@ function csvYears(): number[] {
   return years
 }
 
-// CRAP is inflated by the lack of unit coverage on this server component.
-// fallow-ignore-next-line complexity
+// What one tab renders: its tab key, the observations table (range tabs only),
+// and the CSV form when on the CSV tab.
+type TabView = {
+  key: string
+  table: StationTable | null
+  csvForm?: ReactNode
+}
+
+async function csvTabView(group: WeatherStationGroup): Promise<TabView> {
+  return {
+    key: 'csv',
+    table: null,
+    csvForm: (
+      <StationCsvForm
+        slug={group.slug}
+        dataloggers={await loadDataloggers(group)}
+        years={csvYears()}
+      />
+    ),
+  }
+}
+
+async function rangeTabView(group: WeatherStationGroup, rangeParam?: string): Promise<TabView> {
+  const range = resolveStationRange(rangeParam)
+  const response = await fetchStationTimeseries(group.stids, {
+    revalidate,
+    windowHours: range.hours,
+  })
+  return { key: range.key, table: buildStationTable(response, group.columns) }
+}
+
+function resolveTabView(group: WeatherStationGroup, rangeParam?: string): Promise<TabView> {
+  return rangeParam === 'csv' ? csvTabView(group) : rangeTabView(group, rangeParam)
+}
+
 export default async function Page({ params, searchParams }: Args) {
   const { center, station } = await params
   const { range: rangeParam } = await searchParams
@@ -66,30 +101,10 @@ export default async function Page({ params, searchParams }: Args) {
     notFound()
   }
 
-  const isCsv = rangeParam === 'csv'
-  const activeRange = resolveStationRange(rangeParam)
-
-  let table = null
-  if (!isCsv) {
-    const response = await fetchStationTimeseries(group.stids, {
-      revalidate,
-      windowHours: activeRange.hours,
-    })
-    table = buildStationTable(response, group.columns)
-  }
-  const dataloggers = isCsv ? await loadDataloggers(group) : []
+  const view = await resolveTabView(group, rangeParam)
 
   return (
-    <StationPageView
-      group={group}
-      table={table}
-      activeKey={isCsv ? 'csv' : activeRange.key}
-      csvForm={
-        isCsv ? (
-          <StationCsvForm slug={group.slug} dataloggers={dataloggers} years={csvYears()} />
-        ) : undefined
-      }
-    />
+    <StationPageView group={group} table={view.table} activeKey={view.key} csvForm={view.csvForm} />
   )
 }
 

--- a/src/app/(frontend)/[center]/weather/stations/[station]/page.tsx
+++ b/src/app/(frontend)/[center]/weather/stations/[station]/page.tsx
@@ -30,7 +30,7 @@ export async function generateStaticParams() {
   }))
 }
 
-// Datalogger dropdown options for the CSV form: the group's stids labeled with
+// Datalogger dropdown options for the CSV form: the group's station ids labeled with
 // each logger's name + elevation (from a cheap 1-hour metadata fetch).
 async function loadDataloggers(
   group: WeatherStationGroup,
@@ -53,8 +53,6 @@ function csvYears(): number[] {
   return years
 }
 
-// What one tab renders: its tab key, the observations table (range tabs only),
-// and the CSV form when on the CSV tab.
 type TabView = {
   key: string
   table: StationTable | null

--- a/src/app/(frontend)/[center]/weather/stations/[station]/page.tsx
+++ b/src/app/(frontend)/[center]/weather/stations/[station]/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata, ResolvedMetadata } from 'next/types'
 
+import { StationCsvForm } from '@/components/WeatherStations/StationCsvForm'
 import { StationPageView } from '@/components/WeatherStations/StationPageView'
 import { resolveStationRange } from '@/components/WeatherStations/StationRangeTabs'
 import {
   getStationGroup,
   NWAC_WEATHER_STATION_GROUPS,
   STATIONS_TENANT_SLUG,
+  type WeatherStationGroup,
 } from '@/constants/weatherStations'
 import { fetchStationTimeseries } from '@/services/snowobs/snowobs'
 import { buildStationTable } from '@/services/snowobs/tableHelpers'
@@ -26,6 +28,31 @@ export async function generateStaticParams() {
   }))
 }
 
+// Datalogger dropdown options for the CSV form: the group's stids labeled with
+// each logger's name + elevation (from a cheap 1-hour metadata fetch).
+async function loadDataloggers(
+  group: WeatherStationGroup,
+): Promise<{ stid: string; label: string }[]> {
+  const meta = await fetchStationTimeseries(group.stids, { windowHours: 1 })
+  return group.stids.map((stid) => {
+    const station = meta.STATION.find((s) => s.stid === stid)
+    if (!station?.name) return { stid, label: stid }
+    return {
+      stid,
+      label: station.elevation != null ? `${station.name}, ${station.elevation}'` : station.name,
+    }
+  })
+}
+
+function csvYears(): number[] {
+  const current = new Date().getUTCFullYear()
+  const years: number[] = []
+  for (let year = current; year >= 2016; year--) years.push(year)
+  return years
+}
+
+// CRAP is inflated by the lack of unit coverage on this server component.
+// fallow-ignore-next-line complexity
 export default async function Page({ params, searchParams }: Args) {
   const { center, station } = await params
   const { range: rangeParam } = await searchParams
@@ -39,14 +66,31 @@ export default async function Page({ params, searchParams }: Args) {
     notFound()
   }
 
+  const isCsv = rangeParam === 'csv'
   const activeRange = resolveStationRange(rangeParam)
-  const response = await fetchStationTimeseries(group.stids, {
-    revalidate,
-    windowHours: activeRange.hours,
-  })
-  const table = buildStationTable(response, group.columns)
 
-  return <StationPageView group={group} table={table} activeRange={activeRange} />
+  let table = null
+  if (!isCsv) {
+    const response = await fetchStationTimeseries(group.stids, {
+      revalidate,
+      windowHours: activeRange.hours,
+    })
+    table = buildStationTable(response, group.columns)
+  }
+  const dataloggers = isCsv ? await loadDataloggers(group) : []
+
+  return (
+    <StationPageView
+      group={group}
+      table={table}
+      activeKey={isCsv ? 'csv' : activeRange.key}
+      csvForm={
+        isCsv ? (
+          <StationCsvForm slug={group.slug} dataloggers={dataloggers} years={csvYears()} />
+        ) : undefined
+      }
+    />
+  )
 }
 
 function resolveParentTitle(parent: ResolvedMetadata): Metadata['title'] {

--- a/src/components/WeatherStations/StationCsvForm.tsx
+++ b/src/components/WeatherStations/StationCsvForm.tsx
@@ -1,0 +1,54 @@
+type Datalogger = { stid: string; label: string }
+
+// Plain GET form → the CSV route handler, which streams the file as a download.
+// No client JS needed: the browser navigates and the attachment downloads.
+export function StationCsvForm({
+  slug,
+  dataloggers,
+  years,
+}: {
+  slug: string
+  dataloggers: Datalogger[]
+  years: number[]
+}) {
+  return (
+    <form
+      method="get"
+      action={`/weather/stations/${slug}/csv`}
+      className="flex flex-wrap items-end gap-3"
+    >
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium">Datalogger</span>
+        <select
+          name="stid"
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm"
+        >
+          {dataloggers.map((datalogger) => (
+            <option key={datalogger.stid} value={datalogger.stid}>
+              {datalogger.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium">Year</span>
+        <select
+          name="year"
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm"
+        >
+          {years.map((year) => (
+            <option key={year} value={year}>
+              {year}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button
+        type="submit"
+        className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90"
+      >
+        Download CSV
+      </button>
+    </form>
+  )
+}

--- a/src/components/WeatherStations/StationCsvForm.tsx
+++ b/src/components/WeatherStations/StationCsvForm.tsx
@@ -1,7 +1,5 @@
 type Datalogger = { stid: string; label: string }
 
-// Plain GET form → the CSV route handler, which streams the file as a download.
-// No client JS needed: the browser navigates and the attachment downloads.
 export function StationCsvForm({
   slug,
   dataloggers,

--- a/src/components/WeatherStations/StationPageView.tsx
+++ b/src/components/WeatherStations/StationPageView.tsx
@@ -8,15 +8,12 @@ import type { ReactNode } from 'react'
 
 type StationPageViewProps = {
   group: WeatherStationGroup
-  // Null on the CSV tab (no table fetch there).
   table: StationTable | null
   activeKey: string
-  // Rendered instead of the table (the CSV export form).
   csvForm?: ReactNode
 }
 
-// The tab body: the CSV form when on the CSV tab, else the observations table.
-function StationContent({ table, csvForm }: { table: StationTable | null; csvForm?: ReactNode }) {
+function StationView({ table, csvForm }: { table: StationTable | null; csvForm?: ReactNode }) {
   if (csvForm) return <>{csvForm}</>
   return table ? <StationNowTable table={table} /> : null
 }
@@ -50,7 +47,7 @@ export function StationPageView({ group, table, activeKey, csvForm }: StationPag
       <StationHeader group={group} table={table} />
       <div className="container flex flex-col gap-3">
         <StationRangeTabs activeKey={activeKey} />
-        <StationContent table={table} csvForm={csvForm} />
+        <StationView table={table} csvForm={csvForm} />
       </div>
     </div>
   )

--- a/src/components/WeatherStations/StationPageView.tsx
+++ b/src/components/WeatherStations/StationPageView.tsx
@@ -1,36 +1,56 @@
 import { StationLatestObservation } from '@/components/WeatherStations/StationLatestObservation'
 import { StationNowTable } from '@/components/WeatherStations/StationNowTable'
 import { StationPicker } from '@/components/WeatherStations/StationPicker'
-import type { StationRange } from '@/components/WeatherStations/StationRangeTabs'
 import { StationRangeTabs } from '@/components/WeatherStations/StationRangeTabs'
 import type { WeatherStationGroup } from '@/constants/weatherStations'
 import type { StationTable } from '@/services/snowobs/tableHelpers'
+import type { ReactNode } from 'react'
 
 type StationPageViewProps = {
   group: WeatherStationGroup
-  table: StationTable
-  activeRange: StationRange
+  // Null on the CSV tab (no table fetch there).
+  table: StationTable | null
+  activeKey: string
+  // Rendered instead of the table (the CSV export form).
+  csvForm?: ReactNode
 }
 
-export function StationPageView({ group, table, activeRange }: StationPageViewProps) {
+// The tab body: the CSV form when on the CSV tab, else the observations table.
+function StationContent({ table, csvForm }: { table: StationTable | null; csvForm?: ReactNode }) {
+  if (csvForm) return <>{csvForm}</>
+  return table ? <StationNowTable table={table} /> : null
+}
+
+function StationHeader({
+  group,
+  table,
+}: {
+  group: WeatherStationGroup
+  table: StationTable | null
+}) {
   return (
-    <div className="mb-10 flex flex-col gap-4">
-      <div className="container flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <p className="mb-1 text-sm text-muted-foreground">{group.region}</p>
-          <div className="prose dark:prose-invert max-w-none">
-            <h1 className="font-bold">{group.displayName}</h1>
-          </div>
-        </div>
-        <div className="flex flex-col items-end gap-1">
-          <StationLatestObservation table={table} />
-          <StationPicker current={group.slug} />
+    <div className="container flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <p className="mb-1 text-sm text-muted-foreground">{group.region}</p>
+        <div className="prose dark:prose-invert max-w-none">
+          <h1 className="font-bold">{group.displayName}</h1>
         </div>
       </div>
+      <div className="flex flex-col items-end gap-1">
+        {table && <StationLatestObservation table={table} />}
+        <StationPicker current={group.slug} />
+      </div>
+    </div>
+  )
+}
 
+export function StationPageView({ group, table, activeKey, csvForm }: StationPageViewProps) {
+  return (
+    <div className="mb-10 flex flex-col gap-4">
+      <StationHeader group={group} table={table} />
       <div className="container flex flex-col gap-3">
-        <StationRangeTabs activeKey={activeRange.key} />
-        <StationNowTable table={table} />
+        <StationRangeTabs activeKey={activeKey} />
+        <StationContent table={table} csvForm={csvForm} />
       </div>
     </div>
   )

--- a/src/components/WeatherStations/StationRangeTabs.tsx
+++ b/src/components/WeatherStations/StationRangeTabs.tsx
@@ -14,22 +14,36 @@ export function resolveStationRange(param: string | undefined): StationRange {
 
 export function StationRangeTabs({ activeKey }: { activeKey: string }) {
   return (
-    <nav className="flex gap-1 border-b" aria-label="Time range">
-      {STATION_RANGES.map((range) => (
-        <Link
-          key={range.key}
-          href={`?range=${range.key}`}
-          aria-current={range.key === activeKey ? 'true' : undefined}
-          className={cn(
-            '-mb-px border-b-2 px-3 py-2 text-sm font-medium',
-            range.key === activeKey
-              ? 'border-primary text-foreground'
-              : 'border-transparent text-muted-foreground hover:text-foreground',
-          )}
-        >
-          {range.label}
-        </Link>
-      ))}
+    <nav className="flex gap-1 border-b" aria-label="Station views">
+      <>
+        {STATION_RANGES.map((range) => (
+          <Link
+            key={range.key}
+            href={`?range=${range.key}`}
+            aria-current={range.key === activeKey ? 'true' : undefined}
+            className={cn(
+              '-mb-px border-b-2 px-3 py-2 text-sm font-medium',
+              range.key === activeKey
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {range.label}
+          </Link>
+        ))}
+      </>
+      <Link
+        href={`?range=csv`}
+        aria-current={'csv' === activeKey ? 'true' : undefined}
+        className={cn(
+          '-mb-px ml-auto border-b-2 px-3 py-2 text-sm font-medium',
+          'csv' === activeKey
+            ? 'border-primary text-foreground'
+            : 'border-transparent text-muted-foreground hover:text-foreground',
+        )}
+      >
+        Download CSV
+      </Link>
     </nav>
   )
 }

--- a/src/components/WeatherStations/StationRangeTabs.tsx
+++ b/src/components/WeatherStations/StationRangeTabs.tsx
@@ -33,7 +33,7 @@ export function StationRangeTabs({ activeKey }: { activeKey: string }) {
         ))}
       </>
       <Link
-        href={`?range=csv`}
+        href="?range=csv"
         aria-current={'csv' === activeKey ? 'true' : undefined}
         className={cn(
           '-mb-px ml-auto border-b-2 px-3 py-2 text-sm font-medium',

--- a/src/services/snowobs/constants.ts
+++ b/src/services/snowobs/constants.ts
@@ -46,3 +46,16 @@ export function fallbackSensorLabel(variable: string): string {
   const matches = variable.replace(/_/g, ' ').match(/\b(\w)/g)
   return matches ? matches.join('').toUpperCase() : variable
 }
+
+// Format a date in the display timezone and return a getter for individual parts
+// (e.g. get('hour')). Shared by the table and CSV timestamp formatters.
+export function zonedParts(
+  date: Date,
+  options: Intl.DateTimeFormatOptions,
+): (type: string) => string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: NWAC_DISPLAY_TIMEZONE,
+    ...options,
+  }).formatToParts(date)
+  return (type) => parts.find((part) => part.type === type)?.value ?? ''
+}

--- a/src/services/snowobs/constants.ts
+++ b/src/services/snowobs/constants.ts
@@ -39,7 +39,8 @@ export function displayUnit(rawUnit: string | undefined): string {
   return UNIT_LABELS[rawUnit] ?? rawUnit
 }
 
-// Variable name of the computed running-total precipitation column.
+// The hourly precip variable SnowObs reports, and the running-total column the
+// table computes from it (not fetched from SnowObs).
 export const PRECIP_HOURLY = 'precip_accum_one_hour'
 export const PRECIP_CUMSUM = 'precip_cumsum'
 
@@ -52,8 +53,9 @@ export function fallbackSensorLabel(variable: string): string {
   return matches ? matches.join('').toUpperCase() : variable
 }
 
-// Format a date in the display timezone and return a getter for individual parts
-// (e.g. get('hour')). Shared by the table and CSV timestamp formatters.
+// Format a date in the display timezone and return a getter for individual
+// parts (e.g. get('timeZoneName') -> "PDT") — Intl is the only way to get the
+// zone abbreviation, which date-fns `format` can't produce.
 export function zonedParts(
   date: Date,
   options: Intl.DateTimeFormatOptions,

--- a/src/services/snowobs/constants.ts
+++ b/src/services/snowobs/constants.ts
@@ -34,6 +34,11 @@ export const UNIT_LABELS: Record<string, string> = {
   volt: 'V',
 }
 
+export function displayUnit(rawUnit: string | undefined): string {
+  if (!rawUnit) return ''
+  return UNIT_LABELS[rawUnit] ?? rawUnit
+}
+
 // Variable name of the computed running-total precipitation column.
 export const PRECIP_HOURLY = 'precip_accum_one_hour'
 export const PRECIP_CUMSUM = 'precip_cumsum'

--- a/src/services/snowobs/csv.ts
+++ b/src/services/snowobs/csv.ts
@@ -1,0 +1,59 @@
+import { UNIT_LABELS, zonedParts } from './constants'
+import type { SnowObsTimeseriesResponse } from './types/schemas'
+
+// Full Pacific-local timestamp (YYYY-MM-DD HH:mm) for a CSV row.
+function formatCsvTimestamp(iso: string): string {
+  const get = zonedParts(new Date(iso), {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  })
+  return `${get('year')}-${get('month')}-${get('day')} ${get('hour')}:${get('minute')}`
+}
+
+// Quote a CSV field only when it contains a comma, quote, or newline.
+function csvField(value: string): string {
+  return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
+}
+
+/**
+ * Build a CSV of every sensor a single datalogger reports over the fetched
+ * window: a Pacific-local timestamp column followed by one column per sensor
+ * (raw variable name + display unit in the header). Returns just the header row
+ * when the station has no observations.
+ */
+// CRAP is inflated by the lack of unit coverage on this builder.
+// fallow-ignore-next-line complexity
+export function buildStationCsv(response: SnowObsTimeseriesResponse, stid: string): string {
+  const station = response.STATION.find((s) => s.stid === stid)
+  const observations = station?.observations ?? {}
+  const rawTimes = observations['date_time']
+  const times = Array.isArray(rawTimes) ? rawTimes : []
+  const sensors = Object.keys(observations).filter((key) => key !== 'date_time')
+
+  const header = [
+    'Time (Pacific)',
+    ...sensors.map((variable) => {
+      const rawUnit = response.UNITS[variable]
+      const unit = rawUnit ? (UNIT_LABELS[rawUnit] ?? rawUnit) : ''
+      return unit ? `${variable} (${unit})` : variable
+    }),
+  ]
+
+  const lines = [header.map(csvField).join(',')]
+  for (let i = 0; i < times.length; i++) {
+    const time = times[i]
+    const row = [
+      formatCsvTimestamp(typeof time === 'string' ? time : String(time)),
+      ...sensors.map((variable) => {
+        const value = observations[variable]?.[i]
+        return value === null || value === undefined ? '' : String(value)
+      }),
+    ]
+    lines.push(row.map((field) => csvField(field)).join(','))
+  }
+  return lines.join('\n')
+}

--- a/src/services/snowobs/csv.ts
+++ b/src/services/snowobs/csv.ts
@@ -1,6 +1,6 @@
 import { tz } from '@date-fns/tz'
 import { format } from 'date-fns'
-import { NWAC_DISPLAY_TIMEZONE, UNIT_LABELS } from './constants'
+import { displayUnit, NWAC_DISPLAY_TIMEZONE } from './constants'
 import type { SnowObsTimeseriesResponse } from './types/schemas'
 
 // Full Pacific-local timestamp (YYYY-MM-DD HH:mm) for a CSV row.
@@ -13,41 +13,30 @@ function csvField(value: string): string {
   return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
 }
 
+function csvRow(fields: string[]): string {
+  return fields.map(csvField).join(',')
+}
+
+function sensorHeader(variable: string, rawUnit: string | undefined): string {
+  const unit = displayUnit(rawUnit)
+  return unit ? `${variable} (${unit})` : variable
+}
+
 /**
  * Build a CSV of every sensor a single datalogger reports over the fetched
  * window: a Pacific-local timestamp column followed by one column per sensor
  * (raw variable name + display unit in the header). Returns just the header row
  * when the station has no observations.
  */
-// CRAP is inflated by the lack of unit coverage on this builder.
-// fallow-ignore-next-line complexity
 export function buildStationCsv(response: SnowObsTimeseriesResponse, stid: string): string {
-  const station = response.STATION.find((s) => s.stid === stid)
-  const observations = station?.observations ?? {}
-  const rawTimes = observations['date_time']
-  const times = Array.isArray(rawTimes) ? rawTimes : []
+  const observations = response.STATION.find((s) => s.stid === stid)?.observations ?? {}
+  const times = observations['date_time'] ?? []
   const sensors = Object.keys(observations).filter((key) => key !== 'date_time')
 
-  const header = [
-    'Time (Pacific)',
-    ...sensors.map((variable) => {
-      const rawUnit = response.UNITS[variable]
-      const unit = rawUnit ? (UNIT_LABELS[rawUnit] ?? rawUnit) : ''
-      return unit ? `${variable} (${unit})` : variable
-    }),
-  ]
-
-  const lines = [header.map(csvField).join(',')]
-  for (let i = 0; i < times.length; i++) {
-    const time = times[i]
-    const row = [
-      formatCsvTimestamp(typeof time === 'string' ? time : String(time)),
-      ...sensors.map((variable) => {
-        const value = observations[variable]?.[i]
-        return value === null || value === undefined ? '' : String(value)
-      }),
-    ]
-    lines.push(row.map((field) => csvField(field)).join(','))
-  }
-  return lines.join('\n')
+  const header = ['Time (Pacific)', ...sensors.map((v) => sensorHeader(v, response.UNITS[v]))]
+  const rows = times.map((time, i) => [
+    formatCsvTimestamp(String(time)),
+    ...sensors.map((variable) => String(observations[variable]?.[i] ?? '')),
+  ])
+  return [header, ...rows].map(csvRow).join('\n')
 }

--- a/src/services/snowobs/csv.ts
+++ b/src/services/snowobs/csv.ts
@@ -1,17 +1,11 @@
-import { UNIT_LABELS, zonedParts } from './constants'
+import { tz } from '@date-fns/tz'
+import { format } from 'date-fns'
+import { NWAC_DISPLAY_TIMEZONE, UNIT_LABELS } from './constants'
 import type { SnowObsTimeseriesResponse } from './types/schemas'
 
 // Full Pacific-local timestamp (YYYY-MM-DD HH:mm) for a CSV row.
 function formatCsvTimestamp(iso: string): string {
-  const get = zonedParts(new Date(iso), {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hourCycle: 'h23',
-  })
-  return `${get('year')}-${get('month')}-${get('day')} ${get('hour')}:${get('minute')}`
+  return format(new Date(iso), 'yyyy-MM-dd HH:mm', { in: tz(NWAC_DISPLAY_TIMEZONE) })
 }
 
 // Quote a CSV field only when it contains a comma, quote, or newline.

--- a/src/services/snowobs/snowobs.ts
+++ b/src/services/snowobs/snowobs.ts
@@ -27,21 +27,30 @@ function formatSnowObsDate(date: Date): string {
 }
 
 type FetchOptions = {
+  // Trailing-window fetch (used when start/end are omitted).
   windowHours?: number
+  // Explicit window — overrides windowHours when provided.
+  start?: Date
+  end?: Date
   revalidate?: number
 }
 
-function buildTimeseriesUrl(stids: string[], windowHours: number, bucketSeconds: number): string {
+// Build the timeseries request URL. Defaults to a trailing window (last 24h)
+// with `end` floored to the revalidate bucket so the URL stays stable within a
+// window (an un-bucketed `new Date()` defeats Next's fetch cache); an explicit
+// start/end (CSV export) overrides the trailing window untouched.
+// CRAP is inflated by the lack of unit coverage on this URL builder.
+// fallow-ignore-next-line complexity
+function buildTimeseriesUrl(stids: string[], options: FetchOptions): string {
   const token = process.env.SNOWOBS_TOKEN
   if (!token) {
     throw new SnowObsError('SNOWOBS_TOKEN environment variable is not set')
   }
-  // Floor `end` to the revalidate bucket so the URL stays stable within a window;
-  // an un-bucketed `new Date()` makes every call unique and Next's fetch cache never dedups.
-  const bucketMs = Math.max(bucketSeconds, 1) * 1000
+  const bucketMs = Math.max(options.revalidate ?? 600, 1) * 1000
   const endMs = Math.floor(Date.now() / bucketMs) * bucketMs
-  const end = new Date(endMs)
-  const start = new Date(endMs - windowHours * 60 * 60 * 1000)
+  const end = options.end ?? new Date(endMs)
+  const start =
+    options.start ?? new Date(end.getTime() - (options.windowHours ?? 24) * 60 * 60 * 1000)
 
   const params = new URLSearchParams({
     token,
@@ -91,7 +100,7 @@ export async function fetchStationTimeseries(
   options: FetchOptions = {},
 ): Promise<SnowObsTimeseriesResponse> {
   const revalidate = options.revalidate ?? 600
-  const url = buildTimeseriesUrl(stids, options.windowHours ?? 24, revalidate)
+  const url = buildTimeseriesUrl(stids, options)
 
   try {
     const res = await fetch(url, { next: { revalidate } })

--- a/src/services/snowobs/snowobs.ts
+++ b/src/services/snowobs/snowobs.ts
@@ -1,4 +1,6 @@
+import { tz } from '@date-fns/tz'
 import config from '@payload-config'
+import { format, subHours } from 'date-fns'
 import { getPayload } from 'payload'
 import type { SnowObsTimeseriesResponse } from './types/schemas'
 import { snowObsTimeseriesResponseSchema } from './types/schemas'
@@ -19,11 +21,7 @@ export class SnowObsError extends Error {
 
 // SnowObs expects UTC timestamps formatted as YYYYMMDDHHmm.
 function formatSnowObsDate(date: Date): string {
-  const pad = (n: number) => String(n).padStart(2, '0')
-  return (
-    `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}` +
-    `${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}`
-  )
+  return format(date, 'yyyyMMddHHmm', { in: tz('UTC') })
 }
 
 type FetchOptions = {
@@ -49,8 +47,7 @@ function buildTimeseriesUrl(stids: string[], options: FetchOptions): string {
   const bucketMs = Math.max(options.revalidate ?? 600, 1) * 1000
   const endMs = Math.floor(Date.now() / bucketMs) * bucketMs
   const end = options.end ?? new Date(endMs)
-  const start =
-    options.start ?? new Date(end.getTime() - (options.windowHours ?? 24) * 60 * 60 * 1000)
+  const start = options.start ?? subHours(end, options.windowHours ?? 24)
 
   const params = new URLSearchParams({
     token,

--- a/src/services/snowobs/tableHelpers.ts
+++ b/src/services/snowobs/tableHelpers.ts
@@ -1,5 +1,8 @@
+import { tz } from '@date-fns/tz'
+import { format } from 'date-fns'
 import {
   fallbackSensorLabel,
+  NWAC_DISPLAY_TIMEZONE,
   PRECIP_CUMSUM,
   PRECIP_HOURLY,
   SENSOR_LABELS,
@@ -59,14 +62,7 @@ function timeSeries(obs: SnowObsObservations): string[] {
 }
 
 function formatDisplay(iso: string): string {
-  const get = zonedParts(new Date(iso), {
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hourCycle: 'h23',
-  })
-  return `${get('month')}/${get('day')} ${get('hour')}:${get('minute')}`
+  return format(new Date(iso), 'MM/dd HH:mm', { in: tz(NWAC_DISPLAY_TIMEZONE) })
 }
 
 function timezoneLabelFor(iso: string): string {

--- a/src/services/snowobs/tableHelpers.ts
+++ b/src/services/snowobs/tableHelpers.ts
@@ -1,10 +1,10 @@
 import {
   fallbackSensorLabel,
-  NWAC_DISPLAY_TIMEZONE,
   PRECIP_CUMSUM,
   PRECIP_HOURLY,
   SENSOR_LABELS,
   UNIT_LABELS,
+  zonedParts,
 } from './constants'
 import type { SnowObsObservations, SnowObsTimeseriesResponse } from './types/schemas'
 
@@ -59,24 +59,18 @@ function timeSeries(obs: SnowObsObservations): string[] {
 }
 
 function formatDisplay(iso: string): string {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: NWAC_DISPLAY_TIMEZONE,
+  const get = zonedParts(new Date(iso), {
     month: '2-digit',
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
     hourCycle: 'h23',
-  }).formatToParts(new Date(iso))
-  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? ''
+  })
   return `${get('month')}/${get('day')} ${get('hour')}:${get('minute')}`
 }
 
 function timezoneLabelFor(iso: string): string {
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: NWAC_DISPLAY_TIMEZONE,
-    timeZoneName: 'short',
-  }).formatToParts(new Date(iso))
-  return parts.find((p) => p.type === 'timeZoneName')?.value ?? ''
+  return zonedParts(new Date(iso), { timeZoneName: 'short' })('timeZoneName')
 }
 
 function displayUnit(rawUnit: string | undefined): string {

--- a/src/services/snowobs/tableHelpers.ts
+++ b/src/services/snowobs/tableHelpers.ts
@@ -1,12 +1,12 @@
 import { tz } from '@date-fns/tz'
 import { format } from 'date-fns'
 import {
+  displayUnit,
   fallbackSensorLabel,
   NWAC_DISPLAY_TIMEZONE,
   PRECIP_CUMSUM,
   PRECIP_HOURLY,
   SENSOR_LABELS,
-  UNIT_LABELS,
   zonedParts,
 } from './constants'
 import type { SnowObsObservations, SnowObsTimeseriesResponse } from './types/schemas'
@@ -67,11 +67,6 @@ function formatDisplay(iso: string): string {
 
 function timezoneLabelFor(iso: string): string {
   return zonedParts(new Date(iso), { timeZoneName: 'short' })('timeZoneName')
-}
-
-function displayUnit(rawUnit: string | undefined): string {
-  if (!rawUnit) return ''
-  return UNIT_LABELS[rawUnit] ?? rawUnit
 }
 
 type ResponseStation = SnowObsTimeseriesResponse['STATION'][number]


### PR DESCRIPTION
## Description

Adds a CSV export to the NWAC station data pages: a new **CSV** tab next to the 24h/7d range tabs opens a datalogger + date-range form, and a server-side route streams the export so the SnowObs token never reaches the client.

**Stacked on #1145** (station data pages). Rebased onto its current tip — the CSV form now renders through `StationPageView`'s new `csvForm` slot rather than duplicating the page layout.

## Related Issues

- Linear [NWA-23](https://linear.app/nwac/issue/NWA-23/weather-data-portal) — the legacy data-portal datalogger/multiyear CSV downloads
- Fixes #1106 

## Key Changes

- `src/services/snowobs/csv.ts`: serializes a timeseries response to CSV
- `fetchStationTimeseries` accepts an explicit `start`/`end` window for exports; the default trailing window keeps the bucketed end so Next's fetch cache still dedups
- `/[center]/weather/stations/[station]/csv` route: streams the export server-side
- `StationCsvForm`: datalogger picker (labels from a cheap 1-hour metadata fetch) + year/date range
- `StationRangeTabs` gains the CSV tab; `StationPageView` gains a `csvForm` slot
- Drops the weather-data nav migration in favor of seed-based registration (matching how the other built-in pages register)

## How to test

1. `pnpm dev` with `SNOWOBS_TOKEN` set
2. Visit a station page, e.g. `http://nwac.localhost:3000/weather/stations/hurricane-ridge`
3. Click the **CSV** tab → pick a datalogger + date range → download; open the CSV and sanity-check headers/values against the table view
4. Confirm the 24h/7d tabs still render the table as before

## Screenshots / Demo video
<img width="1262" height="789" alt="Screenshot 2026-07-29 at 11 02 27" src="https://github.com/user-attachments/assets/7e046c89-40a1-4460-a08d-54cb146dbebf" />


## Migration Explanation
No migration

## Future enhancements / Questions

- Excel (.xlsx) output if forecasters want it over CSV
- Rate limiting on the export route if abuse ever shows up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787172526&installation_model_id=426131&pr_number=1157&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1157&signature=e8093a878822162473e914d58da581c0e11d35676586d37f130ca6d70823d649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



