### PR TITLE
Add interactive graphs to the weather station data pages

### DIFF
--- a/__tests__/client/components/Breadcrumbs.client.test.tsx
+++ b/__tests__/client/components/Breadcrumbs.client.test.tsx
@@ -40,9 +40,10 @@ describe('Breadcrumbs', () => {
     )
     // Home is always clickable
     expect(screen.getByText('Home').closest('a')).toHaveAttribute('href', '/')
-    // weather and stations are in knownPathsWithoutPages, so not clickable
+    // weather is in knownPathsWithoutPages, so not clickable
     expect(screen.getByText('weather')).not.toHaveAttribute('href')
-    expect(screen.getByText('stations')).not.toHaveAttribute('href')
+    // stations has a real index page, so its crumb links
+    expect(screen.getByText('stations').closest('a')).toHaveAttribute('href', '/weather/stations')
     // map is the last segment, not clickable
     expect(screen.getByText('map')).not.toHaveAttribute('href')
   })

--- a/__tests__/client/components/Breadcrumbs.client.test.tsx
+++ b/__tests__/client/components/Breadcrumbs.client.test.tsx
@@ -10,10 +10,16 @@ jest.mock('next/navigation', () => ({
   useSelectedLayoutSegments: jest.fn(),
 }))
 
+let mockTenantSlug: string | null = null
+jest.mock('../../../src/providers/TenantProvider', () => ({
+  useTenant: () => ({ tenant: mockTenantSlug ? { slug: mockTenantSlug } : null }),
+}))
+
 const mockUseSelectedLayoutSegments = jest.mocked(useSelectedLayoutSegments)
 
 describe('Breadcrumbs', () => {
   afterEach(() => {
+    mockTenantSlug = null
     jest.clearAllMocks()
   })
 
@@ -42,10 +48,23 @@ describe('Breadcrumbs', () => {
     expect(screen.getByText('Home').closest('a')).toHaveAttribute('href', '/')
     // weather is in knownPathsWithoutPages, so not clickable
     expect(screen.getByText('weather')).not.toHaveAttribute('href')
-    // stations has a real index page, so its crumb links
-    expect(screen.getByText('stations').closest('a')).toHaveAttribute('href', '/weather/stations')
+    // stations only has an index page on NWAC, so not clickable here
+    expect(screen.getByText('stations')).not.toHaveAttribute('href')
     // map is the last segment, not clickable
     expect(screen.getByText('map')).not.toHaveAttribute('href')
+  })
+
+  it('links the stations crumb on NWAC, which has a stations index page', () => {
+    mockTenantSlug = 'nwac'
+    mockUseSelectedLayoutSegments.mockReturnValue(['weather', 'stations', 'map'])
+    render(
+      <BreadcrumbProvider>
+        <NotFoundProvider>
+          <Breadcrumbs />
+        </NotFoundProvider>
+      </BreadcrumbProvider>,
+    )
+    expect(screen.getByText('stations').closest('a')).toHaveAttribute('href', '/weather/stations')
   })
 
   it('renders breadcrumbs for a catch-all segment (single string with slashes)', () => {

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -109,35 +109,6 @@ describe('buildChartOption precision and bar rendering', () => {
   })
 })
 
-describe('buildChartOption negative clamping', () => {
-  const T = 1_700_000_000_000
-  const negative: GraphData = {
-    series: [
-      {
-        kind: 'raw',
-        stid: '1',
-        stationName: 'Station 1',
-        variable: 'snow_depth',
-        label: 'Station 1',
-        unit: 'in',
-        points: [[T, -0.4]],
-      },
-    ],
-    aggregated: false,
-    timezone: 'x',
-  }
-
-  it('clamps sub-zero values to zero unless the preset allows negatives', () => {
-    const SNOW_PRESET = { key: 'snowdepth', title: 'Total Snow Depth', variables: ['snow_depth'] }
-    expect(chartSeries(buildChartOption(negative, SNOW_PRESET))[0].data).toEqual([[T, 0]])
-  })
-
-  it('keeps negatives on presets flagged allowNegative', () => {
-    const preset = { ...TEMP_PRESET, allowNegative: true }
-    expect(chartSeries(buildChartOption(negative, preset))[0].data).toEqual([[T, -0.4]])
-  })
-})
-
 describe('buildChartOption wind band', () => {
   const WIND_PRESET = {
     key: 'wind',

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -5,6 +5,9 @@ import type { GraphData } from '@/services/snowobs/graph'
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen } from '@testing-library/react'
 
+const TEMP_PRESET = { key: 'temp', title: 'Temperature', variables: ['air_temp'] }
+const RH_PRESET = { key: 'rh', title: 'Relative Humidity', variables: ['relative_humidity'] }
+
 // The ECharts canvas never mounts in these tests (fetches resolve to empty data).
 jest.mock('next/dynamic', () => () => {
   const Noop = () => null
@@ -51,6 +54,79 @@ describe('buildChartOption comparison styling', () => {
   })
 })
 
+describe('buildChartOption wind band', () => {
+  const WIND_PRESET = {
+    key: 'wind',
+    title: 'Wind Speed',
+    variables: ['wind_speed_min', 'wind_speed', 'wind_gust'],
+    band: { lower: 'wind_speed_min', upper: 'wind_gust' },
+  }
+  const T = 1_700_000_000_000
+
+  function wind(variable: string, value: number | null): GraphData['series'][number] {
+    return {
+      kind: 'raw',
+      stid: '1',
+      stationName: 'Station 1',
+      variable,
+      label: `Station 1 ${variable}`,
+      unit: 'mph',
+      points: [[T, value]],
+    }
+  }
+
+  type BandSeries = LineSeries & { name?: string; areaStyle?: { opacity?: number }; data?: unknown }
+
+  function isBandSeriesArray(value: unknown): value is BandSeries[] {
+    return Array.isArray(value) && value.every((s) => typeof s === 'object' && s !== null)
+  }
+
+  function chartSeries(option: Record<string, unknown>): BandSeries[] {
+    if (!isBandSeriesArray(option.series)) throw new Error('expected a series array')
+    return option.series
+  }
+
+  it('collapses min and gust into a shaded band around the speed line', () => {
+    const data: GraphData = {
+      series: [wind('wind_speed_min', 5), wind('wind_speed', 10), wind('wind_gust', 20)],
+      aggregated: false,
+      timezone: 'x',
+    }
+    const option = buildChartOption(data, WIND_PRESET)
+    const series = chartSeries(option)
+
+    expect(series.map((s) => s.name)).toEqual([
+      'Station 1 wind_speed',
+      'Station 1 wind_speed_min band',
+      'Station 1 wind_gust band',
+    ])
+    const area = series.find((s) => s.areaStyle)
+    expect(area?.data).toEqual([[T, 15]])
+  })
+
+  it('keeps plain lines when a band edge is missing', () => {
+    const data: GraphData = {
+      series: [wind('wind_speed_min', 5), wind('wind_speed', 10)],
+      aggregated: false,
+      timezone: 'x',
+    }
+    const series = chartSeries(buildChartOption(data, WIND_PRESET))
+
+    expect(series.map((s) => s.name)).toEqual(['Station 1 wind_speed_min', 'Station 1 wind_speed'])
+    expect(series.some((s) => s.areaStyle)).toBe(false)
+  })
+
+  it('breaks the band where either edge is null', () => {
+    const data: GraphData = {
+      series: [wind('wind_speed_min', null), wind('wind_speed', 10), wind('wind_gust', 20)],
+      aggregated: false,
+      timezone: 'x',
+    }
+    const area = chartSeries(buildChartOption(data, WIND_PRESET)).find((s) => s.areaStyle)
+    expect(area?.data).toEqual([[T, null]])
+  })
+})
+
 describe('StationGraphs compare picker', () => {
   const [current, other, third, fourth, fifth] = NWAC_WEATHER_STATION_GROUPS
   if (!fifth) throw new Error('registry needs at least five groups')
@@ -81,11 +157,17 @@ describe('StationGraphs compare picker', () => {
     expect(values).toContain(other.slug)
   })
 
-  it('refetches with the stids of each added station appended', () => {
+  function renderWithCompares(...slugs: string[]): HTMLElement {
     renderGraphs()
     const select = screen.getByLabelText(/Compare with/)
-    fireEvent.change(select, { target: { value: other.slug } })
-    fireEvent.change(select, { target: { value: third.slug } })
+    for (const slug of slugs) {
+      fireEvent.change(select, { target: { value: slug } })
+    }
+    return select
+  }
+
+  it('refetches with the stids of each added station appended', () => {
+    renderWithCompares(other.slug, third.slug)
 
     const expected = [...current.stids, ...other.stids, ...third.stids].join(',')
     expect(fetchedUrls().some((url) => url.includes(`stids=${encodeURIComponent(expected)}`))).toBe(
@@ -94,10 +176,7 @@ describe('StationGraphs compare picker', () => {
   })
 
   it('removes a station via its chip', () => {
-    renderGraphs()
-    const select = screen.getByLabelText(/Compare with/)
-    fireEvent.change(select, { target: { value: other.slug } })
-    fireEvent.change(select, { target: { value: third.slug } })
+    renderWithCompares(other.slug, third.slug)
     fireEvent.click(screen.getByLabelText(`Remove ${other.displayName}`))
 
     const urls = fetchedUrls()
@@ -106,9 +185,7 @@ describe('StationGraphs compare picker', () => {
   })
 
   it('hides selected stations from the options and disables the select at the cap', () => {
-    renderGraphs()
-    const select = screen.getByLabelText(/Compare with/)
-    fireEvent.change(select, { target: { value: other.slug } })
+    const select = renderWithCompares(other.slug)
 
     const values = Array.from(select.querySelectorAll('option')).map((o) => o.value)
     expect(values).not.toContain(other.slug)
@@ -117,5 +194,59 @@ describe('StationGraphs compare picker', () => {
     fireEvent.change(select, { target: { value: third.slug } })
     fireEvent.change(select, { target: { value: fourth.slug } })
     expect(select).toBeDisabled()
+  })
+})
+
+describe('StationGraphs chart arrangement', () => {
+  const current = NWAC_WEATHER_STATION_GROUPS[0]
+  const fetchMock = jest.fn()
+  const dataWithSeries: GraphData = { series: [series('1')], aggregated: false, timezone: 'x' }
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue({ ok: true, json: async () => dataWithSeries })
+    global.fetch = fetchMock
+  })
+
+  function renderGraphs() {
+    render(
+      <StationGraphs
+        stids={current.stids}
+        presets={[TEMP_PRESET, RH_PRESET]}
+        currentSlug={current.slug}
+      />,
+    )
+  }
+
+  async function expectChartOrder(titles: string[]): Promise<void> {
+    const buttons = await screen.findAllByLabelText(/^Move .* down$/)
+    const labels = buttons.map((b) => b.getAttribute('aria-label') ?? '')
+    expect(labels).toEqual(titles.map((title) => `Move ${title} down`))
+  }
+
+  it('moves a chart down past its neighbor', async () => {
+    renderGraphs()
+    await expectChartOrder(['Temperature', 'Relative Humidity'])
+
+    fireEvent.click(screen.getByLabelText('Move Temperature down'))
+    await expectChartOrder(['Relative Humidity', 'Temperature'])
+  })
+
+  it('hides a chart into a restorable chip', async () => {
+    renderGraphs()
+    fireEvent.click(await screen.findByLabelText('Hide Temperature'))
+    expect(screen.queryByLabelText('Hide Temperature')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Show Temperature'))
+    expect(await screen.findByLabelText('Hide Temperature')).toBeInTheDocument()
+  })
+
+  it('persists the arrangement to localStorage', async () => {
+    renderGraphs()
+    fireEvent.click(await screen.findByLabelText('Hide Temperature'))
+
+    const stored = window.localStorage.getItem('nwac-station-graph-prefs') ?? ''
+    expect(stored).toContain('"hidden":["temp"]')
   })
 })

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -52,9 +52,8 @@ describe('buildChartOption comparison styling', () => {
 })
 
 describe('StationGraphs compare picker', () => {
-  const current = NWAC_WEATHER_STATION_GROUPS[0]
-  const other = NWAC_WEATHER_STATION_GROUPS.find((g) => g.slug !== current.slug)
-  if (!other) throw new Error('registry needs at least two groups')
+  const [current, other, third, fourth, fifth] = NWAC_WEATHER_STATION_GROUPS
+  if (!fifth) throw new Error('registry needs at least five groups')
 
   const emptyData: GraphData = { series: [], aggregated: false, timezone: 'x' }
 
@@ -82,23 +81,41 @@ describe('StationGraphs compare picker', () => {
     expect(values).toContain(other.slug)
   })
 
-  it('refetches with the comparison stids appended', () => {
+  it('refetches with the stids of each added station appended', () => {
     renderGraphs()
-    fireEvent.change(screen.getByLabelText(/Compare with/), { target: { value: other.slug } })
+    const select = screen.getByLabelText(/Compare with/)
+    fireEvent.change(select, { target: { value: other.slug } })
+    fireEvent.change(select, { target: { value: third.slug } })
 
-    const expected = [...current.stids, ...other.stids].join(',')
+    const expected = [...current.stids, ...other.stids, ...third.stids].join(',')
     expect(fetchedUrls().some((url) => url.includes(`stids=${encodeURIComponent(expected)}`))).toBe(
       true,
     )
   })
 
-  it('drops back to the base stids when compare is cleared', () => {
+  it('removes a station via its chip', () => {
     renderGraphs()
     const select = screen.getByLabelText(/Compare with/)
     fireEvent.change(select, { target: { value: other.slug } })
-    fireEvent.change(select, { target: { value: '' } })
+    fireEvent.change(select, { target: { value: third.slug } })
+    fireEvent.click(screen.getByLabelText(`Remove ${other.displayName}`))
 
     const urls = fetchedUrls()
-    expect(urls[urls.length - 1]).toContain(`stids=${encodeURIComponent(current.stids.join(','))}`)
+    const expected = [...current.stids, ...third.stids].join(',')
+    expect(urls[urls.length - 1]).toContain(`stids=${encodeURIComponent(expected)}`)
+  })
+
+  it('hides selected stations from the options and disables the select at the cap', () => {
+    renderGraphs()
+    const select = screen.getByLabelText(/Compare with/)
+    fireEvent.change(select, { target: { value: other.slug } })
+
+    const values = Array.from(select.querySelectorAll('option')).map((o) => o.value)
+    expect(values).not.toContain(other.slug)
+    expect(select).not.toBeDisabled()
+
+    fireEvent.change(select, { target: { value: third.slug } })
+    fireEvent.change(select, { target: { value: fourth.slug } })
+    expect(select).toBeDisabled()
   })
 })

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -20,7 +20,7 @@ function series(stid: string, variable = 'air_temp'): GraphData['series'][number
     stid,
     stationName: `Station ${stid}`,
     variable,
-    label: `Station ${stid} ${variable}`,
+    label: `Station ${stid}`,
     unit: '°F',
     points: [[1_700_000_000_000, 30]],
   }
@@ -76,7 +76,7 @@ describe('buildChartOption wind band', () => {
       stid: '1',
       stationName: 'Station 1',
       variable,
-      label: `Station 1 ${variable}`,
+      label: 'Station 1',
       unit: 'mph',
       points: [[T, value]],
     }
@@ -92,9 +92,9 @@ describe('buildChartOption wind band', () => {
     const series = chartSeries(option)
 
     expect(series.map((s) => s.name)).toEqual([
-      'Station 1 wind_speed',
-      'Station 1 wind_speed_min band',
-      'Station 1 wind_gust band',
+      'Station 1',
+      'Station 1 wind_speed_min',
+      'Station 1 wind_gust',
     ])
     const area = series.find((s) => s.areaStyle)
     expect(area?.data).toEqual([[T, 15]])
@@ -108,7 +108,7 @@ describe('buildChartOption wind band', () => {
     }
     const series = chartSeries(buildChartOption(data, WIND_PRESET))
 
-    expect(series.map((s) => s.name)).toEqual(['Station 1 wind_speed_min', 'Station 1 wind_speed'])
+    expect(series.map((s) => s.name)).toEqual(['Station 1', 'Station 1'])
     expect(series.some((s) => s.areaStyle)).toBe(false)
   })
 

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -1,0 +1,104 @@
+import { StationGraphs } from '@/components/WeatherStations/StationGraphs'
+import { buildChartOption } from '@/components/WeatherStations/stationGraphOptions'
+import { NWAC_WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
+import type { GraphData } from '@/services/snowobs/graph'
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+// The ECharts canvas never mounts in these tests (fetches resolve to empty data).
+jest.mock('next/dynamic', () => () => {
+  const Noop = () => null
+  return Noop
+})
+
+const PRESET = { key: 'temp', title: 'Temperature', variables: ['air_temp'] }
+
+function series(stid: string): GraphData['series'][number] {
+  return {
+    kind: 'raw',
+    stid,
+    stationName: `Station ${stid}`,
+    variable: 'air_temp',
+    label: `Station ${stid} Temp`,
+    unit: '°F',
+    points: [[1_700_000_000_000, 30]],
+  }
+}
+
+type LineSeries = { lineStyle?: { type?: string } }
+
+function isLineSeriesArray(value: unknown): value is LineSeries[] {
+  return Array.isArray(value) && value.every((s) => typeof s === 'object' && s !== null)
+}
+
+// The rendered series' lineStyle.type values, in order.
+function seriesLineTypes(option: Record<string, unknown>): (string | undefined)[] {
+  if (!isLineSeriesArray(option.series)) throw new Error('expected a series array')
+  return option.series.map((s) => s.lineStyle?.type)
+}
+
+describe('buildChartOption comparison styling', () => {
+  const data: GraphData = { series: [series('1'), series('9')], aggregated: false, timezone: 'x' }
+
+  it('dashes series from stations outside primaryStids', () => {
+    const option = buildChartOption(data, PRESET, ['1'])
+    expect(seriesLineTypes(option)).toEqual([undefined, 'dashed'])
+  })
+
+  it('leaves everything solid when primaryStids is omitted', () => {
+    const option = buildChartOption(data, PRESET)
+    expect(seriesLineTypes(option)).toEqual([undefined, undefined])
+  })
+})
+
+describe('StationGraphs compare picker', () => {
+  const current = NWAC_WEATHER_STATION_GROUPS[0]
+  const other = NWAC_WEATHER_STATION_GROUPS.find((g) => g.slug !== current.slug)
+  if (!other) throw new Error('registry needs at least two groups')
+
+  const emptyData: GraphData = { series: [], aggregated: false, timezone: 'x' }
+
+  const fetchMock = jest.fn()
+
+  function fetchedUrls(): string[] {
+    return fetchMock.mock.calls.map((call) => String(call[0]))
+  }
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue({ ok: true, json: async () => emptyData })
+    global.fetch = fetchMock
+  })
+
+  function renderGraphs() {
+    render(<StationGraphs stids={current.stids} presets={[PRESET]} currentSlug={current.slug} />)
+  }
+
+  it('excludes the current station from the compare options', () => {
+    renderGraphs()
+    const select = screen.getByLabelText(/Compare with/)
+    const values = Array.from(select.querySelectorAll('option')).map((o) => o.value)
+    expect(values).not.toContain(current.slug)
+    expect(values).toContain(other.slug)
+  })
+
+  it('refetches with the comparison stids appended', () => {
+    renderGraphs()
+    fireEvent.change(screen.getByLabelText(/Compare with/), { target: { value: other.slug } })
+
+    const expected = [...current.stids, ...other.stids].join(',')
+    expect(fetchedUrls().some((url) => url.includes(`stids=${encodeURIComponent(expected)}`))).toBe(
+      true,
+    )
+  })
+
+  it('drops back to the base stids when compare is cleared', () => {
+    renderGraphs()
+    const select = screen.getByLabelText(/Compare with/)
+    fireEvent.change(select, { target: { value: other.slug } })
+    fireEvent.change(select, { target: { value: '' } })
+
+    const urls = fetchedUrls()
+    expect(urls[urls.length - 1]).toContain(`stids=${encodeURIComponent(current.stids.join(','))}`)
+  })
+})

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -31,6 +31,7 @@ type ChartSeries = {
   type?: string
   lineStyle?: { type?: string }
   areaStyle?: { opacity?: number }
+  tooltip?: { valueFormatter?: unknown }
   data?: unknown
 }
 
@@ -66,17 +67,40 @@ describe('buildChartOption precision and bar rendering', () => {
   const data: GraphData = { series: [series('1')], aggregated: false, timezone: 'x' }
   const BAR_PRESET = { key: 'precip', title: 'Precipitation', variables: ['air_temp'], bar: true }
 
+  // Walks a key path through nested plain objects without type assertions.
+  function nested(value: unknown, keys: string[]): unknown {
+    let current = value
+    for (const key of keys) {
+      if (typeof current !== 'object' || current === null) return undefined
+      current = Object.entries(current).find(([k]) => k === key)?.[1]
+    }
+    return current
+  }
+
   function tooltipFormat(option: Record<string, unknown>, value: number): string {
-    const tooltip = option.tooltip
-    if (typeof tooltip !== 'object' || tooltip === null) throw new Error('expected tooltip')
-    const formatter = Object.entries(tooltip).find(([k]) => k === 'valueFormatter')?.[1]
+    const formatter = chartSeries(option)[0].tooltip?.valueFormatter
     if (typeof formatter !== 'function') throw new Error('expected valueFormatter')
     return String(formatter(value))
   }
 
-  it('formats line-chart tooltips to one decimal, bars to two', () => {
-    expect(tooltipFormat(buildChartOption(data, TEMP_PRESET), 31.26)).toBe('31.3')
-    expect(tooltipFormat(buildChartOption(data, BAR_PRESET), 0.125)).toBe('0.13')
+  // Digs the axis-pointer label formatter out of the chart-level tooltip.
+  function dateHeaderFormat(option: Record<string, unknown>, value: number): string {
+    const formatter = nested(option, ['tooltip', 'axisPointer', 'label', 'formatter'])
+    if (typeof formatter !== 'function') throw new Error('expected axis pointer formatter')
+    return String(formatter({ value }))
+  }
+
+  it('formats tooltip values to one decimal with the unit appended', () => {
+    expect(tooltipFormat(buildChartOption(data, TEMP_PRESET), 31.26)).toBe('31.3 °F')
+    expect(tooltipFormat(buildChartOption(data, BAR_PRESET), 0.16)).toBe('0.2 °F')
+    expect(tooltipFormat(buildChartOption(data, TEMP_PRESET), Number.NaN)).toBe('–')
+  })
+
+  it('formats the tooltip date header human-readably', () => {
+    const t = new Date(2026, 0, 10, 14, 30).getTime()
+    expect(dateHeaderFormat(buildChartOption(data, TEMP_PRESET), t)).toBe('Sat Jan 10, 14:30')
+    const daily: GraphData = { ...data, aggregated: true }
+    expect(dateHeaderFormat(buildChartOption(daily, TEMP_PRESET), t)).toBe('Sat Jan 10, 2026')
   })
 
   it('renders bar presets as bar series', () => {

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -8,48 +8,55 @@ import { fireEvent, render, screen } from '@testing-library/react'
 const TEMP_PRESET = { key: 'temp', title: 'Temperature', variables: ['air_temp'] }
 const RH_PRESET = { key: 'rh', title: 'Relative Humidity', variables: ['relative_humidity'] }
 
-// The ECharts canvas never mounts in these tests (fetches resolve to empty data).
+// The ECharts canvas never mounts in these tests.
 jest.mock('next/dynamic', () => () => {
   const Noop = () => null
   return Noop
 })
 
-const PRESET = { key: 'temp', title: 'Temperature', variables: ['air_temp'] }
-
-function series(stid: string): GraphData['series'][number] {
+function series(stid: string, variable = 'air_temp'): GraphData['series'][number] {
   return {
     kind: 'raw',
     stid,
     stationName: `Station ${stid}`,
-    variable: 'air_temp',
-    label: `Station ${stid} Temp`,
+    variable,
+    label: `Station ${stid} ${variable}`,
     unit: '°F',
     points: [[1_700_000_000_000, 30]],
   }
 }
 
-type LineSeries = { lineStyle?: { type?: string } }
+type ChartSeries = {
+  name?: string
+  lineStyle?: { type?: string }
+  areaStyle?: { opacity?: number }
+  data?: unknown
+}
 
-function isLineSeriesArray(value: unknown): value is LineSeries[] {
+function isSeriesArray(value: unknown): value is ChartSeries[] {
   return Array.isArray(value) && value.every((s) => typeof s === 'object' && s !== null)
+}
+
+function chartSeries(option: Record<string, unknown>): ChartSeries[] {
+  if (!isSeriesArray(option.series)) throw new Error('expected a series array')
+  return option.series
 }
 
 // The rendered series' lineStyle.type values, in order.
 function seriesLineTypes(option: Record<string, unknown>): (string | undefined)[] {
-  if (!isLineSeriesArray(option.series)) throw new Error('expected a series array')
-  return option.series.map((s) => s.lineStyle?.type)
+  return chartSeries(option).map((s) => s.lineStyle?.type)
 }
 
 describe('buildChartOption comparison styling', () => {
   const data: GraphData = { series: [series('1'), series('9')], aggregated: false, timezone: 'x' }
 
   it('dashes series from stations outside primaryStids', () => {
-    const option = buildChartOption(data, PRESET, ['1'])
+    const option = buildChartOption(data, TEMP_PRESET, ['1'])
     expect(seriesLineTypes(option)).toEqual([undefined, 'dashed'])
   })
 
   it('leaves everything solid when primaryStids is omitted', () => {
-    const option = buildChartOption(data, PRESET)
+    const option = buildChartOption(data, TEMP_PRESET)
     expect(seriesLineTypes(option)).toEqual([undefined, undefined])
   })
 })
@@ -73,17 +80,6 @@ describe('buildChartOption wind band', () => {
       unit: 'mph',
       points: [[T, value]],
     }
-  }
-
-  type BandSeries = LineSeries & { name?: string; areaStyle?: { opacity?: number }; data?: unknown }
-
-  function isBandSeriesArray(value: unknown): value is BandSeries[] {
-    return Array.isArray(value) && value.every((s) => typeof s === 'object' && s !== null)
-  }
-
-  function chartSeries(option: Record<string, unknown>): BandSeries[] {
-    if (!isBandSeriesArray(option.series)) throw new Error('expected a series array')
-    return option.series
   }
 
   it('collapses min and gust into a shaded band around the speed line', () => {
@@ -146,7 +142,9 @@ describe('StationGraphs compare picker', () => {
   })
 
   function renderGraphs() {
-    render(<StationGraphs stids={current.stids} presets={[PRESET]} currentSlug={current.slug} />)
+    render(
+      <StationGraphs stids={current.stids} presets={[TEMP_PRESET]} currentSlug={current.slug} />,
+    )
   }
 
   it('excludes the current station from the compare options', () => {
@@ -200,7 +198,12 @@ describe('StationGraphs compare picker', () => {
 describe('StationGraphs chart arrangement', () => {
   const current = NWAC_WEATHER_STATION_GROUPS[0]
   const fetchMock = jest.fn()
-  const dataWithSeries: GraphData = { series: [series('1')], aggregated: false, timezone: 'x' }
+  // One response serves both charts: a series per preset variable.
+  const dataWithSeries: GraphData = {
+    series: [series('1', 'air_temp'), series('1', 'relative_humidity')],
+    aggregated: false,
+    timezone: 'x',
+  }
 
   beforeEach(() => {
     window.localStorage.clear()
@@ -248,5 +251,15 @@ describe('StationGraphs chart arrangement', () => {
 
     const stored = window.localStorage.getItem('nwac-station-graph-prefs') ?? ''
     expect(stored).toContain('"hidden":["temp"]')
+  })
+
+  it('drops charts whose variables no station reports', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...dataWithSeries, series: [series('1', 'air_temp')] }),
+    })
+    renderGraphs()
+    await expectChartOrder(['Temperature'])
+    expect(screen.queryByLabelText('Hide Relative Humidity')).not.toBeInTheDocument()
   })
 })

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -109,6 +109,35 @@ describe('buildChartOption precision and bar rendering', () => {
   })
 })
 
+describe('buildChartOption negative clamping', () => {
+  const T = 1_700_000_000_000
+  const negative: GraphData = {
+    series: [
+      {
+        kind: 'raw',
+        stid: '1',
+        stationName: 'Station 1',
+        variable: 'snow_depth',
+        label: 'Station 1',
+        unit: 'in',
+        points: [[T, -0.4]],
+      },
+    ],
+    aggregated: false,
+    timezone: 'x',
+  }
+
+  it('clamps sub-zero values to zero unless the preset allows negatives', () => {
+    const SNOW_PRESET = { key: 'snowdepth', title: 'Total Snow Depth', variables: ['snow_depth'] }
+    expect(chartSeries(buildChartOption(negative, SNOW_PRESET))[0].data).toEqual([[T, 0]])
+  })
+
+  it('keeps negatives on presets flagged allowNegative', () => {
+    const preset = { ...TEMP_PRESET, allowNegative: true }
+    expect(chartSeries(buildChartOption(negative, preset))[0].data).toEqual([[T, -0.4]])
+  })
+})
+
 describe('buildChartOption wind band', () => {
   const WIND_PRESET = {
     key: 'wind',

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -139,11 +139,9 @@ describe('buildChartOption wind band', () => {
     const option = buildChartOption(data, WIND_PRESET)
     const series = chartSeries(option)
 
-    expect(series.map((s) => s.name)).toEqual([
-      'Station 1',
-      'Station 1 wind_speed_min',
-      'Station 1 wind_gust',
-    ])
+    // Band helpers share the station's legend name so legend-hiding the
+    // station hides its band too.
+    expect(series.map((s) => s.name)).toEqual(['Station 1', 'Station 1', 'Station 1'])
     const area = series.find((s) => s.areaStyle)
     expect(area?.data).toEqual([[T, 15]])
   })

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -28,6 +28,7 @@ function series(stid: string, variable = 'air_temp'): GraphData['series'][number
 
 type ChartSeries = {
   name?: string
+  type?: string
   lineStyle?: { type?: string }
   areaStyle?: { opacity?: number }
   data?: unknown
@@ -58,6 +59,29 @@ describe('buildChartOption comparison styling', () => {
   it('leaves everything solid when primaryStids is omitted', () => {
     const option = buildChartOption(data, TEMP_PRESET)
     expect(seriesLineTypes(option)).toEqual([undefined, undefined])
+  })
+})
+
+describe('buildChartOption precision and bar rendering', () => {
+  const data: GraphData = { series: [series('1')], aggregated: false, timezone: 'x' }
+  const BAR_PRESET = { key: 'precip', title: 'Precipitation', variables: ['air_temp'], bar: true }
+
+  function tooltipFormat(option: Record<string, unknown>, value: number): string {
+    const tooltip = option.tooltip
+    if (typeof tooltip !== 'object' || tooltip === null) throw new Error('expected tooltip')
+    const formatter = Object.entries(tooltip).find(([k]) => k === 'valueFormatter')?.[1]
+    if (typeof formatter !== 'function') throw new Error('expected valueFormatter')
+    return String(formatter(value))
+  }
+
+  it('formats line-chart tooltips to one decimal, bars to two', () => {
+    expect(tooltipFormat(buildChartOption(data, TEMP_PRESET), 31.26)).toBe('31.3')
+    expect(tooltipFormat(buildChartOption(data, BAR_PRESET), 0.125)).toBe('0.13')
+  })
+
+  it('renders bar presets as bar series', () => {
+    expect(chartSeries(buildChartOption(data, BAR_PRESET)).map((s) => s.type)).toEqual(['bar'])
+    expect(chartSeries(buildChartOption(data, TEMP_PRESET)).map((s) => s.type)).toEqual(['line'])
   })
 })
 

--- a/__tests__/client/components/stationGraphPrefs.client.test.ts
+++ b/__tests__/client/components/stationGraphPrefs.client.test.ts
@@ -1,0 +1,50 @@
+import {
+  loadChartPrefs,
+  reconcileChartPrefs,
+  saveChartPrefs,
+  swapWithNeighbor,
+} from '@/components/WeatherStations/stationGraphPrefs'
+
+describe('reconcileChartPrefs', () => {
+  it('drops unknown keys and appends new presets in default position', () => {
+    const stored = { order: ['b', 'gone', 'a'], hidden: ['gone', 'b'] }
+    expect(reconcileChartPrefs(stored, ['a', 'b', 'c'])).toEqual({
+      order: ['b', 'a', 'c'],
+      hidden: ['b'],
+    })
+  })
+})
+
+describe('load/save round trip', () => {
+  beforeEach(() => window.localStorage.clear())
+
+  it('restores a saved arrangement', () => {
+    saveChartPrefs({ order: ['b', 'a'], hidden: ['a'] })
+    expect(loadChartPrefs(['a', 'b'])).toEqual({ order: ['b', 'a'], hidden: ['a'] })
+  })
+
+  it('falls back to defaults on garbage', () => {
+    window.localStorage.setItem('nwac-station-graph-prefs', '{"order": "nope"}')
+    expect(loadChartPrefs(['a', 'b'])).toEqual({ order: ['a', 'b'], hidden: [] })
+  })
+})
+
+describe('swapWithNeighbor', () => {
+  const none = () => false
+
+  it('swaps with the adjacent key', () => {
+    expect(swapWithNeighbor(['a', 'b', 'c'], 'b', -1, none)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('skips keys the caller marks unswappable', () => {
+    const skipB = (key: string) => key === 'b'
+    expect(swapWithNeighbor(['a', 'b', 'c'], 'a', 1, skipB)).toEqual(['c', 'b', 'a'])
+  })
+
+  it('returns the order untouched at a boundary', () => {
+    const order = ['a', 'b']
+    expect(swapWithNeighbor(order, 'a', -1, none)).toBe(order)
+    const skipA = (key: string) => key === 'a'
+    expect(swapWithNeighbor(order, 'b', -1, skipA)).toBe(order)
+  })
+})

--- a/__tests__/client/components/stationGraphUnits.client.test.ts
+++ b/__tests__/client/components/stationGraphUnits.client.test.ts
@@ -1,4 +1,9 @@
-import { convertGraphData, convertPreset } from '@/components/WeatherStations/stationGraphUnits'
+import { STATION_GRAPH_PRESETS } from '@/components/WeatherStations/stationGraphPresets'
+import {
+  clampNegativeValues,
+  convertGraphData,
+  convertPreset,
+} from '@/components/WeatherStations/stationGraphUnits'
 import { useUnitSystem } from '@/components/WeatherStations/UnitToggle'
 import type { GraphData } from '@/services/snowobs/graph'
 import { act, renderHook } from '@testing-library/react'
@@ -67,6 +72,47 @@ describe('convertGraphData', () => {
     expect(convertGraphData(data, 'metric').series[0]).toMatchObject({ unit: '%' })
     expect(convertGraphData(data, 'imperial')).toBe(data)
   })
+})
+
+describe('clampNegativeValues', () => {
+  it('clamps raw points and daily rows to zero', () => {
+    const data: GraphData = {
+      series: [
+        rawSeries('snow_depth', 'in', -0.4),
+        {
+          kind: 'daily',
+          stid: '1',
+          stationName: 'Station 1',
+          variable: 'wind_speed',
+          label: 'Station 1',
+          unit: 'mph',
+          days: [[T, -1, 2, 5]],
+        },
+      ],
+      aggregated: false,
+      timezone: 'x',
+    }
+    const [snow, wind] = clampNegativeValues(data).series
+    expect(snow).toMatchObject({ points: [[T, 0]] })
+    expect(wind).toMatchObject({ days: [[T, 0, 2, 5]] })
+  })
+
+  it('sub-freezing metric temps stay negative (temp presets skip the clamp)', () => {
+    const data: GraphData = {
+      series: [rawSeries('equip_temperature', '°F', 25)],
+      aggregated: false,
+      timezone: 'x',
+    }
+    const converted = convertGraphData(data, 'metric')
+    const [point] = converted.series[0].kind === 'raw' ? converted.series[0].points : []
+    expect(point[1]).toBeCloseTo(-3.9, 1)
+  })
+})
+
+it('both temperature presets allow negative values', () => {
+  const temps = STATION_GRAPH_PRESETS.filter((p) => p.variables[0].includes('temp'))
+  expect(temps.map((p) => p.key)).toEqual(['temp', 'equiptemp'])
+  expect(temps.every((p) => p.allowNegative)).toBe(true)
 })
 
 describe('convertPreset', () => {

--- a/__tests__/client/components/stationGraphUnits.client.test.ts
+++ b/__tests__/client/components/stationGraphUnits.client.test.ts
@@ -1,0 +1,98 @@
+import { convertGraphData, convertPreset } from '@/components/WeatherStations/stationGraphUnits'
+import { useUnitSystem } from '@/components/WeatherStations/UnitToggle'
+import type { GraphData } from '@/services/snowobs/graph'
+import { act, renderHook } from '@testing-library/react'
+
+const T = 1_700_000_000_000
+
+function rawSeries(variable: string, unit: string, value: number): GraphData['series'][number] {
+  return {
+    kind: 'raw',
+    stid: '1',
+    stationName: 'Station 1',
+    variable,
+    label: 'Station 1',
+    unit,
+    points: [[T, value]],
+  }
+}
+
+describe('convertGraphData', () => {
+  it('converts values and unit labels to metric', () => {
+    const data: GraphData = {
+      series: [
+        rawSeries('air_temp', '°F', 32),
+        rawSeries('wind_speed', 'mph', 10),
+        rawSeries('snow_depth', 'in', 10),
+        rawSeries('precip_accum_one_hour', 'in', 1),
+      ],
+      aggregated: false,
+      timezone: 'x',
+    }
+    const [temp, wind, snow, precip] = convertGraphData(data, 'metric').series
+    expect(temp).toMatchObject({ unit: '°C', points: [[T, 0]] })
+    expect(wind).toMatchObject({ unit: 'km/h', points: [[T, 16.09344]] })
+    expect(snow).toMatchObject({ unit: 'cm', points: [[T, 25.4]] })
+    expect(precip).toMatchObject({ unit: 'mm', points: [[T, 25.4]] })
+  })
+
+  it('converts daily min/mean/max rows', () => {
+    const data: GraphData = {
+      series: [
+        {
+          kind: 'daily',
+          stid: '1',
+          stationName: 'Station 1',
+          variable: 'air_temp',
+          label: 'Station 1',
+          unit: '°F',
+          days: [[T, 32, 41, 50]],
+        },
+      ],
+      aggregated: true,
+      timezone: 'x',
+    }
+    expect(convertGraphData(data, 'metric').series[0]).toMatchObject({
+      unit: '°C',
+      days: [[T, 0, 5, 10]],
+    })
+  })
+
+  it('passes unconvertible variables and imperial through untouched', () => {
+    const data: GraphData = {
+      series: [rawSeries('relative_humidity', '%', 80)],
+      aggregated: false,
+      timezone: 'x',
+    }
+    expect(convertGraphData(data, 'metric').series[0]).toMatchObject({ unit: '%' })
+    expect(convertGraphData(data, 'imperial')).toBe(data)
+  })
+})
+
+describe('convertPreset', () => {
+  const TEMP_PRESET = {
+    key: 'temp',
+    title: 'Temperature',
+    variables: ['air_temp'],
+    refLine: 32,
+  }
+
+  it('converts the freezing reference line to 0°C', () => {
+    expect(convertPreset(TEMP_PRESET, 'metric').refLine).toBe(0)
+    expect(convertPreset(TEMP_PRESET, 'imperial')).toBe(TEMP_PRESET)
+  })
+})
+
+describe('useUnitSystem', () => {
+  it('defaults to imperial and persists the choice per browser', () => {
+    const first = renderHook(() => useUnitSystem())
+    expect(first.result.current[0]).toBe('imperial')
+    act(() => first.result.current[1]('metric'))
+    expect(first.result.current[0]).toBe('metric')
+    first.unmount()
+
+    const second = renderHook(() => useUnitSystem())
+    expect(second.result.current[0]).toBe('metric')
+    window.localStorage.clear()
+  })
+})

--- a/__tests__/server/graphSeries.server.test.ts
+++ b/__tests__/server/graphSeries.server.test.ts
@@ -1,0 +1,86 @@
+import {
+  aggregateDaily,
+  buildGraphData,
+  DECIMATION_THRESHOLD_DAYS,
+  windowExceedsThreshold,
+} from '../../src/services/snowobs/graph'
+import type { SnowObsTimeseriesResponse } from '../../src/services/snowobs/types/schemas'
+
+const HOUR = 60 * 60 * 1000
+// Noon UTC = early morning in America/Vancouver; hours 0-5 stay on one local day.
+const T0 = new Date('2026-01-10T12:00:00Z').getTime()
+const iso = (hoursAfter: number) => new Date(T0 + hoursAfter * HOUR).toISOString()
+
+const response: SnowObsTimeseriesResponse = {
+  UNITS: { air_temp: 'fahrenheit', snow_depth: 'inches' },
+  VARIABLES: [
+    { variable: 'air_temp', long_name: 'Air Temperature' },
+    { variable: 'snow_depth', long_name: 'Snow Depth' },
+  ],
+  STATION: [
+    {
+      id: '4',
+      stid: '4',
+      name: 'Hurricane Ridge',
+      latitude: 47.9,
+      longitude: -123.4,
+      elevation: 5250,
+      observations: {
+        date_time: [iso(0), iso(1), iso(2)],
+        air_temp: [30, null, 34],
+        snow_depth: [100, 101, 102],
+      },
+    },
+  ],
+}
+
+describe('buildGraphData', () => {
+  it('emits one raw series per station/variable with nulls preserved', () => {
+    const data = buildGraphData(response, ['4'], ['air_temp', 'snow_depth'], false)
+    expect(data.aggregated).toBe(false)
+    expect(data.series).toHaveLength(2)
+    const temp = data.series[0]
+    if (temp.kind !== 'raw') throw new Error('expected raw series')
+    expect(temp.label).toBe('Hurricane Ridge · Temp')
+    expect(temp.unit).toBe('°F')
+    expect(temp.points.map(([, v]) => v)).toEqual([30, null, 34])
+  })
+
+  it('skips unknown stations and absent variables', () => {
+    const data = buildGraphData(response, ['4', 'nope'], ['air_temp', 'wind_speed'], false)
+    expect(data.series).toHaveLength(1)
+  })
+
+  it('aggregates to daily min/mean/max when requested', () => {
+    const data = buildGraphData(response, ['4'], ['air_temp'], true)
+    const series = data.series[0]
+    if (series.kind !== 'daily') throw new Error('expected daily series')
+    // 30 and 34 fall on the same display-timezone day; null dropped.
+    expect(series.days).toHaveLength(1)
+    const [, min, mean, max] = series.days[0]
+    expect([min, mean, max]).toEqual([30, 32, 34])
+  })
+})
+
+describe('aggregateDaily', () => {
+  it('buckets by display-timezone day and omits all-null days', () => {
+    const days = aggregateDaily([
+      [T0, 10],
+      [T0 + 26 * HOUR, null],
+      [T0 + 48 * HOUR, 20],
+    ])
+    expect(days).toHaveLength(2)
+    expect(days[0][1]).toBe(10)
+    expect(days[1][1]).toBe(20)
+  })
+})
+
+describe('windowExceedsThreshold', () => {
+  it('flags windows beyond the threshold only', () => {
+    const from = new Date(T0)
+    const under = new Date(T0 + (DECIMATION_THRESHOLD_DAYS - 1) * 24 * HOUR)
+    const over = new Date(T0 + (DECIMATION_THRESHOLD_DAYS + 1) * 24 * HOUR)
+    expect(windowExceedsThreshold(from, under)).toBe(false)
+    expect(windowExceedsThreshold(from, over)).toBe(true)
+  })
+})

--- a/__tests__/server/graphSeries.server.test.ts
+++ b/__tests__/server/graphSeries.server.test.ts
@@ -2,6 +2,7 @@ import {
   aggregateDaily,
   buildGraphData,
   DECIMATION_THRESHOLD_DAYS,
+  vectorMeanDegrees,
   windowExceedsThreshold,
 } from '../../src/services/snowobs/graph'
 import type { SnowObsTimeseriesResponse } from '../../src/services/snowobs/types/schemas'
@@ -82,5 +83,25 @@ describe('windowExceedsThreshold', () => {
     const over = new Date(T0 + (DECIMATION_THRESHOLD_DAYS + 1) * 24 * HOUR)
     expect(windowExceedsThreshold(from, under)).toBe(false)
     expect(windowExceedsThreshold(from, over)).toBe(true)
+  })
+})
+
+describe('vectorMeanDegrees', () => {
+  it('averages across the north wrap correctly', () => {
+    // Arithmetic mean of 350 and 10 is 180 (dead wrong); vector mean is 0.
+    expect(vectorMeanDegrees([350, 10])).toBe(0)
+    expect(vectorMeanDegrees([90, 90])).toBe(90)
+    expect(vectorMeanDegrees([0, 90])).toBe(45)
+  })
+
+  it('pins min/max to the vector mean in circular aggregation', () => {
+    const days = aggregateDaily(
+      [
+        [Date.UTC(2026, 0, 10, 12), 350],
+        [Date.UTC(2026, 0, 10, 13), 10],
+      ],
+      true,
+    )
+    expect(days[0].slice(1)).toEqual([0, 0, 0])
   })
 })

--- a/__tests__/server/graphSeries.server.test.ts
+++ b/__tests__/server/graphSeries.server.test.ts
@@ -42,7 +42,7 @@ describe('buildGraphData', () => {
     expect(data.series).toHaveLength(2)
     const temp = data.series[0]
     if (temp.kind !== 'raw') throw new Error('expected raw series')
-    expect(temp.label).toBe('Hurricane Ridge · Temp')
+    expect(temp.label).toBe("Hurricane Ridge (5,250')")
     expect(temp.unit).toBe('°F')
     expect(temp.points.map(([, v]) => v)).toEqual([30, null, 34])
   })

--- a/__tests__/server/snowobsService.server.test.ts
+++ b/__tests__/server/snowobsService.server.test.ts
@@ -50,6 +50,19 @@ describe('fetchStationTimeseries', () => {
     expect(result.STATION[0].observations.air_temp).toEqual([30])
   })
 
+  it('requests unrounded values only when rawData is set', async () => {
+    const seenParams: (string | null)[] = []
+    server.use(
+      http.get(TIMESERIES_URL, ({ request }) => {
+        seenParams.push(new URL(request.url).searchParams.get('raw_data'))
+        return HttpResponse.json(validResponse)
+      }),
+    )
+    await fetchStationTimeseries(['4'], { rawData: true })
+    await fetchStationTimeseries(['4'])
+    expect(seenParams).toEqual(['true', null])
+  })
+
   it('throws SnowObsError with the status on a non-2xx response', async () => {
     server.use(http.get(TIMESERIES_URL, () => new HttpResponse(null, { status: 500 })))
     await expect(fetchStationTimeseries(['4'])).rejects.toThrow(SnowObsError)

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "cross-env": "^7.0.3",
     "date-fns": "^4.1.0",
     "dompurify": "^3.3.3",
+    "echarts": "6.1.0",
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
     "fuse.js": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
+    "build": "cross-env NODE_OPTIONS=\"--no-deprecation --max-old-space-size=4096\" next build",
     "dev": "cross-env NODE_OPTIONS=\"${NODE_OPTIONS} --no-deprecation --inspect=${INSPECT_PORT:-9229}\" next dev --port ${PORT:-3000}",
     "dev:prod": "cross-env NODE_OPTIONS=--no-deprecation rm -rf .next && pnpm build && pnpm start",
     "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       dompurify:
         specifier: ^3.3.3
         version: 3.4.0
+      echarts:
+        specifier: 6.1.0
+        version: 6.1.0
       embla-carousel-autoplay:
         specifier: ^8.6.0
         version: 8.6.0(embla-carousel@8.6.0)
@@ -8017,6 +8020,12 @@ packages:
         integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
       }
 
+  echarts@6.1.0:
+    resolution:
+      {
+        integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==,
+      }
+
   ee-first@1.1.1:
     resolution:
       {
@@ -13193,6 +13202,12 @@ packages:
       }
     engines: { node: '>=6' }
 
+  tslib@2.3.0:
+    resolution:
+      {
+        integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==,
+      }
+
   tslib@2.8.1:
     resolution:
       {
@@ -13903,6 +13918,12 @@ packages:
     resolution:
       {
         integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
+      }
+
+  zrender@6.1.0:
+    resolution:
+      {
+        integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==,
       }
 
   zwitch@2.0.4:
@@ -18798,6 +18819,11 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  echarts@6.1.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 6.1.0
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.129: {}
@@ -22606,6 +22632,8 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tslib@2.3.0: {}
+
   tslib@2.8.1: {}
 
   tsx@4.20.3:
@@ -23061,5 +23089,9 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zrender@6.1.0:
+    dependencies:
+      tslib: 2.3.0
 
   zwitch@2.0.4: {}

--- a/src/app/(frontend)/[center]/weather/graph-data/route.ts
+++ b/src/app/(frontend)/[center]/weather/graph-data/route.ts
@@ -1,0 +1,105 @@
+import { STATIONS_TENANT_SLUG, WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
+import { buildGraphData, windowExceedsThreshold } from '@/services/snowobs/graph'
+import { fetchStationTimeseries, SnowObsError } from '@/services/snowobs/snowobs'
+import { NextResponse } from 'next/server'
+
+// The graph engine's data endpoint (grill-me 2026-07-20): serves both the
+// public station Graphs tab and the future self-serve builder. Reads SnowObs
+// live server-side (token stays hidden), auto-aggregates windows longer than
+// 30 days to daily min/mean/max.
+
+const KNOWN_STIDS = new Set(WEATHER_STATION_GROUPS.flatMap((g) => g.stids))
+const MAX_STATIONS = 6
+const MAX_VARIABLES = 8
+const MAX_WINDOW_MS = 5 * 366 * 24 * 60 * 60 * 1000 // ~5 years, verified against SnowObs
+const REVALIDATE_SECONDS = 300
+
+type Params = { center: string }
+
+function csvParam(value: string | null): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+function badRequest(message: string): NextResponse {
+  return NextResponse.json({ error: message }, { status: 400 })
+}
+
+// Each validator returns an error message or null; parseQuery composes them.
+function listBounds(name: string, values: string[], max: number): string | null {
+  return values.length === 0 || values.length > max ? `${name} must list 1-${max} entries` : null
+}
+
+function unknownStids(stids: string[]): string | null {
+  const unknown = stids.filter((stid) => !KNOWN_STIDS.has(stid))
+  return unknown.length > 0 ? `unknown stids: ${unknown.join(',')}` : null
+}
+
+function validateLists(stids: string[], vars: string[]): string | null {
+  return (
+    listBounds('stids', stids, MAX_STATIONS) ??
+    listBounds('vars', vars, MAX_VARIABLES) ??
+    unknownStids(stids)
+  )
+}
+
+function isValidRange(from: Date, to: Date): boolean {
+  return Number.isFinite(from.getTime()) && Number.isFinite(to.getTime()) && from < to
+}
+
+function validateWindow(from: Date, to: Date): string | null {
+  if (!isValidRange(from, to)) return 'from/to must be valid dates with from < to'
+  return to.getTime() - from.getTime() > MAX_WINDOW_MS ? 'window exceeds the 5-year maximum' : null
+}
+
+function dateParam(url: URL, name: string): Date {
+  return new Date(url.searchParams.get(name) ?? '')
+}
+
+// Parse + bound the query surface. Returns an error response or the parsed inputs.
+function parseQuery(
+  url: URL,
+): NextResponse | { stids: string[]; vars: string[]; from: Date; to: Date } {
+  const stids = csvParam(url.searchParams.get('stids'))
+  const vars = csvParam(url.searchParams.get('vars'))
+  const from = dateParam(url, 'from')
+  const to = dateParam(url, 'to')
+  const error = validateLists(stids, vars) ?? validateWindow(from, to)
+  return error ? badRequest(error) : { stids, vars, from, to }
+}
+
+// Branches are the tenant gate + validation + upstream error mapping — splitting
+// further would scatter one request's flow. CRAP inflated by no route-level UT.
+// fallow-ignore-next-line complexity
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<Params> },
+): Promise<NextResponse> {
+  const { center } = await params
+  if (center !== STATIONS_TENANT_SLUG) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+  }
+
+  const parsed = parseQuery(new URL(request.url))
+  if (parsed instanceof NextResponse) return parsed
+  const { stids, vars, from, to } = parsed
+
+  try {
+    const response = await fetchStationTimeseries(stids, {
+      start: from,
+      end: to,
+      revalidate: REVALIDATE_SECONDS,
+    })
+    const data = buildGraphData(response, stids, vars, windowExceedsThreshold(from, to))
+    return NextResponse.json(data, {
+      headers: {
+        'Cache-Control': `public, s-maxage=${REVALIDATE_SECONDS}, stale-while-revalidate=60`,
+      },
+    })
+  } catch (error) {
+    const message = error instanceof SnowObsError ? error.message : 'failed to load station data'
+    return NextResponse.json({ error: message }, { status: 502 })
+  }
+}

--- a/src/app/(frontend)/[center]/weather/graph-data/route.ts
+++ b/src/app/(frontend)/[center]/weather/graph-data/route.ts
@@ -9,9 +9,9 @@ import { NextResponse } from 'next/server'
 // 30 days to daily min/mean/max.
 
 const KNOWN_STIDS = new Set(NWAC_WEATHER_STATION_GROUPS.flatMap((g) => g.stids))
-// Must fit two full station groups (largest is 3 stids): the Graphs tab's
-// compare picker requests the page's group plus one comparison group.
-const MAX_STATIONS = 6
+// Must fit the page's station group plus the Graphs tab's comparison picks:
+// up to 4 full groups (largest is 3 stids).
+const MAX_STATIONS = 12
 const MAX_VARIABLES = 8
 const MAX_WINDOW_MS = 5 * 366 * 24 * 60 * 60 * 1000 // ~5 years, verified against SnowObs
 const REVALIDATE_SECONDS = 300

--- a/src/app/(frontend)/[center]/weather/graph-data/route.ts
+++ b/src/app/(frontend)/[center]/weather/graph-data/route.ts
@@ -1,4 +1,4 @@
-import { STATIONS_TENANT_SLUG, WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
+import { NWAC_WEATHER_STATION_GROUPS, STATIONS_TENANT_SLUG } from '@/constants/weatherStations'
 import { buildGraphData, windowExceedsThreshold } from '@/services/snowobs/graph'
 import { fetchStationTimeseries, SnowObsError } from '@/services/snowobs/snowobs'
 import { NextResponse } from 'next/server'
@@ -8,7 +8,7 @@ import { NextResponse } from 'next/server'
 // live server-side (token stays hidden), auto-aggregates windows longer than
 // 30 days to daily min/mean/max.
 
-const KNOWN_STIDS = new Set(WEATHER_STATION_GROUPS.flatMap((g) => g.stids))
+const KNOWN_STIDS = new Set(NWAC_WEATHER_STATION_GROUPS.flatMap((g) => g.stids))
 const MAX_STATIONS = 6
 const MAX_VARIABLES = 8
 const MAX_WINDOW_MS = 5 * 366 * 24 * 60 * 60 * 1000 // ~5 years, verified against SnowObs

--- a/src/app/(frontend)/[center]/weather/graph-data/route.ts
+++ b/src/app/(frontend)/[center]/weather/graph-data/route.ts
@@ -9,6 +9,8 @@ import { NextResponse } from 'next/server'
 // 30 days to daily min/mean/max.
 
 const KNOWN_STIDS = new Set(NWAC_WEATHER_STATION_GROUPS.flatMap((g) => g.stids))
+// Must fit two full station groups (largest is 3 stids): the Graphs tab's
+// compare picker requests the page's group plus one comparison group.
 const MAX_STATIONS = 6
 const MAX_VARIABLES = 8
 const MAX_WINDOW_MS = 5 * 366 * 24 * 60 * 60 * 1000 // ~5 years, verified against SnowObs

--- a/src/app/(frontend)/[center]/weather/graph-data/route.ts
+++ b/src/app/(frontend)/[center]/weather/graph-data/route.ts
@@ -8,14 +8,12 @@ import { buildGraphData, windowExceedsThreshold } from '@/services/snowobs/graph
 import { fetchStationTimeseries, SnowObsError } from '@/services/snowobs/snowobs'
 import { NextResponse } from 'next/server'
 
-// The graph engine's data endpoint: serves both the public station Graphs tab
-// and the future self-serve builder. Reads SnowObs live server-side (token
-// stays hidden), auto-aggregates windows longer than 30 days to daily
-// min/mean/max.
+// Serves the station Graphs tab. Reads SnowObs server-side (token stays
+// hidden); windows longer than 30 days aggregate to daily min/mean/max.
 
 const KNOWN_STIDS = new Set(NWAC_WEATHER_STATION_GROUPS.flatMap((g) => g.stids))
-// Derived caps: the page's station group plus every comparison pick, and the
-// union of all preset variables (the Graphs tab fetches them in one request).
+// Caps sized to the Graphs tab's single fetch: the page's station group plus
+// every comparison pick, and the union of all preset variables.
 const MAX_GROUP_STIDS = Math.max(...NWAC_WEATHER_STATION_GROUPS.map((g) => g.stids.length))
 const MAX_STATIONS = (1 + MAX_COMPARE_STATIONS) * MAX_GROUP_STIDS
 const MAX_VARIABLES = new Set(STATION_GRAPH_PRESETS.flatMap((p) => p.variables)).size

--- a/src/app/(frontend)/[center]/weather/graph-data/route.ts
+++ b/src/app/(frontend)/[center]/weather/graph-data/route.ts
@@ -1,18 +1,24 @@
-import { NWAC_WEATHER_STATION_GROUPS, STATIONS_TENANT_SLUG } from '@/constants/weatherStations'
+import { STATION_GRAPH_PRESETS } from '@/components/WeatherStations/stationGraphPresets'
+import {
+  MAX_COMPARE_STATIONS,
+  NWAC_WEATHER_STATION_GROUPS,
+  STATIONS_TENANT_SLUG,
+} from '@/constants/weatherStations'
 import { buildGraphData, windowExceedsThreshold } from '@/services/snowobs/graph'
 import { fetchStationTimeseries, SnowObsError } from '@/services/snowobs/snowobs'
 import { NextResponse } from 'next/server'
 
-// The graph engine's data endpoint (grill-me 2026-07-20): serves both the
-// public station Graphs tab and the future self-serve builder. Reads SnowObs
-// live server-side (token stays hidden), auto-aggregates windows longer than
-// 30 days to daily min/mean/max.
+// The graph engine's data endpoint: serves both the public station Graphs tab
+// and the future self-serve builder. Reads SnowObs live server-side (token
+// stays hidden), auto-aggregates windows longer than 30 days to daily
+// min/mean/max.
 
 const KNOWN_STIDS = new Set(NWAC_WEATHER_STATION_GROUPS.flatMap((g) => g.stids))
-// Must fit the page's station group plus the Graphs tab's comparison picks:
-// up to 4 full groups (largest is 3 stids).
-const MAX_STATIONS = 12
-const MAX_VARIABLES = 8
+// Derived caps: the page's station group plus every comparison pick, and the
+// union of all preset variables (the Graphs tab fetches them in one request).
+const MAX_GROUP_STIDS = Math.max(...NWAC_WEATHER_STATION_GROUPS.map((g) => g.stids.length))
+const MAX_STATIONS = (1 + MAX_COMPARE_STATIONS) * MAX_GROUP_STIDS
+const MAX_VARIABLES = new Set(STATION_GRAPH_PRESETS.flatMap((p) => p.variables)).size
 const MAX_WINDOW_MS = 5 * 366 * 24 * 60 * 60 * 1000 // ~5 years, verified against SnowObs
 const REVALIDATE_SECONDS = 300
 
@@ -29,7 +35,6 @@ function badRequest(message: string): NextResponse {
   return NextResponse.json({ error: message }, { status: 400 })
 }
 
-// Each validator returns an error message or null; parseQuery composes them.
 function listBounds(name: string, values: string[], max: number): string | null {
   return values.length === 0 || values.length > max ? `${name} must list 1-${max} entries` : null
 }
@@ -60,7 +65,6 @@ function dateParam(url: URL, name: string): Date {
   return new Date(url.searchParams.get(name) ?? '')
 }
 
-// Parse + bound the query surface. Returns an error response or the parsed inputs.
 function parseQuery(
   url: URL,
 ): NextResponse | { stids: string[]; vars: string[]; from: Date; to: Date } {
@@ -72,8 +76,7 @@ function parseQuery(
   return error ? badRequest(error) : { stids, vars, from, to }
 }
 
-// Branches are the tenant gate + validation + upstream error mapping — splitting
-// further would scatter one request's flow. CRAP inflated by no route-level UT.
+// CRAP is inflated by the lack of unit coverage on this route handler.
 // fallow-ignore-next-line complexity
 export async function GET(
   request: Request,

--- a/src/app/(frontend)/[center]/weather/graph-data/route.ts
+++ b/src/app/(frontend)/[center]/weather/graph-data/route.ts
@@ -96,6 +96,7 @@ export async function GET(
       start: from,
       end: to,
       revalidate: REVALIDATE_SECONDS,
+      rawData: true,
     })
     const data = buildGraphData(response, stids, vars, windowExceedsThreshold(from, to))
     return NextResponse.json(data, {

--- a/src/app/(frontend)/[center]/weather/stations/[station]/page.tsx
+++ b/src/app/(frontend)/[center]/weather/stations/[station]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata, ResolvedMetadata } from 'next/types'
 
 import { StationCsvForm } from '@/components/WeatherStations/StationCsvForm'
+import { presetsForGroup } from '@/components/WeatherStations/stationGraphPresets'
+import { StationGraphs } from '@/components/WeatherStations/StationGraphs'
 import { StationPageView } from '@/components/WeatherStations/StationPageView'
 import { resolveStationRange } from '@/components/WeatherStations/StationRangeTabs'
 import {
@@ -56,20 +58,28 @@ function csvYears(): number[] {
 type TabView = {
   key: string
   table: StationTable | null
-  csvForm?: ReactNode
+  tabContent?: ReactNode
 }
 
 async function csvTabView(group: WeatherStationGroup): Promise<TabView> {
   return {
     key: 'csv',
     table: null,
-    csvForm: (
+    tabContent: (
       <StationCsvForm
         slug={group.slug}
         dataloggers={await loadDataloggers(group)}
         years={csvYears()}
       />
     ),
+  }
+}
+
+function graphsTabView(group: WeatherStationGroup): TabView {
+  return {
+    key: 'graphs',
+    table: null,
+    tabContent: <StationGraphs stids={group.stids} presets={presetsForGroup(group)} />,
   }
 }
 
@@ -82,8 +92,10 @@ async function rangeTabView(group: WeatherStationGroup, rangeParam?: string): Pr
   return { key: range.key, table: buildStationTable(response, group.columns) }
 }
 
-function resolveTabView(group: WeatherStationGroup, rangeParam?: string): Promise<TabView> {
-  return rangeParam === 'csv' ? csvTabView(group) : rangeTabView(group, rangeParam)
+async function resolveTabView(group: WeatherStationGroup, rangeParam?: string): Promise<TabView> {
+  if (rangeParam === 'csv') return csvTabView(group)
+  if (rangeParam === 'graphs') return graphsTabView(group)
+  return rangeTabView(group, rangeParam)
 }
 
 export default async function Page({ params, searchParams }: Args) {
@@ -102,7 +114,7 @@ export default async function Page({ params, searchParams }: Args) {
   const view = await resolveTabView(group, rangeParam)
 
   return (
-    <StationPageView group={group} table={view.table} activeKey={view.key} csvForm={view.csvForm} />
+    <StationPageView group={group} table={view.table} activeKey={view.key} tabContent={view.tabContent} />
   )
 }
 

--- a/src/app/(frontend)/[center]/weather/stations/[station]/page.tsx
+++ b/src/app/(frontend)/[center]/weather/stations/[station]/page.tsx
@@ -79,7 +79,13 @@ function graphsTabView(group: WeatherStationGroup): TabView {
   return {
     key: 'graphs',
     table: null,
-    tabContent: <StationGraphs stids={group.stids} presets={presetsForGroup(group)} />,
+    tabContent: (
+      <StationGraphs
+        stids={group.stids}
+        presets={presetsForGroup(group)}
+        currentSlug={group.slug}
+      />
+    ),
   }
 }
 
@@ -114,7 +120,12 @@ export default async function Page({ params, searchParams }: Args) {
   const view = await resolveTabView(group, rangeParam)
 
   return (
-    <StationPageView group={group} table={view.table} activeKey={view.key} tabContent={view.tabContent} />
+    <StationPageView
+      group={group}
+      table={view.table}
+      activeKey={view.key}
+      tabContent={view.tabContent}
+    />
   )
 }
 

--- a/src/app/(frontend)/[center]/weather/stations/[station]/page.tsx
+++ b/src/app/(frontend)/[center]/weather/stations/[station]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, ResolvedMetadata } from 'next/types'
 
 import { StationCsvForm } from '@/components/WeatherStations/StationCsvForm'
-import { presetsForGroup } from '@/components/WeatherStations/stationGraphPresets'
+import { STATION_GRAPH_PRESETS } from '@/components/WeatherStations/stationGraphPresets'
 import { StationGraphs } from '@/components/WeatherStations/StationGraphs'
 import { StationPageView } from '@/components/WeatherStations/StationPageView'
 import { resolveStationRange } from '@/components/WeatherStations/StationRangeTabs'
@@ -80,11 +80,7 @@ function graphsTabView(group: WeatherStationGroup): TabView {
     key: 'graphs',
     table: null,
     tabContent: (
-      <StationGraphs
-        stids={group.stids}
-        presets={presetsForGroup(group)}
-        currentSlug={group.slug}
-      />
+      <StationGraphs stids={group.stids} presets={STATION_GRAPH_PRESETS} currentSlug={group.slug} />
     ),
   }
 }

--- a/src/components/Breadcrumbs/Breadcrumbs.client.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.client.tsx
@@ -16,10 +16,10 @@ import {
   BreadcrumbSeparator,
 } from '../ui/breadcrumb'
 
+// /weather/stations has a real index page now, so its crumb links.
 const knownPathsWithoutPages = [
   '/forecasts',
   '/weather',
-  '/weather/stations',
   '/weather/accumulations',
   '/observations/avalanches',
 ]

--- a/src/components/Breadcrumbs/Breadcrumbs.client.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.client.tsx
@@ -17,47 +17,10 @@ import {
   BreadcrumbSeparator,
 } from '../ui/breadcrumb'
 
-const knownPathsWithoutPages = [
-  '/forecasts',
-  '/weather',
-  '/weather/accumulations',
-  '/observations/avalanches',
-]
-
 type BreadcrumbType = {
   name: string
   isLast: boolean
   href: string | null
-}
-
-const createBreadcrumbItem = (
-  name: string,
-  href: string | null,
-  isLast: boolean,
-  unlinkedPaths: string[],
-): BreadcrumbType => ({
-  name: name.replace(/-/g, ' '),
-  href: href && unlinkedPaths.includes(href) ? null : href,
-  isLast,
-})
-
-const processNestedSegments = (
-  nestedSegments: string[],
-  index: number,
-  totalSegments: number,
-  unlinkedPaths: string[],
-): BreadcrumbType[] => {
-  const prependedSegments = nestedSegments
-    .slice(0, -1)
-    .map((segment) => createBreadcrumbItem(segment, null, false, unlinkedPaths))
-
-  const lastNestedSegment = nestedSegments[nestedSegments.length - 1]
-  const href = '/' + [...nestedSegments.slice(0, index), lastNestedSegment].join('/')
-  const isLast = index === totalSegments - 1
-
-  const mainSegment = createBreadcrumbItem(lastNestedSegment, href, isLast, unlinkedPaths)
-
-  return [...prependedSegments, mainSegment]
 }
 
 export function Breadcrumbs() {
@@ -71,22 +34,47 @@ export function Breadcrumbs() {
 
   if (decodedSegments.length === 0 || isNotFound) return null
 
+  const knownPathsWithoutPages = [
+    '/forecasts',
+    '/weather',
+    '/weather/accumulations',
+    '/observations/avalanches',
+  ]
   // Only NWAC has a /weather/stations index page, so only its crumb links.
-  const unlinkedPaths =
-    tenant?.slug === 'nwac'
-      ? knownPathsWithoutPages
-      : [...knownPathsWithoutPages, '/weather/stations']
+  if (tenant?.slug !== 'nwac') knownPathsWithoutPages.push('/weather/stations')
+
+  const createBreadcrumbItem = (
+    name: string,
+    href: string | null,
+    isLast: boolean,
+  ): BreadcrumbType => ({
+    name: name.replace(/-/g, ' '),
+    href: href && knownPathsWithoutPages.includes(href) ? null : href,
+    isLast,
+  })
+
+  const processNestedSegments = (nestedSegments: string[], index: number): BreadcrumbType[] => {
+    const prependedSegments = nestedSegments
+      .slice(0, -1)
+      .map((segment) => createBreadcrumbItem(segment, null, false))
+
+    const lastNestedSegment = nestedSegments[nestedSegments.length - 1]
+    const href = '/' + [...nestedSegments.slice(0, index), lastNestedSegment].join('/')
+    const isLast = index === decodedSegments.length - 1
+
+    return [...prependedSegments, createBreadcrumbItem(lastNestedSegment, href, isLast)]
+  }
 
   const breadcrumbItems: BreadcrumbType[] = decodedSegments.flatMap((segment, index) => {
     const nestedSegments = segment.split('/').filter((seg) => seg !== '')
 
     if (nestedSegments.length > 1) {
-      return processNestedSegments(nestedSegments, index, decodedSegments.length, unlinkedPaths)
+      return processNestedSegments(nestedSegments, index)
     } else {
       const href = '/' + decodedSegments.slice(0, index + 1).join('/')
       const isLast = index === decodedSegments.length - 1
 
-      return [createBreadcrumbItem(segment, href, isLast, unlinkedPaths)]
+      return [createBreadcrumbItem(segment, href, isLast)]
     }
   })
 

--- a/src/components/Breadcrumbs/Breadcrumbs.client.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.client.tsx
@@ -2,6 +2,7 @@
 
 import { useBreadcrumbs } from '@/providers/BreadcrumbProvider'
 import { useNotFound } from '@/providers/NotFoundProvider'
+import { useTenant } from '@/providers/TenantProvider'
 import { cn } from '@/utilities/ui'
 import { useAnalytics } from '@/utilities/useAnalytics'
 import Link from 'next/link'
@@ -16,7 +17,6 @@ import {
   BreadcrumbSeparator,
 } from '../ui/breadcrumb'
 
-// /weather/stations has a real index page now, so its crumb links.
 const knownPathsWithoutPages = [
   '/forecasts',
   '/weather',
@@ -34,9 +34,10 @@ const createBreadcrumbItem = (
   name: string,
   href: string | null,
   isLast: boolean,
+  unlinkedPaths: string[],
 ): BreadcrumbType => ({
   name: name.replace(/-/g, ' '),
-  href: href && knownPathsWithoutPages.includes(href) ? null : href,
+  href: href && unlinkedPaths.includes(href) ? null : href,
   isLast,
 })
 
@@ -44,16 +45,17 @@ const processNestedSegments = (
   nestedSegments: string[],
   index: number,
   totalSegments: number,
+  unlinkedPaths: string[],
 ): BreadcrumbType[] => {
   const prependedSegments = nestedSegments
     .slice(0, -1)
-    .map((segment) => createBreadcrumbItem(segment, null, false))
+    .map((segment) => createBreadcrumbItem(segment, null, false, unlinkedPaths))
 
   const lastNestedSegment = nestedSegments[nestedSegments.length - 1]
   const href = '/' + [...nestedSegments.slice(0, index), lastNestedSegment].join('/')
   const isLast = index === totalSegments - 1
 
-  const mainSegment = createBreadcrumbItem(lastNestedSegment, href, isLast)
+  const mainSegment = createBreadcrumbItem(lastNestedSegment, href, isLast, unlinkedPaths)
 
   return [...prependedSegments, mainSegment]
 }
@@ -65,19 +67,26 @@ export function Breadcrumbs() {
   const { isNotFound } = useNotFound()
   const { pageLabel } = useBreadcrumbs()
   const { captureWithTenant } = useAnalytics()
+  const { tenant } = useTenant()
 
   if (decodedSegments.length === 0 || isNotFound) return null
+
+  // Only NWAC has a /weather/stations index page, so only its crumb links.
+  const unlinkedPaths =
+    tenant?.slug === 'nwac'
+      ? knownPathsWithoutPages
+      : [...knownPathsWithoutPages, '/weather/stations']
 
   const breadcrumbItems: BreadcrumbType[] = decodedSegments.flatMap((segment, index) => {
     const nestedSegments = segment.split('/').filter((seg) => seg !== '')
 
     if (nestedSegments.length > 1) {
-      return processNestedSegments(nestedSegments, index, decodedSegments.length)
+      return processNestedSegments(nestedSegments, index, decodedSegments.length, unlinkedPaths)
     } else {
       const href = '/' + decodedSegments.slice(0, index + 1).join('/')
       const isLast = index === decodedSegments.length - 1
 
-      return [createBreadcrumbItem(segment, href, isLast)]
+      return [createBreadcrumbItem(segment, href, isLast, unlinkedPaths)]
     }
   })
 

--- a/src/components/WeatherStations/EChart.tsx
+++ b/src/components/WeatherStations/EChart.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { LineChart } from 'echarts/charts'
+import {
+  DataZoomComponent,
+  GridComponent,
+  LegendComponent,
+  TooltipComponent,
+} from 'echarts/components'
+import type { ComposeOption } from 'echarts/core'
+import * as echarts from 'echarts/core'
+import { CanvasRenderer } from 'echarts/renderers'
+import { useEffect, useRef } from 'react'
+
+// Thin tree-shaken ECharts wrapper: line charts + grid/tooltip/legend/dataZoom
+// only, canvas renderer. Register once at module load.
+echarts.use([
+  LineChart,
+  GridComponent,
+  TooltipComponent,
+  LegendComponent,
+  DataZoomComponent,
+  CanvasRenderer,
+])
+
+export type EChartOption = ComposeOption<never> & Record<string, unknown>
+
+export function EChart({ option, height = 320 }: { option: EChartOption; height?: number }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const chartRef = useRef<echarts.ECharts | null>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const chart = echarts.init(container)
+    chartRef.current = chart
+    const observer = new ResizeObserver(() => chart.resize())
+    observer.observe(container)
+    return () => {
+      observer.disconnect()
+      chart.dispose()
+      chartRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    // notMerge so a range switch fully replaces series instead of layering.
+    chartRef.current?.setOption(option, { notMerge: true })
+  }, [option])
+
+  return <div ref={containerRef} style={{ height }} className="w-full" />
+}

--- a/src/components/WeatherStations/EChart.tsx
+++ b/src/components/WeatherStations/EChart.tsx
@@ -5,6 +5,7 @@ import {
   DataZoomComponent,
   GridComponent,
   LegendComponent,
+  TitleComponent,
   TooltipComponent,
 } from 'echarts/components'
 import type { ComposeOption } from 'echarts/core'
@@ -17,6 +18,7 @@ import { useEffect, useRef } from 'react'
 echarts.use([
   LineChart,
   GridComponent,
+  TitleComponent,
   TooltipComponent,
   LegendComponent,
   DataZoomComponent,
@@ -25,7 +27,16 @@ echarts.use([
 
 export type EChartOption = ComposeOption<never> & Record<string, unknown>
 
-export function EChart({ option, height = 320 }: { option: EChartOption; height?: number }) {
+export function EChart({
+  option,
+  height = 380,
+  group,
+}: {
+  option: EChartOption
+  height?: number
+  /** Charts sharing a group id zoom/pan together (echarts.connect). */
+  group?: string
+}) {
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<echarts.ECharts | null>(null)
 
@@ -34,6 +45,10 @@ export function EChart({ option, height = 320 }: { option: EChartOption; height?
     if (!container) return
     const chart = echarts.init(container)
     chartRef.current = chart
+    if (group) {
+      chart.group = group
+      echarts.connect(group)
+    }
     const observer = new ResizeObserver(() => chart.resize())
     observer.observe(container)
     return () => {
@@ -41,7 +56,7 @@ export function EChart({ option, height = 320 }: { option: EChartOption; height?
       chart.dispose()
       chartRef.current = null
     }
-  }, [])
+  }, [group])
 
   useEffect(() => {
     // notMerge so a range switch fully replaces series instead of layering.

--- a/src/components/WeatherStations/EChart.tsx
+++ b/src/components/WeatherStations/EChart.tsx
@@ -5,6 +5,7 @@ import {
   DataZoomComponent,
   GridComponent,
   LegendComponent,
+  MarkLineComponent,
   TitleComponent,
   TooltipComponent,
 } from 'echarts/components'
@@ -18,6 +19,7 @@ import { useEffect, useRef } from 'react'
 echarts.use([
   LineChart,
   GridComponent,
+  MarkLineComponent,
   TitleComponent,
   TooltipComponent,
   LegendComponent,

--- a/src/components/WeatherStations/EChart.tsx
+++ b/src/components/WeatherStations/EChart.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { LineChart } from 'echarts/charts'
+import { BarChart, LineChart } from 'echarts/charts'
 import {
   DataZoomComponent,
   GridComponent,
@@ -14,10 +14,11 @@ import * as echarts from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
 import { useEffect, useRef } from 'react'
 
-// Thin tree-shaken ECharts wrapper: line charts + grid/tooltip/legend/dataZoom
-// only, canvas renderer. Register once at module load.
+// Thin tree-shaken ECharts wrapper: line/bar charts + grid/tooltip/legend/
+// dataZoom only, canvas renderer. Register once at module load.
 echarts.use([
   LineChart,
+  BarChart,
   GridComponent,
   MarkLineComponent,
   TitleComponent,

--- a/src/components/WeatherStations/EChart.tsx
+++ b/src/components/WeatherStations/EChart.tsx
@@ -14,8 +14,7 @@ import * as echarts from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
 import { useEffect, useRef } from 'react'
 
-// Thin tree-shaken ECharts wrapper: line/bar charts + grid/tooltip/legend/
-// dataZoom only, canvas renderer. Register once at module load.
+// Tree-shaken ECharts: only what the station charts use.
 echarts.use([
   LineChart,
   BarChart,

--- a/src/components/WeatherStations/PrecipAccumulationTable.tsx
+++ b/src/components/WeatherStations/PrecipAccumulationTable.tsx
@@ -8,7 +8,6 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import type {
   PrecipAccumulationTable as PrecipAccumulationData,
   PrecipAccumulationRow,
@@ -17,9 +16,11 @@ import { PRECIP_ACCUMULATION_WINDOWS } from '@/services/snowobs/tableHelpers'
 import { cn } from '@/utilities/ui'
 import { ChevronDown, ChevronsUpDown, ChevronUp } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import type { UnitSystem } from './UnitToggle'
+import { UnitToggle } from './UnitToggle'
 
 // Totals come from the API in inches, elevation in feet; metric converts on display.
-type Unit = 'imperial' | 'metric'
+type Unit = UnitSystem
 const PRECIP_UNIT: Record<Unit, string> = { imperial: 'in', metric: 'mm' }
 const ELEVATION_UNIT: Record<Unit, string> = { imperial: 'ft', metric: 'm' }
 function formatTotal(value: number, unit: Unit): string {
@@ -204,34 +205,6 @@ function AccumulationCells({ row, unit }: { row: PrecipAccumulationRow; unit: Un
   })
 }
 
-function UnitToggle({ unit, onChange }: { unit: Unit; onChange: (u: Unit) => void }) {
-  return (
-    <div className="mb-2 flex justify-end">
-      <ToggleGroup
-        type="single"
-        size="sm"
-        variant="outline"
-        value={unit}
-        onValueChange={(v) => (v === 'imperial' || v === 'metric') && onChange(v)}
-        aria-label="Units"
-      >
-        <ToggleGroupItem
-          value="imperial"
-          className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
-        >
-          Imperial
-        </ToggleGroupItem>
-        <ToggleGroupItem
-          value="metric"
-          className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
-        >
-          Metric
-        </ToggleGroupItem>
-      </ToggleGroup>
-    </div>
-  )
-}
-
 function HeaderRow({
   sort,
   onSort,
@@ -299,7 +272,9 @@ export function PrecipAccumulationTable({ table }: { table: PrecipAccumulationDa
 
   return (
     <div>
-      <UnitToggle unit={unit} onChange={setUnit} />
+      <div className="mb-2 flex justify-end">
+        <UnitToggle unit={unit} onChange={setUnit} />
+      </div>
       <Table className="mx-auto w-auto text-base">
         <TableHeader>
           <HeaderRow sort={sort} onSort={onSort} unit={unit} timezoneLabel={table.timezoneLabel} />

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -2,7 +2,9 @@
 
 import type { GraphData } from '@/services/snowobs/graph'
 import { cn } from '@/utilities/ui'
+import { Loader2 } from 'lucide-react'
 import dynamic from 'next/dynamic'
+import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { buildChartOption } from './stationGraphOptions'
 import type { GraphPreset } from './stationGraphPresets'
@@ -54,25 +56,43 @@ function WindowPicker({ active, onChange }: { active: string; onChange: (key: st
   )
 }
 
-// Fetches graph-data for one preset; re-fetches on window change, aborts stale requests.
+// Fetches graph-data for one preset; re-fetches on window change, aborts stale
+// requests. `loading` stays true through refetches so the UI can signal them.
 function useGraphData(preset: GraphPreset, stids: string[], windowKey: string) {
   const [data, setData] = useState<GraphData | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const { from, to } = windowRange(windowKey)
     const controller = new AbortController()
     setError(null)
+    setLoading(true)
     fetch(graphDataUrl(stids, preset.variables, from, to), { signal: controller.signal })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
       .then(setData)
       .catch((err: unknown) => {
         if (!controller.signal.aborted) setError(err instanceof Error ? err.message : 'failed')
       })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
     return () => controller.abort()
   }, [preset, stids, windowKey])
 
-  return { data, error }
+  return { data, error, loading }
+}
+
+// Dims the current chart and overlays a spinner while a refetch is in flight.
+function ChartFrame({ loading, children }: { loading: boolean; children: ReactNode }) {
+  return (
+    <div className="relative" aria-busy={loading}>
+      <div className={cn('transition-opacity', loading && 'opacity-40')}>{children}</div>
+      {loading && (
+        <Loader2 className="absolute inset-0 m-auto h-6 w-6 animate-spin text-muted-foreground" />
+      )}
+    </div>
+  )
 }
 
 // Error / empty-window notice text, or null when the chart should render.
@@ -91,7 +111,7 @@ function PresetChart({
   stids: string[]
   windowKey: string
 }) {
-  const { data, error } = useGraphData(preset, stids, windowKey)
+  const { data, error, loading } = useGraphData(preset, stids, windowKey)
   const option = useMemo(
     () => (data ? buildChartOption(data, preset.title) : null),
     [data, preset.title],
@@ -100,7 +120,11 @@ function PresetChart({
   const notice = chartNotice(preset.title, error, data)
   if (notice) return <p className="text-sm text-muted-foreground">{notice}</p>
   if (!option) return <div className="h-80 animate-pulse rounded-md bg-muted" />
-  return <EChart option={option} group="station-graphs" />
+  return (
+    <ChartFrame loading={loading}>
+      <EChart option={option} group="station-graphs" />
+    </ChartFrame>
+  )
 }
 
 // The station page's Graphs tab: fixed preset charts for this station group,

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -95,11 +95,22 @@ function ChartFrame({ loading, children }: { loading: boolean; children: ReactNo
   )
 }
 
-// Error / empty-window notice text, or null when the chart should render.
-function chartNotice(title: string, error: string | null, data: GraphData | null): string | null {
-  if (error) return `Couldn't load ${title}: ${error}`
-  if (data && data.series.length === 0) return `${title}: no data in this window.`
-  return null
+// Everything a chart renders before it's ready: error notice, hidden (absent
+// sensor — most stations report a subset of the preset list), or skeleton.
+const isEmpty = (data: GraphData | null) => data !== null && data.series.length === 0
+
+function preChartState(
+  title: string,
+  error: string | null,
+  data: GraphData | null,
+  option: object | null,
+): ReactNode | 'ready' {
+  if (error) {
+    return <p className="text-sm text-muted-foreground">{`Couldn't load ${title}: ${error}`}</p>
+  }
+  if (isEmpty(data)) return null
+  if (!option) return <div className="h-80 animate-pulse rounded-md bg-muted" />
+  return 'ready'
 }
 
 function PresetChart({
@@ -112,14 +123,11 @@ function PresetChart({
   windowKey: string
 }) {
   const { data, error, loading } = useGraphData(preset, stids, windowKey)
-  const option = useMemo(
-    () => (data ? buildChartOption(data, preset.title) : null),
-    [data, preset.title],
-  )
+  const option = useMemo(() => (data ? buildChartOption(data, preset) : null), [data, preset])
 
-  const notice = chartNotice(preset.title, error, data)
-  if (notice) return <p className="text-sm text-muted-foreground">{notice}</p>
-  if (!option) return <div className="h-80 animate-pulse rounded-md bg-muted" />
+  const state = preChartState(preset.title, error, data, option)
+  if (state !== 'ready') return state
+  if (!option) return null // unreachable: preChartState returns the skeleton
   return (
     <ChartFrame loading={loading}>
       <EChart option={option} group="station-graphs" />

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import type { GraphData } from '@/services/snowobs/graph'
+import { cn } from '@/utilities/ui'
+import dynamic from 'next/dynamic'
+import { useEffect, useMemo, useState } from 'react'
+import { buildChartOption } from './stationGraphOptions'
+import type { GraphPreset } from './stationGraphPresets'
+import { GRAPH_WINDOWS, seasonHours } from './stationGraphPresets'
+
+// ECharts only loads when the Graphs tab actually renders.
+const EChart = dynamic(() => import('./EChart').then((m) => m.EChart), {
+  ssr: false,
+  loading: () => <div className="h-80 animate-pulse rounded-md bg-muted" />,
+})
+
+function windowRange(key: string): { from: Date; to: Date } {
+  const to = new Date()
+  const window = GRAPH_WINDOWS.find((w) => w.key === key) ?? GRAPH_WINDOWS[1]
+  const hours = window.key === 'season' ? seasonHours(to) : window.hours
+  return { from: new Date(to.getTime() - hours * 60 * 60 * 1000), to }
+}
+
+function graphDataUrl(stids: string[], variables: string[], from: Date, to: Date): string {
+  const params = new URLSearchParams({
+    stids: stids.join(','),
+    vars: variables.join(','),
+    from: from.toISOString(),
+    to: to.toISOString(),
+  })
+  return `/weather/graph-data?${params.toString()}`
+}
+
+function WindowPicker({ active, onChange }: { active: string; onChange: (key: string) => void }) {
+  return (
+    <div className="flex gap-1">
+      {GRAPH_WINDOWS.map((w) => (
+        <button
+          key={w.key}
+          type="button"
+          onClick={() => onChange(w.key)}
+          aria-pressed={w.key === active}
+          className={cn(
+            'rounded-md px-3 py-1.5 text-sm',
+            w.key === active
+              ? 'bg-primary text-primary-foreground'
+              : 'bg-muted text-muted-foreground hover:text-foreground',
+          )}
+        >
+          {w.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// Fetches graph-data for one preset; re-fetches on window change, aborts stale requests.
+function useGraphData(preset: GraphPreset, stids: string[], windowKey: string) {
+  const [data, setData] = useState<GraphData | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const { from, to } = windowRange(windowKey)
+    const controller = new AbortController()
+    setError(null)
+    fetch(graphDataUrl(stids, preset.variables, from, to), { signal: controller.signal })
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then(setData)
+      .catch((err: unknown) => {
+        if (!controller.signal.aborted) setError(err instanceof Error ? err.message : 'failed')
+      })
+    return () => controller.abort()
+  }, [preset, stids, windowKey])
+
+  return { data, error }
+}
+
+// Error / empty-window notice text, or null when the chart should render.
+function chartNotice(title: string, error: string | null, data: GraphData | null): string | null {
+  if (error) return `Couldn't load ${title}: ${error}`
+  if (data && data.series.length === 0) return `${title}: no data in this window.`
+  return null
+}
+
+function PresetChart({
+  preset,
+  stids,
+  windowKey,
+}: {
+  preset: GraphPreset
+  stids: string[]
+  windowKey: string
+}) {
+  const { data, error } = useGraphData(preset, stids, windowKey)
+  const option = useMemo(
+    () => (data ? buildChartOption(data, preset.title) : null),
+    [data, preset.title],
+  )
+
+  const notice = chartNotice(preset.title, error, data)
+  if (notice) return <p className="text-sm text-muted-foreground">{notice}</p>
+  if (!option) return <div className="h-80 animate-pulse rounded-md bg-muted" />
+  return <EChart option={option} />
+}
+
+// The station page's Graphs tab: fixed preset charts for this station group,
+// with a shared time-window picker. The v2 self-serve builder renders the same
+// charts from a user-built config instead of presets.
+export function StationGraphs({ stids, presets }: { stids: string[]; presets: GraphPreset[] }) {
+  const [windowKey, setWindowKey] = useState('7d')
+
+  if (presets.length === 0) {
+    return <p className="text-muted-foreground">This station has no graphable sensors.</p>
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <WindowPicker active={windowKey} onChange={setWindowKey} />
+      {presets.map((preset) => (
+        <PresetChart key={preset.key} preset={preset} stids={stids} windowKey={windowKey} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -100,7 +100,7 @@ function PresetChart({
   const notice = chartNotice(preset.title, error, data)
   if (notice) return <p className="text-sm text-muted-foreground">{notice}</p>
   if (!option) return <div className="h-80 animate-pulse rounded-md bg-muted" />
-  return <EChart option={option} />
+  return <EChart option={option} group="station-graphs" />
 }
 
 // The station page's Graphs tab: fixed preset charts for this station group,

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -3,7 +3,7 @@
 import { NWAC_STATION_REGIONS, NWAC_WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
 import type { GraphData } from '@/services/snowobs/graph'
 import { cn } from '@/utilities/ui'
-import { Loader2 } from 'lucide-react'
+import { Loader2, X } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
@@ -114,43 +114,81 @@ function preChartState(
   return 'ready'
 }
 
-// Overlays another station's series on every chart. Region-grouped like the
-// StationPicker; the page's own station is excluded.
+// Keeps every chart legible and total stids within the graph-data route's cap.
+const MAX_COMPARE_STATIONS = 3
+
+// Overlays other stations' series on every chart: an add-select plus removable
+// chips. Region-grouped like the StationPicker; the page's own station and
+// already-selected stations are excluded.
 function CompareStationPicker({
   currentSlug,
-  compareSlug,
-  onChange,
+  compareSlugs,
+  onAdd,
+  onRemove,
 }: {
   currentSlug: string
-  compareSlug: string
-  onChange: (slug: string) => void
+  compareSlugs: string[]
+  onAdd: (slug: string) => void
+  onRemove: (slug: string) => void
 }) {
+  const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
+  const selected = compareSlugs.flatMap((slug) => {
+    const group = NWAC_WEATHER_STATION_GROUPS.find((g) => g.slug === slug)
+    return group ? [group] : []
+  })
+
   return (
-    <label className="inline-flex items-center gap-2 text-sm">
-      <span className="text-muted-foreground">Compare with</span>
-      <select
-        value={compareSlug}
-        onChange={(event) => onChange(event.target.value)}
-        className="rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
-      >
-        <option value="">None</option>
-        {NWAC_STATION_REGIONS.map((region) => {
-          const groups = NWAC_WEATHER_STATION_GROUPS.filter(
-            (group) => group.region === region && group.slug !== currentSlug,
-          )
-          if (groups.length === 0) return null
-          return (
-            <optgroup key={region} label={region}>
-              {groups.map((group) => (
-                <option key={group.slug} value={group.slug}>
-                  {group.displayName}
-                </option>
-              ))}
-            </optgroup>
-          )
-        })}
-      </select>
-    </label>
+    <div className="flex flex-wrap items-center gap-2">
+      {selected.map((group) => (
+        <span
+          key={group.slug}
+          className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm"
+        >
+          {group.displayName}
+          <button
+            type="button"
+            aria-label={`Remove ${group.displayName}`}
+            onClick={() => onRemove(group.slug)}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </span>
+      ))}
+      <label className="inline-flex items-center gap-2 text-sm">
+        <span className="text-muted-foreground">Compare with</span>
+        <select
+          value=""
+          disabled={atCap}
+          onChange={(event) => {
+            if (event.target.value) onAdd(event.target.value)
+          }}
+          className="rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+        >
+          <option value="">
+            {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
+          </option>
+          {NWAC_STATION_REGIONS.map((region) => {
+            const groups = NWAC_WEATHER_STATION_GROUPS.filter(
+              (group) =>
+                group.region === region &&
+                group.slug !== currentSlug &&
+                !compareSlugs.includes(group.slug),
+            )
+            if (groups.length === 0) return null
+            return (
+              <optgroup key={region} label={region}>
+                {groups.map((group) => (
+                  <option key={group.slug} value={group.slug}>
+                    {group.displayName}
+                  </option>
+                ))}
+              </optgroup>
+            )
+          })}
+        </select>
+      </label>
+    </div>
   )
 }
 
@@ -182,7 +220,7 @@ function PresetChart({
 }
 
 // The station page's Graphs tab: fixed preset charts for this station group,
-// with a shared time-window picker and an optional comparison station whose
+// with a shared time-window picker and optional comparison stations whose
 // series overlay every chart as dashed lines. The v2 self-serve builder renders
 // the same charts from a user-built config instead of presets.
 export function StationGraphs({
@@ -195,14 +233,19 @@ export function StationGraphs({
   currentSlug: string
 }) {
   const [windowKey, setWindowKey] = useState('7d')
-  const [compareSlug, setCompareSlug] = useState('')
+  const [compareSlugs, setCompareSlugs] = useState<string[]>([])
 
-  // The comparison group's stids, minus any the page's own group already plots.
+  // Base stids plus each comparison group's, deduped in selection order.
   const allStids = useMemo(() => {
-    const compareGroup = NWAC_WEATHER_STATION_GROUPS.find((g) => g.slug === compareSlug)
-    if (!compareGroup) return stids
-    return [...stids, ...compareGroup.stids.filter((stid) => !stids.includes(stid))]
-  }, [stids, compareSlug])
+    const combined = [...stids]
+    for (const slug of compareSlugs) {
+      const group = NWAC_WEATHER_STATION_GROUPS.find((g) => g.slug === slug)
+      for (const stid of group?.stids ?? []) {
+        if (!combined.includes(stid)) combined.push(stid)
+      }
+    }
+    return combined
+  }, [stids, compareSlugs])
 
   if (presets.length === 0) {
     return <p className="text-muted-foreground">This station has no graphable sensors.</p>
@@ -214,8 +257,9 @@ export function StationGraphs({
         <WindowPicker active={windowKey} onChange={setWindowKey} />
         <CompareStationPicker
           currentSlug={currentSlug}
-          compareSlug={compareSlug}
-          onChange={setCompareSlug}
+          compareSlugs={compareSlugs}
+          onAdd={(slug) => setCompareSlugs((prev) => [...prev, slug])}
+          onRemove={(slug) => setCompareSlugs((prev) => prev.filter((s) => s !== slug))}
         />
       </div>
       {presets.map((preset) => (

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -1,15 +1,17 @@
 'use client'
 
-import { NWAC_STATION_REGIONS, NWAC_WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
+import { NWAC_WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
 import type { GraphData } from '@/services/snowobs/graph'
 import { cn } from '@/utilities/ui'
-import { Loader2, X } from 'lucide-react'
+import { ChevronDown, ChevronUp, Eye, EyeOff, Loader2, X } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { buildChartOption } from './stationGraphOptions'
 import type { GraphPreset } from './stationGraphPresets'
 import { GRAPH_WINDOWS, seasonHours } from './stationGraphPresets'
+import { StationOptGroups } from './StationPicker'
+import { useChartArrangement } from './useChartArrangement'
 
 // ECharts only loads when the Graphs tab actually renders.
 const EChart = dynamic(() => import('./EChart').then((m) => m.EChart), {
@@ -117,78 +119,138 @@ function preChartState(
 // Keeps every chart legible and total stids within the graph-data route's cap.
 const MAX_COMPARE_STATIONS = 3
 
-// Overlays other stations' series on every chart: an add-select plus removable
-// chips. Region-grouped like the StationPicker; the page's own station and
-// already-selected stations are excluded.
+// Adds another station to overlay on every chart. Region-grouped like the
+// StationPicker; the page's own station and already-selected stations are
+// excluded.
 function CompareStationPicker({
   currentSlug,
   compareSlugs,
   onAdd,
-  onRemove,
 }: {
   currentSlug: string
   compareSlugs: string[]
   onAdd: (slug: string) => void
-  onRemove: (slug: string) => void
 }) {
   const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
+  return (
+    <label className="inline-flex items-center gap-2 text-sm">
+      <span className="text-muted-foreground">Compare with</span>
+      <select
+        value=""
+        disabled={atCap}
+        onChange={(event) => {
+          if (event.target.value) onAdd(event.target.value)
+        }}
+        className="rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+      >
+        <option value="">
+          {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
+        </option>
+        <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
+      </select>
+    </label>
+  )
+}
+
+// The selected comparison stations as removable chips.
+function CompareChips({
+  compareSlugs,
+  onRemove,
+}: {
+  compareSlugs: string[]
+  onRemove: (slug: string) => void
+}) {
   const selected = compareSlugs.flatMap((slug) => {
     const group = NWAC_WEATHER_STATION_GROUPS.find((g) => g.slug === slug)
     return group ? [group] : []
   })
 
+  return selected.map((group) => (
+    <span
+      key={group.slug}
+      className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm"
+    >
+      {group.displayName}
+      <button
+        type="button"
+        aria-label={`Remove ${group.displayName}`}
+        onClick={() => onRemove(group.slug)}
+        className="text-muted-foreground hover:text-foreground"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </span>
+  ))
+}
+
+// Move/hide controls for one rendered chart, top-right above the canvas.
+function ChartControls({
+  title,
+  canUp,
+  canDown,
+  onMove,
+  onHide,
+}: {
+  title: string
+  canUp: boolean
+  canDown: boolean
+  onMove: (direction: -1 | 1) => void
+  onHide: () => void
+}) {
+  const buttonClass =
+    'rounded-md p-1 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:hover:text-muted-foreground'
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      {selected.map((group) => (
-        <span
-          key={group.slug}
-          className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm"
-        >
-          {group.displayName}
-          <button
-            type="button"
-            aria-label={`Remove ${group.displayName}`}
-            onClick={() => onRemove(group.slug)}
-            className="text-muted-foreground hover:text-foreground"
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        </span>
-      ))}
-      <label className="inline-flex items-center gap-2 text-sm">
-        <span className="text-muted-foreground">Compare with</span>
-        <select
-          value=""
-          disabled={atCap}
-          onChange={(event) => {
-            if (event.target.value) onAdd(event.target.value)
-          }}
-          className="rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
-        >
-          <option value="">
-            {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
-          </option>
-          {NWAC_STATION_REGIONS.map((region) => {
-            const groups = NWAC_WEATHER_STATION_GROUPS.filter(
-              (group) =>
-                group.region === region &&
-                group.slug !== currentSlug &&
-                !compareSlugs.includes(group.slug),
-            )
-            if (groups.length === 0) return null
-            return (
-              <optgroup key={region} label={region}>
-                {groups.map((group) => (
-                  <option key={group.slug} value={group.slug}>
-                    {group.displayName}
-                  </option>
-                ))}
-              </optgroup>
-            )
-          })}
-        </select>
-      </label>
+    <div className="flex justify-end gap-1">
+      <button
+        type="button"
+        aria-label={`Move ${title} up`}
+        disabled={!canUp}
+        onClick={() => onMove(-1)}
+        className={buttonClass}
+      >
+        <ChevronUp className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        aria-label={`Move ${title} down`}
+        disabled={!canDown}
+        onClick={() => onMove(1)}
+        className={buttonClass}
+      >
+        <ChevronDown className="h-4 w-4" />
+      </button>
+      <button type="button" aria-label={`Hide ${title}`} onClick={onHide} className={buttonClass}>
+        <EyeOff className="h-4 w-4" />
+      </button>
     </div>
+  )
+}
+
+// Hidden charts as chips that restore on click.
+function HiddenChartChips({
+  presets,
+  onShow,
+}: {
+  presets: GraphPreset[]
+  onShow: (key: string) => void
+}) {
+  if (presets.length === 0) return null
+  return (
+    <>
+      <span className="text-sm text-muted-foreground">Hidden:</span>
+      {presets.map((preset) => (
+        <button
+          key={preset.key}
+          type="button"
+          aria-label={`Show ${preset.title}`}
+          onClick={() => onShow(preset.key)}
+          className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <Eye className="h-3.5 w-3.5" />
+          {preset.title}
+        </button>
+      ))}
+    </>
   )
 }
 
@@ -197,11 +259,15 @@ function PresetChart({
   stids,
   primaryStids,
   windowKey,
+  controls,
+  onEmptyChange,
 }: {
   preset: GraphPreset
   stids: string[]
   primaryStids: string[]
   windowKey: string
+  controls: ReactNode
+  onEmptyChange: (key: string, empty: boolean) => void
 }) {
   const { data, error, loading } = useGraphData(preset, stids, windowKey)
   const option = useMemo(
@@ -209,13 +275,65 @@ function PresetChart({
     [data, preset, primaryStids],
   )
 
+  // Report no-data charts so move up/down skips over them.
+  useEffect(() => {
+    onEmptyChange(preset.key, isEmpty(data))
+    return () => onEmptyChange(preset.key, false)
+  }, [data, preset.key, onEmptyChange])
+
   const state = preChartState(preset.title, error, data, option)
   if (state !== 'ready') return state
   if (!option) return null // unreachable: preChartState returns the skeleton
   return (
-    <ChartFrame loading={loading}>
-      <EChart option={option} group="station-graphs" />
-    </ChartFrame>
+    // Controls overlay the canvas's top-right, level with the ECharts title.
+    <div className="relative">
+      <div className="absolute right-0 top-0 z-10">{controls}</div>
+      <ChartFrame loading={loading}>
+        <EChart option={option} group="station-graphs" />
+      </ChartFrame>
+    </div>
+  )
+}
+
+// Window picker, compare-station picker, and the chip row (comparison stations
+// + hidden charts) above the charts.
+function GraphsToolbar({
+  windowKey,
+  onWindowChange,
+  currentSlug,
+  compareSlugs,
+  onCompareChange,
+  hiddenPresets,
+  onShowChart,
+}: {
+  windowKey: string
+  onWindowChange: (key: string) => void
+  currentSlug: string
+  compareSlugs: string[]
+  onCompareChange: (slugs: string[]) => void
+  hiddenPresets: GraphPreset[]
+  onShowChart: (key: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <WindowPicker active={windowKey} onChange={onWindowChange} />
+        <CompareStationPicker
+          currentSlug={currentSlug}
+          compareSlugs={compareSlugs}
+          onAdd={(slug) => onCompareChange([...compareSlugs, slug])}
+        />
+      </div>
+      {(compareSlugs.length > 0 || hiddenPresets.length > 0) && (
+        <div className="flex flex-wrap items-center gap-2">
+          <CompareChips
+            compareSlugs={compareSlugs}
+            onRemove={(slug) => onCompareChange(compareSlugs.filter((s) => s !== slug))}
+          />
+          <HiddenChartChips presets={hiddenPresets} onShow={onShowChart} />
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -234,6 +352,7 @@ export function StationGraphs({
 }) {
   const [windowKey, setWindowKey] = useState('7d')
   const [compareSlugs, setCompareSlugs] = useState<string[]>([])
+  const arrangement = useChartArrangement(presets)
 
   // Base stids plus each comparison group's, deduped in selection order.
   const allStids = useMemo(() => {
@@ -253,22 +372,32 @@ export function StationGraphs({
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <WindowPicker active={windowKey} onChange={setWindowKey} />
-        <CompareStationPicker
-          currentSlug={currentSlug}
-          compareSlugs={compareSlugs}
-          onAdd={(slug) => setCompareSlugs((prev) => [...prev, slug])}
-          onRemove={(slug) => setCompareSlugs((prev) => prev.filter((s) => s !== slug))}
-        />
-      </div>
-      {presets.map((preset) => (
+      <GraphsToolbar
+        windowKey={windowKey}
+        onWindowChange={setWindowKey}
+        currentSlug={currentSlug}
+        compareSlugs={compareSlugs}
+        onCompareChange={setCompareSlugs}
+        hiddenPresets={arrangement.hiddenPresets}
+        onShowChart={arrangement.showChart}
+      />
+      {arrangement.visiblePresets.map((preset) => (
         <PresetChart
           key={preset.key}
           preset={preset}
           stids={allStids}
           primaryStids={stids}
           windowKey={windowKey}
+          onEmptyChange={arrangement.onEmptyChange}
+          controls={
+            <ChartControls
+              title={preset.title}
+              canUp={arrangement.canMove(preset.key, -1)}
+              canDown={arrangement.canMove(preset.key, 1)}
+              onMove={(direction) => arrangement.moveChart(preset.key, direction)}
+              onHide={() => arrangement.hideChart(preset.key)}
+            />
+          }
         />
       ))}
     </div>

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -4,7 +4,7 @@ import { getStationGroup, MAX_COMPARE_STATIONS } from '@/constants/weatherStatio
 import type { GraphData } from '@/services/snowobs/graph'
 import { cn } from '@/utilities/ui'
 import { subHours } from 'date-fns'
-import { ChevronDown, ChevronUp, Eye, EyeOff, Loader2, X } from 'lucide-react'
+import { ArrowDown, ArrowUp, Eye, EyeOff, Loader2, X } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
@@ -198,7 +198,7 @@ function ChartControls({
         onClick={() => onMove(-1)}
         className={buttonClass}
       >
-        <ChevronUp className="h-4 w-4" />
+        <ArrowUp className="h-4 w-4" />
       </button>
       <button
         type="button"
@@ -207,7 +207,7 @@ function ChartControls({
         onClick={() => onMove(1)}
         className={buttonClass}
       >
-        <ChevronDown className="h-4 w-4" />
+        <ArrowDown className="h-4 w-4" />
       </button>
       <button type="button" aria-label={`Hide ${title}`} onClick={onHide} className={buttonClass}>
         <EyeOff className="h-4 w-4" />

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { NWAC_STATION_REGIONS, NWAC_WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
 import type { GraphData } from '@/services/snowobs/graph'
 import { cn } from '@/utilities/ui'
 import { Loader2 } from 'lucide-react'
@@ -113,17 +114,62 @@ function preChartState(
   return 'ready'
 }
 
+// Overlays another station's series on every chart. Region-grouped like the
+// StationPicker; the page's own station is excluded.
+function CompareStationPicker({
+  currentSlug,
+  compareSlug,
+  onChange,
+}: {
+  currentSlug: string
+  compareSlug: string
+  onChange: (slug: string) => void
+}) {
+  return (
+    <label className="inline-flex items-center gap-2 text-sm">
+      <span className="text-muted-foreground">Compare with</span>
+      <select
+        value={compareSlug}
+        onChange={(event) => onChange(event.target.value)}
+        className="rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
+      >
+        <option value="">None</option>
+        {NWAC_STATION_REGIONS.map((region) => {
+          const groups = NWAC_WEATHER_STATION_GROUPS.filter(
+            (group) => group.region === region && group.slug !== currentSlug,
+          )
+          if (groups.length === 0) return null
+          return (
+            <optgroup key={region} label={region}>
+              {groups.map((group) => (
+                <option key={group.slug} value={group.slug}>
+                  {group.displayName}
+                </option>
+              ))}
+            </optgroup>
+          )
+        })}
+      </select>
+    </label>
+  )
+}
+
 function PresetChart({
   preset,
   stids,
+  primaryStids,
   windowKey,
 }: {
   preset: GraphPreset
   stids: string[]
+  primaryStids: string[]
   windowKey: string
 }) {
   const { data, error, loading } = useGraphData(preset, stids, windowKey)
-  const option = useMemo(() => (data ? buildChartOption(data, preset) : null), [data, preset])
+  const option = useMemo(
+    () => (data ? buildChartOption(data, preset, primaryStids) : null),
+    [data, preset, primaryStids],
+  )
 
   const state = preChartState(preset.title, error, data, option)
   if (state !== 'ready') return state
@@ -136,10 +182,27 @@ function PresetChart({
 }
 
 // The station page's Graphs tab: fixed preset charts for this station group,
-// with a shared time-window picker. The v2 self-serve builder renders the same
-// charts from a user-built config instead of presets.
-export function StationGraphs({ stids, presets }: { stids: string[]; presets: GraphPreset[] }) {
+// with a shared time-window picker and an optional comparison station whose
+// series overlay every chart as dashed lines. The v2 self-serve builder renders
+// the same charts from a user-built config instead of presets.
+export function StationGraphs({
+  stids,
+  presets,
+  currentSlug,
+}: {
+  stids: string[]
+  presets: GraphPreset[]
+  currentSlug: string
+}) {
   const [windowKey, setWindowKey] = useState('7d')
+  const [compareSlug, setCompareSlug] = useState('')
+
+  // The comparison group's stids, minus any the page's own group already plots.
+  const allStids = useMemo(() => {
+    const compareGroup = NWAC_WEATHER_STATION_GROUPS.find((g) => g.slug === compareSlug)
+    if (!compareGroup) return stids
+    return [...stids, ...compareGroup.stids.filter((stid) => !stids.includes(stid))]
+  }, [stids, compareSlug])
 
   if (presets.length === 0) {
     return <p className="text-muted-foreground">This station has no graphable sensors.</p>
@@ -147,9 +210,22 @@ export function StationGraphs({ stids, presets }: { stids: string[]; presets: Gr
 
   return (
     <div className="flex flex-col gap-6">
-      <WindowPicker active={windowKey} onChange={setWindowKey} />
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <WindowPicker active={windowKey} onChange={setWindowKey} />
+        <CompareStationPicker
+          currentSlug={currentSlug}
+          compareSlug={compareSlug}
+          onChange={setCompareSlug}
+        />
+      </div>
       {presets.map((preset) => (
-        <PresetChart key={preset.key} preset={preset} stids={stids} windowKey={windowKey} />
+        <PresetChart
+          key={preset.key}
+          preset={preset}
+          stids={allStids}
+          primaryStids={stids}
+          windowKey={windowKey}
+        />
       ))}
     </div>
   )

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -135,7 +135,7 @@ function CompareStationPicker({
       className={cn(stationSelectClass, 'px-3 py-1.5 disabled:opacity-50')}
     >
       <option value="">
-        {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Compare with a station…'}
+        {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
       </option>
       <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
     </select>

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -3,6 +3,7 @@
 import { NWAC_WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
 import type { GraphData } from '@/services/snowobs/graph'
 import { cn } from '@/utilities/ui'
+import { subHours } from 'date-fns'
 import { ChevronDown, ChevronUp, Eye, EyeOff, Loader2, X } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
@@ -23,7 +24,7 @@ function windowRange(key: string): { from: Date; to: Date } {
   const to = new Date()
   const window = GRAPH_WINDOWS.find((w) => w.key === key) ?? GRAPH_WINDOWS[1]
   const hours = window.key === 'season' ? seasonHours(to) : window.hours
-  return { from: new Date(to.getTime() - hours * 60 * 60 * 1000), to }
+  return { from: subHours(to, hours), to }
 }
 
 function graphDataUrl(stids: string[], variables: string[], from: Date, to: Date): string {

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -125,22 +125,20 @@ function CompareStationPicker({
 }) {
   const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
   return (
-    <label className="inline-flex items-center gap-2 text-sm">
-      <span className="text-muted-foreground">Compare with</span>
-      <select
-        value=""
-        disabled={atCap}
-        onChange={(event) => {
-          if (event.target.value) onAdd(event.target.value)
-        }}
-        className={cn(stationSelectClass, 'px-3 py-1.5 disabled:opacity-50')}
-      >
-        <option value="">
-          {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
-        </option>
-        <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
-      </select>
-    </label>
+    <select
+      value=""
+      disabled={atCap}
+      aria-label="Compare with"
+      onChange={(event) => {
+        if (event.target.value) onAdd(event.target.value)
+      }}
+      className={cn(stationSelectClass, 'px-3 py-1.5 disabled:opacity-50')}
+    >
+      <option value="">
+        {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Compare with a station…'}
+      </option>
+      <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
+    </select>
   )
 }
 

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -373,15 +373,13 @@ function GraphsToolbar({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <WindowPicker active={graphWindow} onChange={onWindowChange} />
-          <UnitToggle unit={unitSystem} onChange={onUnitChange} />
-        </div>
+        <WindowPicker active={graphWindow} onChange={onWindowChange} />
         <CompareStationPicker
           currentSlug={currentSlug}
           compareSlugs={compareSlugs}
           onAdd={(slug) => onCompareChange([...compareSlugs, slug])}
         />
+        <UnitToggle unit={unitSystem} onChange={onUnitChange} />
       </div>
       <GraphsChipRow
         compareSlugs={compareSlugs}

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -4,7 +4,7 @@ import { getStationGroup, MAX_COMPARE_STATIONS } from '@/constants/weatherStatio
 import type { GraphData } from '@/services/snowobs/graph'
 import { cn } from '@/utilities/ui'
 import { subHours } from 'date-fns'
-import { ArrowDown, ArrowUp, Eye, EyeOff, Loader2, X } from 'lucide-react'
+import { ArrowDown, ArrowUp, Eye, EyeOff, Loader2, Plus, X } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
@@ -125,22 +125,34 @@ function CompareStationPicker({
 }) {
   const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
   return (
-    // A native select styled as a button: the closed control reads as
-    // "+ Add a station", clicking it still opens the region-grouped menu.
-    <select
-      value=""
-      disabled={atCap}
-      aria-label="Compare with another station"
-      onChange={(event) => {
-        if (event.target.value) onAdd(event.target.value)
-      }}
-      className="cursor-pointer appearance-none rounded-md bg-muted px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-50"
-    >
-      <option value="">
-        {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : '+ Add a station'}
-      </option>
-      <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
-    </select>
+    // A button-looking span with an invisible native select stacked on top,
+    // so the control is content-width but clicking still opens the
+    // region-grouped menu.
+    <div className="group relative inline-flex">
+      <span
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors',
+          atCap
+            ? 'bg-muted text-muted-foreground opacity-50'
+            : 'bg-primary text-primary-foreground group-hover:bg-primary/90',
+        )}
+      >
+        {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station'}
+        {!atCap && <Plus className="h-4 w-4" />}
+      </span>
+      <select
+        value=""
+        disabled={atCap}
+        aria-label="Compare with another station"
+        onChange={(event) => {
+          if (event.target.value) onAdd(event.target.value)
+        }}
+        className="absolute inset-0 cursor-pointer opacity-0 disabled:cursor-default"
+      >
+        <option value="" />
+        <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
+      </select>
+    </div>
   )
 }
 

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -18,15 +18,13 @@ function ChartSkeleton() {
   return <div className="h-80 animate-pulse rounded-md bg-muted" />
 }
 
-// ECharts only loads when the Graphs tab actually renders.
 const EChart = dynamic(() => import('./EChart').then((m) => m.EChart), {
   ssr: false,
   loading: () => <ChartSkeleton />,
 })
 
-// "Now" is bucketed to the route's cache window so request URLs stay stable
-// across charts, remounts, and users — a fresh Date would make every URL
-// unique and defeat the route's CDN caching.
+// "Now" is bucketed so request URLs stay stable across charts and users —
+// a fresh Date per request would defeat the route's CDN caching.
 const CACHE_BUCKET_MS = 5 * 60 * 1000
 
 function windowRange(window: GraphWindow): { from: Date; to: Date } {
@@ -45,8 +43,7 @@ function graphDataUrl(stids: string[], variables: string[], from: Date, to: Date
 }
 
 // One fetch serves every chart: the union of all preset variables for all
-// selected stations. Re-fetches on window/station change, aborts stale
-// requests; `loading` stays true through refetches so the UI can signal them.
+// selected stations.
 function useGraphData(stids: string[], variables: string[], window: GraphWindow) {
   const [data, setData] = useState<GraphData | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -101,7 +98,6 @@ function WindowPicker({
   )
 }
 
-// Dims the charts and overlays a spinner while a refetch is in flight.
 function ChartFrame({ loading, children }: { loading: boolean; children: ReactNode }) {
   return (
     <div className="relative" aria-busy={loading}>
@@ -115,9 +111,6 @@ function ChartFrame({ loading, children }: { loading: boolean; children: ReactNo
 
 const chipClass = 'inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm'
 
-// Adds another station to overlay on every chart. Region-grouped like the
-// StationPicker; the page's own station and already-selected stations are
-// excluded.
 function CompareStationPicker({
   currentSlug,
   compareSlugs,
@@ -148,7 +141,6 @@ function CompareStationPicker({
   )
 }
 
-// The selected comparison stations as removable chips.
 function CompareChips({
   compareSlugs,
   onRemove,
@@ -173,7 +165,6 @@ function CompareChips({
   ))
 }
 
-// Move/hide controls for one rendered chart, top-right above the canvas.
 function ChartControls({
   title,
   canUp,
@@ -216,7 +207,6 @@ function ChartControls({
   )
 }
 
-// Hidden charts as chips that restore on click.
 function HiddenChartChips({
   presets,
   onShow,
@@ -264,7 +254,6 @@ function PresetChart({
     [presetData, preset, primaryStids],
   )
   return (
-    // Controls overlay the canvas's top-right, level with the ECharts title.
     <div className="relative">
       <div className="absolute right-0 top-0 z-10">{controls}</div>
       <EChart option={option} group="station-graphs" />
@@ -272,7 +261,6 @@ function PresetChart({
   )
 }
 
-// The chip row under the toolbar: comparison stations and hidden charts.
 function GraphsChipRow({
   compareSlugs,
   onCompareChange,
@@ -296,15 +284,12 @@ function GraphsChipRow({
   )
 }
 
-// Keys of presets none of the selected stations report (their charts hide).
 function emptyPresetKeys(data: GraphData | null, presets: GraphPreset[]): Set<string> {
   if (!data) return new Set()
   const reported = new Set(data.series.map((s) => s.variable))
   return new Set(presets.filter((p) => !p.variables.some((v) => reported.has(v))).map((p) => p.key))
 }
 
-// The fetch's charts area: error notice, loading skeletons, no-data notice, or
-// the arranged charts dimmed while a refetch is in flight.
 function GraphsCharts({
   presets,
   primaryStids,
@@ -354,9 +339,6 @@ function GraphsCharts({
   )
 }
 
-// The station page's Graphs tab: fixed preset charts for this station group,
-// with a shared time-window picker and optional comparison stations whose
-// series overlay every chart as dashed lines.
 export function StationGraphs({
   stids,
   presets,
@@ -369,7 +351,6 @@ export function StationGraphs({
   const [graphWindow, setGraphWindow] = useState(DEFAULT_GRAPH_WINDOW)
   const [compareSlugs, setCompareSlugs] = useState<string[]>([])
 
-  // Base stids plus each comparison group's, deduped in selection order.
   const allStids = useMemo(() => {
     const combined = [...stids]
     for (const slug of compareSlugs) {

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { NWAC_WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
+import { getStationGroup, MAX_COMPARE_STATIONS } from '@/constants/weatherStations'
 import type { GraphData } from '@/services/snowobs/graph'
 import { cn } from '@/utilities/ui'
 import { subHours } from 'date-fns'
@@ -9,22 +9,29 @@ import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { buildChartOption } from './stationGraphOptions'
-import type { GraphPreset } from './stationGraphPresets'
-import { GRAPH_WINDOWS, seasonHours } from './stationGraphPresets'
-import { StationOptGroups } from './StationPicker'
+import type { GraphPreset, GraphWindow } from './stationGraphPresets'
+import { DEFAULT_GRAPH_WINDOW, GRAPH_WINDOWS } from './stationGraphPresets'
+import { StationOptGroups, stationSelectClass } from './StationPicker'
 import { useChartArrangement } from './useChartArrangement'
+
+function ChartSkeleton() {
+  return <div className="h-80 animate-pulse rounded-md bg-muted" />
+}
 
 // ECharts only loads when the Graphs tab actually renders.
 const EChart = dynamic(() => import('./EChart').then((m) => m.EChart), {
   ssr: false,
-  loading: () => <div className="h-80 animate-pulse rounded-md bg-muted" />,
+  loading: () => <ChartSkeleton />,
 })
 
-function windowRange(key: string): { from: Date; to: Date } {
-  const to = new Date()
-  const window = GRAPH_WINDOWS.find((w) => w.key === key) ?? GRAPH_WINDOWS[1]
-  const hours = window.key === 'season' ? seasonHours(to) : window.hours
-  return { from: subHours(to, hours), to }
+// "Now" is bucketed to the route's cache window so request URLs stay stable
+// across charts, remounts, and users — a fresh Date would make every URL
+// unique and defeat the route's CDN caching.
+const CACHE_BUCKET_MS = 5 * 60 * 1000
+
+function windowRange(window: GraphWindow): { from: Date; to: Date } {
+  const to = new Date(Math.floor(Date.now() / CACHE_BUCKET_MS) * CACHE_BUCKET_MS)
+  return { from: subHours(to, window.hoursBack(to)), to }
 }
 
 function graphDataUrl(stids: string[], variables: string[], from: Date, to: Date): string {
@@ -37,18 +44,52 @@ function graphDataUrl(stids: string[], variables: string[], from: Date, to: Date
   return `/weather/graph-data?${params.toString()}`
 }
 
-function WindowPicker({ active, onChange }: { active: string; onChange: (key: string) => void }) {
+// One fetch serves every chart: the union of all preset variables for all
+// selected stations. Re-fetches on window/station change, aborts stale
+// requests; `loading` stays true through refetches so the UI can signal them.
+function useGraphData(stids: string[], variables: string[], window: GraphWindow) {
+  const [data, setData] = useState<GraphData | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const { from, to } = windowRange(window)
+    const controller = new AbortController()
+    setError(null)
+    setLoading(true)
+    fetch(graphDataUrl(stids, variables, from, to), { signal: controller.signal })
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then(setData)
+      .catch((err: unknown) => {
+        if (!controller.signal.aborted) setError(err instanceof Error ? err.message : 'failed')
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+    return () => controller.abort()
+  }, [stids, variables, window])
+
+  return { data, error, loading }
+}
+
+function WindowPicker({
+  active,
+  onChange,
+}: {
+  active: GraphWindow
+  onChange: (window: GraphWindow) => void
+}) {
   return (
     <div className="flex gap-1">
       {GRAPH_WINDOWS.map((w) => (
         <button
           key={w.key}
           type="button"
-          onClick={() => onChange(w.key)}
-          aria-pressed={w.key === active}
+          onClick={() => onChange(w)}
+          aria-pressed={w === active}
           className={cn(
             'rounded-md px-3 py-1.5 text-sm',
-            w.key === active
+            w === active
               ? 'bg-primary text-primary-foreground'
               : 'bg-muted text-muted-foreground hover:text-foreground',
           )}
@@ -60,34 +101,7 @@ function WindowPicker({ active, onChange }: { active: string; onChange: (key: st
   )
 }
 
-// Fetches graph-data for one preset; re-fetches on window change, aborts stale
-// requests. `loading` stays true through refetches so the UI can signal them.
-function useGraphData(preset: GraphPreset, stids: string[], windowKey: string) {
-  const [data, setData] = useState<GraphData | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    const { from, to } = windowRange(windowKey)
-    const controller = new AbortController()
-    setError(null)
-    setLoading(true)
-    fetch(graphDataUrl(stids, preset.variables, from, to), { signal: controller.signal })
-      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
-      .then(setData)
-      .catch((err: unknown) => {
-        if (!controller.signal.aborted) setError(err instanceof Error ? err.message : 'failed')
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false)
-      })
-    return () => controller.abort()
-  }, [preset, stids, windowKey])
-
-  return { data, error, loading }
-}
-
-// Dims the current chart and overlays a spinner while a refetch is in flight.
+// Dims the charts and overlays a spinner while a refetch is in flight.
 function ChartFrame({ loading, children }: { loading: boolean; children: ReactNode }) {
   return (
     <div className="relative" aria-busy={loading}>
@@ -99,26 +113,7 @@ function ChartFrame({ loading, children }: { loading: boolean; children: ReactNo
   )
 }
 
-// Everything a chart renders before it's ready: error notice, hidden (absent
-// sensor — most stations report a subset of the preset list), or skeleton.
-const isEmpty = (data: GraphData | null) => data !== null && data.series.length === 0
-
-function preChartState(
-  title: string,
-  error: string | null,
-  data: GraphData | null,
-  option: object | null,
-): ReactNode | 'ready' {
-  if (error) {
-    return <p className="text-sm text-muted-foreground">{`Couldn't load ${title}: ${error}`}</p>
-  }
-  if (isEmpty(data)) return null
-  if (!option) return <div className="h-80 animate-pulse rounded-md bg-muted" />
-  return 'ready'
-}
-
-// Keeps every chart legible and total stids within the graph-data route's cap.
-const MAX_COMPARE_STATIONS = 3
+const chipClass = 'inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm'
 
 // Adds another station to overlay on every chart. Region-grouped like the
 // StationPicker; the page's own station and already-selected stations are
@@ -142,7 +137,7 @@ function CompareStationPicker({
         onChange={(event) => {
           if (event.target.value) onAdd(event.target.value)
         }}
-        className="rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+        className={cn(stationSelectClass, 'px-3 py-1.5 disabled:opacity-50')}
       >
         <option value="">
           {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
@@ -161,16 +156,10 @@ function CompareChips({
   compareSlugs: string[]
   onRemove: (slug: string) => void
 }) {
-  const selected = compareSlugs.flatMap((slug) => {
-    const group = NWAC_WEATHER_STATION_GROUPS.find((g) => g.slug === slug)
-    return group ? [group] : []
-  })
+  const selected = compareSlugs.flatMap((slug) => getStationGroup(slug) ?? [])
 
   return selected.map((group) => (
-    <span
-      key={group.slug}
-      className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm"
-    >
+    <span key={group.slug} className={chipClass}>
       {group.displayName}
       <button
         type="button"
@@ -245,7 +234,7 @@ function HiddenChartChips({
           type="button"
           aria-label={`Show ${preset.title}`}
           onClick={() => onShow(preset.key)}
-          className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm text-muted-foreground hover:text-foreground"
+          className={cn(chipClass, 'text-muted-foreground hover:text-foreground')}
         >
           <Eye className="h-3.5 w-3.5" />
           {preset.title}
@@ -257,91 +246,117 @@ function HiddenChartChips({
 
 function PresetChart({
   preset,
-  stids,
+  data,
   primaryStids,
-  windowKey,
   controls,
-  onEmptyChange,
 }: {
   preset: GraphPreset
-  stids: string[]
+  data: GraphData
   primaryStids: string[]
-  windowKey: string
   controls: ReactNode
-  onEmptyChange: (key: string, empty: boolean) => void
 }) {
-  const { data, error, loading } = useGraphData(preset, stids, windowKey)
-  const option = useMemo(
-    () => (data ? buildChartOption(data, preset, primaryStids) : null),
-    [data, preset, primaryStids],
+  const presetData = useMemo(
+    () => ({ ...data, series: data.series.filter((s) => preset.variables.includes(s.variable)) }),
+    [data, preset],
   )
-
-  // Report no-data charts so move up/down skips over them.
-  useEffect(() => {
-    onEmptyChange(preset.key, isEmpty(data))
-    return () => onEmptyChange(preset.key, false)
-  }, [data, preset.key, onEmptyChange])
-
-  const state = preChartState(preset.title, error, data, option)
-  if (state !== 'ready') return state
-  if (!option) return null // unreachable: preChartState returns the skeleton
+  const option = useMemo(
+    () => buildChartOption(presetData, preset, primaryStids),
+    [presetData, preset, primaryStids],
+  )
   return (
     // Controls overlay the canvas's top-right, level with the ECharts title.
     <div className="relative">
       <div className="absolute right-0 top-0 z-10">{controls}</div>
-      <ChartFrame loading={loading}>
-        <EChart option={option} group="station-graphs" />
-      </ChartFrame>
+      <EChart option={option} group="station-graphs" />
     </div>
   )
 }
 
-// Window picker, compare-station picker, and the chip row (comparison stations
-// + hidden charts) above the charts.
-function GraphsToolbar({
-  windowKey,
-  onWindowChange,
-  currentSlug,
+// The chip row under the toolbar: comparison stations and hidden charts.
+function GraphsChipRow({
   compareSlugs,
   onCompareChange,
   hiddenPresets,
-  onShowChart,
+  onShow,
 }: {
-  windowKey: string
-  onWindowChange: (key: string) => void
-  currentSlug: string
   compareSlugs: string[]
   onCompareChange: (slugs: string[]) => void
   hiddenPresets: GraphPreset[]
-  onShowChart: (key: string) => void
+  onShow: (key: string) => void
 }) {
+  if (compareSlugs.length === 0 && hiddenPresets.length === 0) return null
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <WindowPicker active={windowKey} onChange={onWindowChange} />
-        <CompareStationPicker
-          currentSlug={currentSlug}
-          compareSlugs={compareSlugs}
-          onAdd={(slug) => onCompareChange([...compareSlugs, slug])}
-        />
-      </div>
-      {(compareSlugs.length > 0 || hiddenPresets.length > 0) && (
-        <div className="flex flex-wrap items-center gap-2">
-          <CompareChips
-            compareSlugs={compareSlugs}
-            onRemove={(slug) => onCompareChange(compareSlugs.filter((s) => s !== slug))}
-          />
-          <HiddenChartChips presets={hiddenPresets} onShow={onShowChart} />
-        </div>
-      )}
+    <div className="flex flex-wrap items-center gap-2">
+      <CompareChips
+        compareSlugs={compareSlugs}
+        onRemove={(slug) => onCompareChange(compareSlugs.filter((s) => s !== slug))}
+      />
+      <HiddenChartChips presets={hiddenPresets} onShow={onShow} />
     </div>
+  )
+}
+
+// Keys of presets none of the selected stations report (their charts hide).
+function emptyPresetKeys(data: GraphData | null, presets: GraphPreset[]): Set<string> {
+  if (!data) return new Set()
+  const reported = new Set(data.series.map((s) => s.variable))
+  return new Set(presets.filter((p) => !p.variables.some((v) => reported.has(v))).map((p) => p.key))
+}
+
+// The fetch's charts area: error notice, loading skeletons, no-data notice, or
+// the arranged charts dimmed while a refetch is in flight.
+function GraphsCharts({
+  presets,
+  primaryStids,
+  arrangement,
+  data,
+  error,
+  loading,
+}: {
+  presets: GraphPreset[]
+  primaryStids: string[]
+  arrangement: ReturnType<typeof useChartArrangement>
+  data: GraphData | null
+  error: string | null
+  loading: boolean
+}) {
+  if (error) {
+    return <p className="text-sm text-muted-foreground">{`Couldn't load station data: ${error}`}</p>
+  }
+  if (!data) {
+    return presets.map((preset) => <ChartSkeleton key={preset.key} />)
+  }
+  if (data.series.length === 0) {
+    return <p className="text-muted-foreground">No data reported for this window.</p>
+  }
+  return (
+    <ChartFrame loading={loading}>
+      <div className="flex flex-col gap-6">
+        {arrangement.visiblePresets.map((preset) => (
+          <PresetChart
+            key={preset.key}
+            preset={preset}
+            data={data}
+            primaryStids={primaryStids}
+            controls={
+              <ChartControls
+                title={preset.title}
+                canUp={arrangement.canMove(preset.key, -1)}
+                canDown={arrangement.canMove(preset.key, 1)}
+                onMove={(direction) => arrangement.moveChart(preset.key, direction)}
+                onHide={() => arrangement.hideChart(preset.key)}
+              />
+            }
+          />
+        ))}
+      </div>
+    </ChartFrame>
   )
 }
 
 // The station page's Graphs tab: fixed preset charts for this station group,
 // with a shared time-window picker and optional comparison stations whose
-// series overlay every chart as dashed lines. The v2 self-serve builder renders
-// the same charts from a user-built config instead of presets.
+// series overlay every chart as dashed lines.
 export function StationGraphs({
   stids,
   presets,
@@ -351,21 +366,30 @@ export function StationGraphs({
   presets: GraphPreset[]
   currentSlug: string
 }) {
-  const [windowKey, setWindowKey] = useState('7d')
+  const [graphWindow, setGraphWindow] = useState(DEFAULT_GRAPH_WINDOW)
   const [compareSlugs, setCompareSlugs] = useState<string[]>([])
-  const arrangement = useChartArrangement(presets)
 
   // Base stids plus each comparison group's, deduped in selection order.
   const allStids = useMemo(() => {
     const combined = [...stids]
     for (const slug of compareSlugs) {
-      const group = NWAC_WEATHER_STATION_GROUPS.find((g) => g.slug === slug)
-      for (const stid of group?.stids ?? []) {
+      for (const stid of getStationGroup(slug)?.stids ?? []) {
         if (!combined.includes(stid)) combined.push(stid)
       }
     }
     return combined
   }, [stids, compareSlugs])
+
+  const variables = useMemo(() => {
+    const unique = new Set(presets.flatMap((p) => p.variables))
+    return Array.from(unique)
+  }, [presets])
+
+  const { data, error, loading } = useGraphData(allStids, variables, graphWindow)
+
+  const emptyKeys = useMemo(() => emptyPresetKeys(data, presets), [data, presets])
+
+  const arrangement = useChartArrangement(presets, emptyKeys)
 
   if (presets.length === 0) {
     return <p className="text-muted-foreground">This station has no graphable sensors.</p>
@@ -373,34 +397,30 @@ export function StationGraphs({
 
   return (
     <div className="flex flex-col gap-6">
-      <GraphsToolbar
-        windowKey={windowKey}
-        onWindowChange={setWindowKey}
-        currentSlug={currentSlug}
-        compareSlugs={compareSlugs}
-        onCompareChange={setCompareSlugs}
-        hiddenPresets={arrangement.hiddenPresets}
-        onShowChart={arrangement.showChart}
-      />
-      {arrangement.visiblePresets.map((preset) => (
-        <PresetChart
-          key={preset.key}
-          preset={preset}
-          stids={allStids}
-          primaryStids={stids}
-          windowKey={windowKey}
-          onEmptyChange={arrangement.onEmptyChange}
-          controls={
-            <ChartControls
-              title={preset.title}
-              canUp={arrangement.canMove(preset.key, -1)}
-              canDown={arrangement.canMove(preset.key, 1)}
-              onMove={(direction) => arrangement.moveChart(preset.key, direction)}
-              onHide={() => arrangement.hideChart(preset.key)}
-            />
-          }
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <WindowPicker active={graphWindow} onChange={setGraphWindow} />
+          <CompareStationPicker
+            currentSlug={currentSlug}
+            compareSlugs={compareSlugs}
+            onAdd={(slug) => setCompareSlugs([...compareSlugs, slug])}
+          />
+        </div>
+        <GraphsChipRow
+          compareSlugs={compareSlugs}
+          onCompareChange={setCompareSlugs}
+          hiddenPresets={arrangement.hiddenPresets}
+          onShow={arrangement.showChart}
         />
-      ))}
+      </div>
+      <GraphsCharts
+        presets={presets}
+        primaryStids={stids}
+        arrangement={arrangement}
+        data={data}
+        error={error}
+        loading={loading}
+      />
     </div>
   )
 }

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -11,7 +11,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { buildChartOption } from './stationGraphOptions'
 import type { GraphPreset, GraphWindow } from './stationGraphPresets'
 import { DEFAULT_GRAPH_WINDOW, GRAPH_WINDOWS } from './stationGraphPresets'
-import { convertGraphData, convertPreset } from './stationGraphUnits'
+import { clampNegativeValues, convertGraphData, convertPreset } from './stationGraphUnits'
 import { StationOptGroups, stationSelectClass } from './StationPicker'
 import type { UnitSystem } from './UnitToggle'
 import { UnitToggle, useUnitSystem } from './UnitToggle'
@@ -250,10 +250,14 @@ function PresetChart({
   unitSystem: UnitSystem
   controls: ReactNode
 }) {
-  const presetData = useMemo(
-    () => ({ ...data, series: data.series.filter((s) => preset.variables.includes(s.variable)) }),
-    [data, preset],
-  )
+  const presetData = useMemo(() => {
+    const filtered = {
+      ...data,
+      series: data.series.filter((s) => preset.variables.includes(s.variable)),
+    }
+    const clamped = preset.allowNegative ? filtered : clampNegativeValues(filtered)
+    return convertGraphData(clamped, unitSystem)
+  }, [data, preset, unitSystem])
   const option = useMemo(
     () => buildChartOption(presetData, convertPreset(preset, unitSystem), primaryStids),
     [presetData, preset, unitSystem, primaryStids],
@@ -421,11 +425,6 @@ export function StationGraphs({
 
   const { data, error, loading } = useGraphData(allStids, variables, graphWindow)
 
-  const displayData = useMemo(
-    () => (data ? convertGraphData(data, unitSystem) : null),
-    [data, unitSystem],
-  )
-
   const emptyKeys = useMemo(() => emptyPresetKeys(data, presets), [data, presets])
 
   const arrangement = useChartArrangement(presets, emptyKeys)
@@ -450,7 +449,7 @@ export function StationGraphs({
         presets={presets}
         primaryStids={stids}
         arrangement={arrangement}
-        data={displayData}
+        data={data}
         error={error}
         loading={loading}
         unitSystem={unitSystem}

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -11,7 +11,10 @@ import { useEffect, useMemo, useState } from 'react'
 import { buildChartOption } from './stationGraphOptions'
 import type { GraphPreset, GraphWindow } from './stationGraphPresets'
 import { DEFAULT_GRAPH_WINDOW, GRAPH_WINDOWS } from './stationGraphPresets'
+import { convertGraphData, convertPreset } from './stationGraphUnits'
 import { StationOptGroups, stationSelectClass } from './StationPicker'
+import type { UnitSystem } from './UnitToggle'
+import { UnitToggle, useUnitSystem } from './UnitToggle'
 import { useChartArrangement } from './useChartArrangement'
 
 function ChartSkeleton() {
@@ -238,11 +241,13 @@ function PresetChart({
   preset,
   data,
   primaryStids,
+  unitSystem,
   controls,
 }: {
   preset: GraphPreset
   data: GraphData
   primaryStids: string[]
+  unitSystem: UnitSystem
   controls: ReactNode
 }) {
   const presetData = useMemo(
@@ -250,8 +255,8 @@ function PresetChart({
     [data, preset],
   )
   const option = useMemo(
-    () => buildChartOption(presetData, preset, primaryStids),
-    [presetData, preset, primaryStids],
+    () => buildChartOption(presetData, convertPreset(preset, unitSystem), primaryStids),
+    [presetData, preset, unitSystem, primaryStids],
   )
   return (
     <div className="relative">
@@ -297,6 +302,7 @@ function GraphsCharts({
   data,
   error,
   loading,
+  unitSystem,
 }: {
   presets: GraphPreset[]
   primaryStids: string[]
@@ -304,6 +310,7 @@ function GraphsCharts({
   data: GraphData | null
   error: string | null
   loading: boolean
+  unitSystem: UnitSystem
 }) {
   if (error) {
     return <p className="text-sm text-muted-foreground">{`Couldn't load station data: ${error}`}</p>
@@ -323,6 +330,7 @@ function GraphsCharts({
             preset={preset}
             data={data}
             primaryStids={primaryStids}
+            unitSystem={unitSystem}
             controls={
               <ChartControls
                 title={preset.title}
@@ -339,6 +347,59 @@ function GraphsCharts({
   )
 }
 
+function GraphsToolbar({
+  graphWindow,
+  onWindowChange,
+  unitSystem,
+  onUnitChange,
+  currentSlug,
+  compareSlugs,
+  onCompareChange,
+  arrangement,
+}: {
+  graphWindow: GraphWindow
+  onWindowChange: (window: GraphWindow) => void
+  unitSystem: UnitSystem
+  onUnitChange: (system: UnitSystem) => void
+  currentSlug: string
+  compareSlugs: string[]
+  onCompareChange: (slugs: string[]) => void
+  arrangement: ReturnType<typeof useChartArrangement>
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <WindowPicker active={graphWindow} onChange={onWindowChange} />
+          <UnitToggle unit={unitSystem} onChange={onUnitChange} />
+        </div>
+        <CompareStationPicker
+          currentSlug={currentSlug}
+          compareSlugs={compareSlugs}
+          onAdd={(slug) => onCompareChange([...compareSlugs, slug])}
+        />
+      </div>
+      <GraphsChipRow
+        compareSlugs={compareSlugs}
+        onCompareChange={onCompareChange}
+        hiddenPresets={arrangement.hiddenPresets}
+        onShow={arrangement.showChart}
+      />
+    </div>
+  )
+}
+
+// The page's stids plus each comparison group's, deduped in selection order.
+function combinedStids(stids: string[], compareSlugs: string[]): string[] {
+  const combined = [...stids]
+  for (const slug of compareSlugs) {
+    for (const stid of getStationGroup(slug)?.stids ?? []) {
+      if (!combined.includes(stid)) combined.push(stid)
+    }
+  }
+  return combined
+}
+
 export function StationGraphs({
   stids,
   presets,
@@ -350,23 +411,20 @@ export function StationGraphs({
 }) {
   const [graphWindow, setGraphWindow] = useState(DEFAULT_GRAPH_WINDOW)
   const [compareSlugs, setCompareSlugs] = useState<string[]>([])
+  const [unitSystem, changeUnitSystem] = useUnitSystem()
 
-  const allStids = useMemo(() => {
-    const combined = [...stids]
-    for (const slug of compareSlugs) {
-      for (const stid of getStationGroup(slug)?.stids ?? []) {
-        if (!combined.includes(stid)) combined.push(stid)
-      }
-    }
-    return combined
-  }, [stids, compareSlugs])
-
-  const variables = useMemo(() => {
-    const unique = new Set(presets.flatMap((p) => p.variables))
-    return Array.from(unique)
-  }, [presets])
+  const allStids = useMemo(() => combinedStids(stids, compareSlugs), [stids, compareSlugs])
+  const variables = useMemo(
+    () => Array.from(new Set(presets.flatMap((p) => p.variables))),
+    [presets],
+  )
 
   const { data, error, loading } = useGraphData(allStids, variables, graphWindow)
+
+  const displayData = useMemo(
+    () => (data ? convertGraphData(data, unitSystem) : null),
+    [data, unitSystem],
+  )
 
   const emptyKeys = useMemo(() => emptyPresetKeys(data, presets), [data, presets])
 
@@ -378,29 +436,24 @@ export function StationGraphs({
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <WindowPicker active={graphWindow} onChange={setGraphWindow} />
-          <CompareStationPicker
-            currentSlug={currentSlug}
-            compareSlugs={compareSlugs}
-            onAdd={(slug) => setCompareSlugs([...compareSlugs, slug])}
-          />
-        </div>
-        <GraphsChipRow
-          compareSlugs={compareSlugs}
-          onCompareChange={setCompareSlugs}
-          hiddenPresets={arrangement.hiddenPresets}
-          onShow={arrangement.showChart}
-        />
-      </div>
+      <GraphsToolbar
+        graphWindow={graphWindow}
+        onWindowChange={setGraphWindow}
+        unitSystem={unitSystem}
+        onUnitChange={changeUnitSystem}
+        currentSlug={currentSlug}
+        compareSlugs={compareSlugs}
+        onCompareChange={setCompareSlugs}
+        arrangement={arrangement}
+      />
       <GraphsCharts
         presets={presets}
         primaryStids={stids}
         arrangement={arrangement}
-        data={data}
+        data={displayData}
         error={error}
         loading={loading}
+        unitSystem={unitSystem}
       />
     </div>
   )

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -236,8 +236,8 @@ function HiddenChartChips({
           onClick={() => onShow(preset.key)}
           className={cn(chipClass, 'text-muted-foreground hover:text-foreground')}
         >
-          <Eye className="h-3.5 w-3.5" />
           {preset.title}
+          <Eye className="h-3.5 w-3.5" />
         </button>
       ))}
     </>

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -4,7 +4,7 @@ import { getStationGroup, MAX_COMPARE_STATIONS } from '@/constants/weatherStatio
 import type { GraphData } from '@/services/snowobs/graph'
 import { cn } from '@/utilities/ui'
 import { subHours } from 'date-fns'
-import { ArrowDown, ArrowUp, Eye, EyeOff, Loader2, Plus, X } from 'lucide-react'
+import { ArrowDown, ArrowUp, Eye, EyeOff, Loader2, X } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
@@ -12,7 +12,7 @@ import { buildChartOption } from './stationGraphOptions'
 import type { GraphPreset, GraphWindow } from './stationGraphPresets'
 import { DEFAULT_GRAPH_WINDOW, GRAPH_WINDOWS } from './stationGraphPresets'
 import { clampNegativeValues, convertGraphData, convertPreset } from './stationGraphUnits'
-import { StationOptGroups } from './StationPicker'
+import { StationOptGroups, stationSelectClass } from './StationPicker'
 import type { UnitSystem } from './UnitToggle'
 import { UnitToggle, useUnitSystem } from './UnitToggle'
 import { useChartArrangement } from './useChartArrangement'
@@ -125,34 +125,20 @@ function CompareStationPicker({
 }) {
   const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
   return (
-    // A button-looking span with an invisible native select stacked on top,
-    // so the control is content-width but clicking still opens the
-    // region-grouped menu.
-    <div className="group relative inline-flex">
-      <span
-        className={cn(
-          'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors',
-          atCap
-            ? 'bg-muted text-muted-foreground opacity-50'
-            : 'bg-primary text-primary-foreground group-hover:bg-primary/90',
-        )}
-      >
-        {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station'}
-        {!atCap && <Plus className="h-4 w-4" />}
-      </span>
-      <select
-        value=""
-        disabled={atCap}
-        aria-label="Compare with another station"
-        onChange={(event) => {
-          if (event.target.value) onAdd(event.target.value)
-        }}
-        className="absolute inset-0 cursor-pointer opacity-0 disabled:cursor-default"
-      >
-        <option value="" />
-        <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
-      </select>
-    </div>
+    <select
+      value=""
+      disabled={atCap}
+      aria-label="Compare with"
+      onChange={(event) => {
+        if (event.target.value) onAdd(event.target.value)
+      }}
+      className={cn(stationSelectClass, 'px-3 py-1.5 disabled:opacity-50')}
+    >
+      <option value="">
+        {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Compare with a station…'}
+      </option>
+      <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
+    </select>
   )
 }
 

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -12,7 +12,7 @@ import { buildChartOption } from './stationGraphOptions'
 import type { GraphPreset, GraphWindow } from './stationGraphPresets'
 import { DEFAULT_GRAPH_WINDOW, GRAPH_WINDOWS } from './stationGraphPresets'
 import { clampNegativeValues, convertGraphData, convertPreset } from './stationGraphUnits'
-import { StationOptGroups, stationSelectClass } from './StationPicker'
+import { StationOptGroups } from './StationPicker'
 import type { UnitSystem } from './UnitToggle'
 import { UnitToggle, useUnitSystem } from './UnitToggle'
 import { useChartArrangement } from './useChartArrangement'
@@ -125,17 +125,19 @@ function CompareStationPicker({
 }) {
   const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
   return (
+    // A native select styled as a button: the closed control reads as
+    // "+ Add a station", clicking it still opens the region-grouped menu.
     <select
       value=""
       disabled={atCap}
-      aria-label="Compare with"
+      aria-label="Compare with another station"
       onChange={(event) => {
         if (event.target.value) onAdd(event.target.value)
       }}
-      className={cn(stationSelectClass, 'px-3 py-1.5 disabled:opacity-50')}
+      className="cursor-pointer appearance-none rounded-md bg-muted px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-50"
     >
       <option value="">
-        {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Compare with a station…'}
+        {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : '+ Add a station'}
       </option>
       <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
     </select>

--- a/src/components/WeatherStations/StationPageView.tsx
+++ b/src/components/WeatherStations/StationPageView.tsx
@@ -13,7 +13,13 @@ type StationPageViewProps = {
   tabContent?: ReactNode
 }
 
-function StationView({ table, tabContent }: { table: StationTable | null; tabContent?: ReactNode }) {
+function StationView({
+  table,
+  tabContent,
+}: {
+  table: StationTable | null
+  tabContent?: ReactNode
+}) {
   if (tabContent) return <>{tabContent}</>
   return table ? <StationNowTable table={table} /> : null
 }

--- a/src/components/WeatherStations/StationPageView.tsx
+++ b/src/components/WeatherStations/StationPageView.tsx
@@ -10,11 +10,11 @@ type StationPageViewProps = {
   group: WeatherStationGroup
   table: StationTable | null
   activeKey: string
-  csvForm?: ReactNode
+  tabContent?: ReactNode
 }
 
-function StationView({ table, csvForm }: { table: StationTable | null; csvForm?: ReactNode }) {
-  if (csvForm) return <>{csvForm}</>
+function StationView({ table, tabContent }: { table: StationTable | null; tabContent?: ReactNode }) {
+  if (tabContent) return <>{tabContent}</>
   return table ? <StationNowTable table={table} /> : null
 }
 
@@ -41,13 +41,13 @@ function StationHeader({
   )
 }
 
-export function StationPageView({ group, table, activeKey, csvForm }: StationPageViewProps) {
+export function StationPageView({ group, table, activeKey, tabContent }: StationPageViewProps) {
   return (
     <div className="mb-10 flex flex-col gap-4">
       <StationHeader group={group} table={table} />
       <div className="container flex flex-col gap-3">
         <StationRangeTabs activeKey={activeKey} />
-        <StationView table={table} csvForm={csvForm} />
+        <StationView table={table} tabContent={tabContent} />
       </div>
     </div>
   )

--- a/src/components/WeatherStations/StationPicker.tsx
+++ b/src/components/WeatherStations/StationPicker.tsx
@@ -4,6 +4,25 @@ import { NWAC_STATION_REGIONS, NWAC_WEATHER_STATION_GROUPS } from '@/constants/w
 import { cn } from '@/utilities/ui'
 import { useRouter } from 'next/navigation'
 
+// Region-grouped station options, shared by every station select.
+export function StationOptGroups({ excludeSlugs = [] }: { excludeSlugs?: string[] }) {
+  return NWAC_STATION_REGIONS.map((region) => {
+    const groups = NWAC_WEATHER_STATION_GROUPS.filter(
+      (group) => group.region === region && !excludeSlugs.includes(group.slug),
+    )
+    if (groups.length === 0) return null
+    return (
+      <optgroup key={region} label={region}>
+        {groups.map((group) => (
+          <option key={group.slug} value={group.slug}>
+            {group.displayName}
+          </option>
+        ))}
+      </optgroup>
+    )
+  })
+}
+
 // Region-grouped dropdown that navigates to a station's page. Reused on both the
 // stations index and the per-station detail page.
 export function StationPicker({ current, className }: { current?: string; className?: string }) {
@@ -22,19 +41,7 @@ export function StationPicker({ current, className }: { current?: string; classN
         <option value="" disabled>
           Jump to a station…
         </option>
-        {NWAC_STATION_REGIONS.map((region) => {
-          const groups = NWAC_WEATHER_STATION_GROUPS.filter((group) => group.region === region)
-          if (groups.length === 0) return null
-          return (
-            <optgroup key={region} label={region}>
-              {groups.map((group) => (
-                <option key={group.slug} value={group.slug}>
-                  {group.displayName}
-                </option>
-              ))}
-            </optgroup>
-          )
-        })}
+        <StationOptGroups />
       </select>
     </label>
   )

--- a/src/components/WeatherStations/StationPicker.tsx
+++ b/src/components/WeatherStations/StationPicker.tsx
@@ -4,6 +4,10 @@ import { NWAC_STATION_REGIONS, NWAC_WEATHER_STATION_GROUPS } from '@/constants/w
 import { cn } from '@/utilities/ui'
 import { useRouter } from 'next/navigation'
 
+// Shared styling for every station select (padding varies per site).
+export const stationSelectClass =
+  'rounded-md border border-input bg-background text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring'
+
 // Region-grouped station options, shared by every station select.
 export function StationOptGroups({ excludeSlugs = [] }: { excludeSlugs?: string[] }) {
   return NWAC_STATION_REGIONS.map((region) => {
@@ -36,7 +40,7 @@ export function StationPicker({ current, className }: { current?: string; classN
         onChange={(event) => {
           if (event.target.value) router.push(`/weather/stations/${event.target.value}`)
         }}
-        className="rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        className={cn(stationSelectClass, 'px-3 py-2')}
       >
         <option value="" disabled>
           Jump to a station…

--- a/src/components/WeatherStations/StationPicker.tsx
+++ b/src/components/WeatherStations/StationPicker.tsx
@@ -4,11 +4,9 @@ import { NWAC_STATION_REGIONS, NWAC_WEATHER_STATION_GROUPS } from '@/constants/w
 import { cn } from '@/utilities/ui'
 import { useRouter } from 'next/navigation'
 
-// Shared styling for every station select (padding varies per site).
 export const stationSelectClass =
   'rounded-md border border-input bg-background text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring'
 
-// Region-grouped station options, shared by every station select.
 export function StationOptGroups({ excludeSlugs = [] }: { excludeSlugs?: string[] }) {
   return NWAC_STATION_REGIONS.map((region) => {
     const groups = NWAC_WEATHER_STATION_GROUPS.filter(

--- a/src/components/WeatherStations/StationRangeTabs.tsx
+++ b/src/components/WeatherStations/StationRangeTabs.tsx
@@ -12,38 +12,43 @@ export function resolveStationRange(param: string | undefined): StationRange {
   return STATION_RANGES.find((range) => range.key === param) ?? STATION_RANGES[0]
 }
 
+function TabLink({
+  tabKey,
+  label,
+  activeKey,
+  className,
+}: {
+  tabKey: string
+  label: string
+  activeKey: string
+  className?: string
+}) {
+  const active = tabKey === activeKey
+  return (
+    <Link
+      href={`?range=${tabKey}`}
+      aria-current={active ? 'true' : undefined}
+      className={cn(
+        '-mb-px border-b-2 px-3 py-2 text-sm font-medium',
+        active
+          ? 'border-primary text-foreground'
+          : 'border-transparent text-muted-foreground hover:text-foreground',
+        className,
+      )}
+    >
+      {label}
+    </Link>
+  )
+}
+
 export function StationRangeTabs({ activeKey }: { activeKey: string }) {
   return (
     <nav className="flex gap-1 border-b" aria-label="Station views">
-      <>
-        {STATION_RANGES.map((range) => (
-          <Link
-            key={range.key}
-            href={`?range=${range.key}`}
-            aria-current={range.key === activeKey ? 'true' : undefined}
-            className={cn(
-              '-mb-px border-b-2 px-3 py-2 text-sm font-medium',
-              range.key === activeKey
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground',
-            )}
-          >
-            {range.label}
-          </Link>
-        ))}
-      </>
-      <Link
-        href="?range=csv"
-        aria-current={'csv' === activeKey ? 'true' : undefined}
-        className={cn(
-          '-mb-px ml-auto border-b-2 px-3 py-2 text-sm font-medium',
-          'csv' === activeKey
-            ? 'border-primary text-foreground'
-            : 'border-transparent text-muted-foreground hover:text-foreground',
-        )}
-      >
-        Download CSV
-      </Link>
+      {STATION_RANGES.map((range) => (
+        <TabLink key={range.key} tabKey={range.key} label={range.label} activeKey={activeKey} />
+      ))}
+      <TabLink tabKey="graphs" label="Graphs" activeKey={activeKey} />
+      <TabLink tabKey="csv" label="Download CSV" activeKey={activeKey} className="ml-auto" />
     </nav>
   )
 }

--- a/src/components/WeatherStations/UnitToggle.tsx
+++ b/src/components/WeatherStations/UnitToggle.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { useEffect, useState } from 'react'
+
+export type UnitSystem = 'imperial' | 'metric'
+
+const STORAGE_KEY = 'nwac-station-graph-units'
+
+function loadUnitSystem(): UnitSystem {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === 'metric' ? 'metric' : 'imperial'
+  } catch {
+    return 'imperial'
+  }
+}
+
+// Unit choice persisted per browser; localStorage is browser-only, so the
+// stored choice loads after mount.
+export function useUnitSystem(): [UnitSystem, (system: UnitSystem) => void] {
+  const [unitSystem, setUnitSystem] = useState<UnitSystem>('imperial')
+  useEffect(() => setUnitSystem(loadUnitSystem()), [])
+  const changeUnitSystem = (system: UnitSystem) => {
+    setUnitSystem(system)
+    try {
+      window.localStorage.setItem(STORAGE_KEY, system)
+    } catch {
+      // Private mode / quota errors just lose persistence, never the feature.
+    }
+  }
+  return [unitSystem, changeUnitSystem]
+}
+
+export function UnitToggle({
+  unit,
+  onChange,
+}: {
+  unit: UnitSystem
+  onChange: (unit: UnitSystem) => void
+}) {
+  return (
+    <ToggleGroup
+      type="single"
+      size="sm"
+      variant="outline"
+      value={unit}
+      onValueChange={(v) => (v === 'imperial' || v === 'metric') && onChange(v)}
+      aria-label="Units"
+    >
+      <ToggleGroupItem
+        value="imperial"
+        className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+      >
+        Imperial
+      </ToggleGroupItem>
+      <ToggleGroupItem
+        value="metric"
+        className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+      >
+        Metric
+      </ToggleGroupItem>
+    </ToggleGroup>
+  )
+}

--- a/src/components/WeatherStations/UnitToggle.tsx
+++ b/src/components/WeatherStations/UnitToggle.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { cn } from '@/utilities/ui'
 import { useEffect, useState } from 'react'
 
 export type UnitSystem = 'imperial' | 'metric'
@@ -38,27 +38,31 @@ export function UnitToggle({
   unit: UnitSystem
   onChange: (unit: UnitSystem) => void
 }) {
-  return (
-    <ToggleGroup
-      type="single"
-      size="sm"
-      variant="outline"
-      value={unit}
-      onValueChange={(v) => (v === 'imperial' || v === 'metric') && onChange(v)}
-      aria-label="Units"
+  const chip = (system: UnitSystem, text: string) => (
+    <button
+      type="button"
+      onClick={() => onChange(system)}
+      aria-pressed={unit === system}
+      className={cn(
+        'relative z-10 w-20 rounded-md py-1.5 text-center text-sm transition-colors',
+        unit === system ? 'text-primary-foreground' : 'text-muted-foreground hover:text-foreground',
+      )}
     >
-      <ToggleGroupItem
-        value="imperial"
-        className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
-      >
-        Imperial
-      </ToggleGroupItem>
-      <ToggleGroupItem
-        value="metric"
-        className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
-      >
-        Metric
-      </ToggleGroupItem>
-    </ToggleGroup>
+      {text}
+    </button>
+  )
+  return (
+    <div role="group" aria-label="Units" className="relative inline-flex rounded-md bg-muted p-1">
+      {/* The active-chip background, sliding between the fixed-width chips. */}
+      <span
+        aria-hidden
+        className={cn(
+          'absolute inset-y-1 left-1 w-20 rounded-md bg-primary transition-transform duration-200',
+          unit === 'metric' && 'translate-x-20',
+        )}
+      />
+      {chip('imperial', 'Imperial')}
+      {chip('metric', 'Metric')}
+    </div>
   )
 }

--- a/src/components/WeatherStations/UnitToggle.tsx
+++ b/src/components/WeatherStations/UnitToggle.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { readLocalStorage, writeLocalStorage } from '@/utilities/safeLocalStorage'
 import { cn } from '@/utilities/ui'
 import { useEffect, useState } from 'react'
 
@@ -7,26 +8,16 @@ export type UnitSystem = 'imperial' | 'metric'
 
 const STORAGE_KEY = 'nwac-station-graph-units'
 
-function loadUnitSystem(): UnitSystem {
-  try {
-    return window.localStorage.getItem(STORAGE_KEY) === 'metric' ? 'metric' : 'imperial'
-  } catch {
-    return 'imperial'
-  }
-}
-
 // Unit choice persisted per browser; localStorage is browser-only, so the
 // stored choice loads after mount.
 export function useUnitSystem(): [UnitSystem, (system: UnitSystem) => void] {
   const [unitSystem, setUnitSystem] = useState<UnitSystem>('imperial')
-  useEffect(() => setUnitSystem(loadUnitSystem()), [])
+  useEffect(() => {
+    setUnitSystem(readLocalStorage(STORAGE_KEY) === 'metric' ? 'metric' : 'imperial')
+  }, [])
   const changeUnitSystem = (system: UnitSystem) => {
     setUnitSystem(system)
-    try {
-      window.localStorage.setItem(STORAGE_KEY, system)
-    } catch {
-      // Private mode / quota errors just lose persistence, never the feature.
-    }
+    writeLocalStorage(STORAGE_KEY, system)
   }
   return [unitSystem, changeUnitSystem]
 }

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -201,10 +201,13 @@ export function buildChartOption(data: GraphData, preset: GraphPreset): EChartOp
       ...degreeAxisOverrides(symbolsOnly),
       ...presetAxisOverrides(preset),
     })),
-    dataZoom: [
-      { type: 'inside', xAxisIndex: 0 },
-      { type: 'slider', xAxisIndex: 0, height: 18, bottom: 8 },
-    ],
+    dataZoom: (() => {
+      const minValueSpan = (data.aggregated ? 6 * 24 : 6) * 60 * 60 * 1000
+      return [
+        { type: 'inside', xAxisIndex: 0, minValueSpan },
+        { type: 'slider', xAxisIndex: 0, height: 18, bottom: 8, minValueSpan },
+      ]
+    })(),
     series,
   }
 }

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -1,0 +1,98 @@
+import type { GraphData, GraphSeries } from '@/services/snowobs/graph'
+import type { EChartOption } from './EChart'
+
+// Builds the ECharts option for one preset chart from the graph-data response.
+// Raw series render as lines; daily-aggregated series render as a mean line
+// plus a shaded min→max band (two stacked helper series).
+
+// Series grouped onto up to two y-axes by unit (°F and % on one chart, etc.).
+function unitAxes(series: GraphSeries[]): string[] {
+  const units: string[] = []
+  for (const s of series) {
+    if (!units.includes(s.unit)) units.push(s.unit)
+  }
+  return units.slice(0, 2)
+}
+
+function axisIndexFor(unit: string, axes: string[]): number {
+  const index = axes.indexOf(unit)
+  return index === -1 ? 0 : index
+}
+
+function rawSeries(s: GraphSeries & { kind: 'raw' }, yAxisIndex: number): object[] {
+  return [
+    {
+      name: s.label,
+      type: 'line',
+      yAxisIndex,
+      showSymbol: false,
+      connectNulls: false,
+      data: s.points,
+    },
+  ]
+}
+
+// Mean line + min→max band: a transparent "floor" line at min, stacked with
+// (max − min) area on top.
+function dailySeries(s: GraphSeries & { kind: 'daily' }, yAxisIndex: number): object[] {
+  const stack = `band-${s.label}`
+  return [
+    {
+      name: s.label,
+      type: 'line',
+      yAxisIndex,
+      showSymbol: false,
+      data: s.days.map(([t, , mean]) => [t, mean]),
+    },
+    {
+      name: `${s.label} range`,
+      type: 'line',
+      yAxisIndex,
+      stack,
+      showSymbol: false,
+      lineStyle: { opacity: 0 },
+      tooltip: { show: false },
+      legendHoverLink: false,
+      data: s.days.map(([t, min]) => [t, min]),
+    },
+    {
+      name: `${s.label} range`,
+      type: 'line',
+      yAxisIndex,
+      stack,
+      showSymbol: false,
+      lineStyle: { opacity: 0 },
+      areaStyle: { opacity: 0.15 },
+      tooltip: { show: false },
+      legendHoverLink: false,
+      data: s.days.map(([t, min, , max]) => [t, max - min]),
+    },
+  ]
+}
+
+export function buildChartOption(data: GraphData, title: string): EChartOption {
+  const axes = unitAxes(data.series)
+  const series = data.series.flatMap((s) => {
+    const yAxisIndex = axisIndexFor(s.unit, axes)
+    return s.kind === 'raw' ? rawSeries(s, yAxisIndex) : dailySeries(s, yAxisIndex)
+  })
+  return {
+    title: { text: title, left: 0, textStyle: { fontSize: 14 } },
+    tooltip: { trigger: 'axis' },
+    legend: { top: 0, right: 0, data: data.series.map((s) => s.label) },
+    grid: { left: 48, right: 48, top: 40, bottom: 56 },
+    xAxis: { type: 'time' },
+    yAxis: axes.map((unit, i) => ({
+      type: 'value',
+      name: unit,
+      position: i === 0 ? 'left' : 'right',
+      scale: true,
+      splitLine: { show: i === 0 },
+    })),
+    dataZoom: [
+      { type: 'inside', xAxisIndex: 0 },
+      { type: 'slider', xAxisIndex: 0, height: 18, bottom: 8 },
+    ],
+    series,
+  }
+}

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -149,6 +149,27 @@ function degreeAxisOverrides(symbolsOnly: boolean): object {
   }
 }
 
+// Preset-pinned axis bounds (RH 0-100, ...), matching the legacy plot specs.
+function presetAxisOverrides(preset: GraphPreset): object {
+  if (!preset.axis) return {}
+  return { ...preset.axis, scale: false }
+}
+
+// Legacy-style horizontal reference line (32°F freezing on temperature),
+// attached to the first series.
+function refLineFor(preset: GraphPreset): object {
+  if (preset.refLine === undefined) return {}
+  return {
+    markLine: {
+      silent: true,
+      symbol: 'none',
+      lineStyle: { type: 'dashed', color: '#94a3b8' },
+      label: { position: 'insideEndTop', formatter: String(preset.refLine) },
+      data: [{ yAxis: preset.refLine }],
+    },
+  }
+}
+
 // Tooltip values as "SW (225°)" on direction charts.
 function directionTooltip(symbolsOnly: boolean): object {
   if (!symbolsOnly) return {}
@@ -167,7 +188,9 @@ export function buildChartOption(data: GraphData, preset: GraphPreset): EChartOp
   const series = data.series.flatMap((s, i) => {
     const yAxisIndex = axisIndexFor(s.unit, axes)
     const color = SERIES_COLORS[i % SERIES_COLORS.length]
-    return seriesFor(s, yAxisIndex, color, symbolsOnly)
+    const built = seriesFor(s, yAxisIndex, color, symbolsOnly)
+    if (i === 0) Object.assign(built[0], refLineFor(preset))
+    return built
   })
   return {
     // Title top-left, legend on its own row below — they no longer collide.
@@ -203,6 +226,7 @@ export function buildChartOption(data: GraphData, preset: GraphPreset): EChartOp
       scale: true,
       splitLine: { show: i === 0 },
       ...degreeAxisOverrides(symbolsOnly),
+      ...presetAxisOverrides(preset),
     })),
     dataZoom: [
       { type: 'inside', xAxisIndex: 0 },

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -46,8 +46,7 @@ function rawSeries(
   ]
 }
 
-// Mean line + min→max band: a transparent "floor" line at min, stacked with
-// (max − min) area on top.
+// Daily vector-mean dots for direction charts on aggregated windows.
 function dailyMeanDots(
   s: GraphSeries & { kind: 'daily' },
   yAxisIndex: number,
@@ -68,12 +67,13 @@ function dailyMeanDots(
   ]
 }
 
+// Daily-aggregated series render as the mean line (the min→max band was
+// dropped in review — it read as a stray shadow).
 function dailySeries(
   s: GraphSeries & { kind: 'daily' },
   yAxisIndex: number,
   color: string,
 ): object[] {
-  const stack = `band-${s.label}`
   return [
     {
       name: s.label,
@@ -82,33 +82,6 @@ function dailySeries(
       yAxisIndex,
       showSymbol: false,
       data: s.days.map(([t, , mean]) => [t, mean]),
-    },
-    {
-      name: `${s.label} range`,
-      type: 'line',
-      color,
-      yAxisIndex,
-      stack,
-      showSymbol: false,
-      lineStyle: { opacity: 0 },
-      tooltip: { show: false },
-      legendHoverLink: false,
-      silent: true,
-      data: s.days.map(([t, min]) => [t, min]),
-    },
-    {
-      name: `${s.label} range`,
-      type: 'line',
-      color,
-      yAxisIndex,
-      stack,
-      showSymbol: false,
-      lineStyle: { opacity: 0 },
-      areaStyle: { color, opacity: 0.14 },
-      tooltip: { show: false },
-      legendHoverLink: false,
-      silent: true,
-      data: s.days.map(([t, min, , max]) => [t, max - min]),
     },
   ]
 }

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -84,7 +84,18 @@ export function buildChartOption(data: GraphData, title: string): EChartOption {
     grid: { left: 64, right: 64, top: 64, bottom: 64 },
     xAxis: {
       type: 'time',
-      axisLabel: { hideOverlap: true },
+      axisLabel: {
+        hideOverlap: true,
+        // Lead date-level ticks with the day of week ("Mon Jul 20"; hourly
+        // ticks "Mon 14:00") — forecasters think in storm days.
+        formatter: {
+          year: '{yyyy}',
+          month: '{MMM} {yyyy}',
+          day: '{ee} {MMM} {d}',
+          hour: '{ee} {HH}:{mm}',
+          minute: '{HH}:{mm}',
+        },
+      },
     },
     // Unit reads along the axis (rotated, centered) instead of a clipped label
     // floating above the axis top.

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -77,14 +77,24 @@ export function buildChartOption(data: GraphData, title: string): EChartOption {
     return s.kind === 'raw' ? rawSeries(s, yAxisIndex) : dailySeries(s, yAxisIndex)
   })
   return {
-    title: { text: title, left: 0, textStyle: { fontSize: 14 } },
+    // Title top-left, legend on its own row below — they no longer collide.
+    title: { text: title, left: 0, top: 0, textStyle: { fontSize: 15, fontWeight: 600 } },
     tooltip: { trigger: 'axis' },
-    legend: { top: 0, right: 0, data: data.series.map((s) => s.label) },
-    grid: { left: 48, right: 48, top: 40, bottom: 56 },
-    xAxis: { type: 'time' },
+    legend: { top: 26, left: 0, type: 'scroll', data: data.series.map((s) => s.label) },
+    grid: { left: 64, right: 64, top: 64, bottom: 64 },
+    xAxis: {
+      type: 'time',
+      axisLabel: { hideOverlap: true },
+    },
+    // Unit reads along the axis (rotated, centered) instead of a clipped label
+    // floating above the axis top.
     yAxis: axes.map((unit, i) => ({
       type: 'value',
       name: unit,
+      nameLocation: 'middle',
+      nameGap: 44,
+      nameRotate: i === 0 ? 90 : -90,
+      nameTextStyle: { fontSize: 12 },
       position: i === 0 ? 'left' : 'right',
       scale: true,
       splitLine: { show: i === 0 },

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -5,6 +5,10 @@ import type { EChartOption } from './EChart'
 // Raw series render as lines; daily-aggregated series render as a mean line
 // plus a shaded min→max band (two stacked helper series).
 
+// Fixed palette so a series' min-max band always shades in ITS line's color
+// (auto-assignment gave the invisible band helpers their own colors).
+const SERIES_COLORS = ['#2563eb', '#dc2626', '#059669', '#d97706', '#7c3aed', '#0891b2']
+
 // Series grouped onto up to two y-axes by unit (°F and % on one chart, etc.).
 function unitAxes(series: GraphSeries[]): string[] {
   const units: string[] = []
@@ -19,11 +23,12 @@ function axisIndexFor(unit: string, axes: string[]): number {
   return index === -1 ? 0 : index
 }
 
-function rawSeries(s: GraphSeries & { kind: 'raw' }, yAxisIndex: number): object[] {
+function rawSeries(s: GraphSeries & { kind: 'raw' }, yAxisIndex: number, color: string): object[] {
   return [
     {
       name: s.label,
       type: 'line',
+      color,
       yAxisIndex,
       showSymbol: false,
       connectNulls: false,
@@ -34,12 +39,17 @@ function rawSeries(s: GraphSeries & { kind: 'raw' }, yAxisIndex: number): object
 
 // Mean line + min→max band: a transparent "floor" line at min, stacked with
 // (max − min) area on top.
-function dailySeries(s: GraphSeries & { kind: 'daily' }, yAxisIndex: number): object[] {
+function dailySeries(
+  s: GraphSeries & { kind: 'daily' },
+  yAxisIndex: number,
+  color: string,
+): object[] {
   const stack = `band-${s.label}`
   return [
     {
       name: s.label,
       type: 'line',
+      color,
       yAxisIndex,
       showSymbol: false,
       data: s.days.map(([t, , mean]) => [t, mean]),
@@ -47,24 +57,28 @@ function dailySeries(s: GraphSeries & { kind: 'daily' }, yAxisIndex: number): ob
     {
       name: `${s.label} range`,
       type: 'line',
+      color,
       yAxisIndex,
       stack,
       showSymbol: false,
       lineStyle: { opacity: 0 },
       tooltip: { show: false },
       legendHoverLink: false,
+      silent: true,
       data: s.days.map(([t, min]) => [t, min]),
     },
     {
       name: `${s.label} range`,
       type: 'line',
+      color,
       yAxisIndex,
       stack,
       showSymbol: false,
       lineStyle: { opacity: 0 },
-      areaStyle: { opacity: 0.15 },
+      areaStyle: { color, opacity: 0.14 },
       tooltip: { show: false },
       legendHoverLink: false,
+      silent: true,
       data: s.days.map(([t, min, , max]) => [t, max - min]),
     },
   ]
@@ -72,9 +86,10 @@ function dailySeries(s: GraphSeries & { kind: 'daily' }, yAxisIndex: number): ob
 
 export function buildChartOption(data: GraphData, title: string): EChartOption {
   const axes = unitAxes(data.series)
-  const series = data.series.flatMap((s) => {
+  const series = data.series.flatMap((s, i) => {
     const yAxisIndex = axisIndexFor(s.unit, axes)
-    return s.kind === 'raw' ? rawSeries(s, yAxisIndex) : dailySeries(s, yAxisIndex)
+    const color = SERIES_COLORS[i % SERIES_COLORS.length]
+    return s.kind === 'raw' ? rawSeries(s, yAxisIndex, color) : dailySeries(s, yAxisIndex, color)
   })
   return {
     // Title top-left, legend on its own row below — they no longer collide.

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -1,5 +1,6 @@
 import type { GraphData, GraphSeries } from '@/services/snowobs/graph'
 import type { EChartOption } from './EChart'
+import type { GraphPreset } from './stationGraphPresets'
 
 // Builds the ECharts option for one preset chart from the graph-data response.
 // Raw series render as lines; daily-aggregated series render as a mean line
@@ -23,22 +24,50 @@ function axisIndexFor(unit: string, axes: string[]): number {
   return index === -1 ? 0 : index
 }
 
-function rawSeries(s: GraphSeries & { kind: 'raw' }, yAxisIndex: number, color: string): object[] {
+function rawSeries(
+  s: GraphSeries & { kind: 'raw' },
+  yAxisIndex: number,
+  color: string,
+  symbolsOnly: boolean,
+): object[] {
   return [
     {
       name: s.label,
       type: 'line',
       color,
       yAxisIndex,
-      showSymbol: false,
+      showSymbol: symbolsOnly,
+      symbolSize: 4,
+      lineStyle: symbolsOnly ? { opacity: 0 } : undefined,
       connectNulls: false,
       data: s.points,
+      ...directionTooltip(symbolsOnly),
     },
   ]
 }
 
 // Mean line + min→max band: a transparent "floor" line at min, stacked with
 // (max − min) area on top.
+function dailyMeanDots(
+  s: GraphSeries & { kind: 'daily' },
+  yAxisIndex: number,
+  color: string,
+): object[] {
+  return [
+    {
+      name: s.label,
+      type: 'line',
+      color,
+      yAxisIndex,
+      showSymbol: true,
+      symbolSize: 4,
+      lineStyle: { opacity: 0 },
+      data: s.days.map(([t, , mean]) => [t, mean]),
+      ...directionTooltip(true),
+    },
+  ]
+}
+
 function dailySeries(
   s: GraphSeries & { kind: 'daily' },
   yAxisIndex: number,
@@ -84,12 +113,61 @@ function dailySeries(
   ]
 }
 
-export function buildChartOption(data: GraphData, title: string): EChartOption {
+function seriesFor(
+  s: GraphSeries,
+  yAxisIndex: number,
+  color: string,
+  symbolsOnly: boolean,
+): object[] {
+  if (s.kind === 'raw') return rawSeries(s, yAxisIndex, color, symbolsOnly)
+  return symbolsOnly ? dailyMeanDots(s, yAxisIndex, color) : dailySeries(s, yAxisIndex, color)
+}
+
+const AXIS_CARDINALS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW']
+// prettier-ignore
+const ROSE_16 = ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW']
+
+// Axis ticks land on 45° multiples — 8-wind keeps them readable.
+export function degreesToCardinal(deg: number): string {
+  return AXIS_CARDINALS[Math.round(deg / 45) % 8]
+}
+
+// Hover labels use the 16-wind rose (22.5° sectors), matching the legacy plots.
+export function degreesToRose(deg: number): string {
+  if (deg < 0 || deg > 360) return 'INV'
+  return ROSE_16[Math.round(deg / 22.5) % 16]
+}
+
+// Compass scale for wind direction: cardinal tick labels every 45°.
+function degreeAxisOverrides(symbolsOnly: boolean): object {
+  if (!symbolsOnly) return {}
+  return {
+    min: 0,
+    max: 360,
+    interval: 45,
+    axisLabel: { formatter: (deg: number) => degreesToCardinal(deg) },
+  }
+}
+
+// Tooltip values as "SW (225°)" on direction charts.
+function directionTooltip(symbolsOnly: boolean): object {
+  if (!symbolsOnly) return {}
+  return {
+    tooltip: {
+      valueFormatter: (deg: unknown) =>
+        typeof deg === 'number' ? `${degreesToRose(deg)} (${Math.round(deg)}°)` : '–',
+    },
+  }
+}
+
+export function buildChartOption(data: GraphData, preset: GraphPreset): EChartOption {
+  const title = preset.title
+  const symbolsOnly = preset.symbolsOnly ?? false
   const axes = unitAxes(data.series)
   const series = data.series.flatMap((s, i) => {
     const yAxisIndex = axisIndexFor(s.unit, axes)
     const color = SERIES_COLORS[i % SERIES_COLORS.length]
-    return s.kind === 'raw' ? rawSeries(s, yAxisIndex, color) : dailySeries(s, yAxisIndex, color)
+    return seriesFor(s, yAxisIndex, color, symbolsOnly)
   })
   return {
     // Title top-left, legend on its own row below — they no longer collide.
@@ -124,6 +202,7 @@ export function buildChartOption(data: GraphData, title: string): EChartOption {
       position: i === 0 ? 'left' : 'right',
       scale: true,
       splitLine: { show: i === 0 },
+      ...degreeAxisOverrides(symbolsOnly),
     })),
     dataZoom: [
       { type: 'inside', xAxisIndex: 0 },

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -41,7 +41,7 @@ function seriesFor(
     name: s.label,
     color,
     yAxisIndex,
-    data: meanPoints(s),
+    data: meanPoints(s, preset.allowNegative ?? false),
     ...(symbolsOnly ? directionTooltip() : unitTooltip(s.unit)),
   }
   if (preset.bar) {
@@ -110,9 +110,13 @@ function refLineSeries(preset: GraphPreset): object[] {
 }
 
 // Mean points regardless of series kind — daily series plot and band on their means.
-function meanPoints(s: GraphSeries): [number, number | null][] {
-  if (s.kind === 'raw') return s.points
-  return s.days.map(([t, , mean]) => [t, mean])
+// Unless the preset allows negatives (temperature), sub-zero readings are
+// sensor noise and clamp to zero.
+function meanPoints(s: GraphSeries, allowNegative: boolean): [number, number | null][] {
+  const points: [number, number | null][] =
+    s.kind === 'raw' ? s.points : s.days.map(([t, , mean]) => [t, mean])
+  if (allowNegative) return points
+  return points.map(([t, v]) => [t, v === null ? v : Math.max(0, v)])
 }
 
 type BandPair = { lower: GraphSeries; upper: GraphSeries }
@@ -136,9 +140,14 @@ function bandPairsByStid(
 // Lower→upper shaded band: a transparent "floor" line at the lower edge,
 // stacked with (upper − lower) area on top. Aligned by timestamp; gaps in
 // either edge break the band rather than guessing.
-function bandSeries(pair: BandPair, yAxisIndex: number, color: string): object[] {
-  const lowerByTime = new Map(meanPoints(pair.lower))
-  const points = meanPoints(pair.upper).map(([t, upper]) => {
+function bandSeries(
+  pair: BandPair,
+  yAxisIndex: number,
+  color: string,
+  allowNegative: boolean,
+): object[] {
+  const lowerByTime = new Map(meanPoints(pair.lower, allowNegative))
+  const points = meanPoints(pair.upper, allowNegative).map(([t, upper]) => {
     const lower = lowerByTime.get(t) ?? null
     return { t, lower, delta: lower !== null && upper !== null ? upper - lower : null }
   })
@@ -222,7 +231,12 @@ export function buildChartOption(
   for (const [stid, pair] of bands) {
     const lineIndex = lineSeries.findIndex((s) => s.stid === stid)
     series.push(
-      ...bandSeries(pair, axisIndexFor(pair.lower.unit, axes), colorFor(Math.max(lineIndex, 0))),
+      ...bandSeries(
+        pair,
+        axisIndexFor(pair.lower.unit, axes),
+        colorFor(Math.max(lineIndex, 0)),
+        preset.allowNegative ?? false,
+      ),
     )
   }
   return {

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -1,4 +1,5 @@
 import type { GraphData, GraphSeries } from '@/services/snowobs/graph'
+import { format } from 'date-fns'
 import type { EChartOption } from './EChart'
 import type { GraphPreset } from './stationGraphPresets'
 
@@ -41,6 +42,7 @@ function seriesFor(
     color,
     yAxisIndex,
     data: meanPoints(s),
+    ...(symbolsOnly ? directionTooltip() : unitTooltip(s.unit)),
   }
   if (preset.bar) {
     return { ...base, type: 'bar', itemStyle: dashed ? { opacity: 0.6 } : undefined }
@@ -52,7 +54,6 @@ function seriesFor(
     symbolSize: 4,
     lineStyle: symbolsOnly ? { opacity: 0 } : dashed ? { type: 'dashed' } : undefined,
     connectNulls: false,
-    ...directionTooltip(symbolsOnly),
   }
 }
 
@@ -169,12 +170,23 @@ function bandSeries(pair: BandPair, yAxisIndex: number, color: string): object[]
 }
 
 // Tooltip values as "SW (225°)" on direction charts.
-function directionTooltip(symbolsOnly: boolean): object {
-  if (!symbolsOnly) return {}
+function directionTooltip(): object {
   return {
     tooltip: {
       valueFormatter: (deg: unknown) =>
         typeof deg === 'number' ? `${degreesToRose(deg)} (${Math.round(deg)}°)` : '–',
+    },
+  }
+}
+
+// Tooltip values as "31.3 °F": one decimal everywhere, the series' unit appended.
+function unitTooltip(unit: string): object {
+  return {
+    tooltip: {
+      valueFormatter: (value: unknown) =>
+        typeof value === 'number' && Number.isFinite(value)
+          ? `${value.toFixed(1)}${unit ? ` ${unit}` : ''}`
+          : '–',
     },
   }
 }
@@ -214,12 +226,18 @@ export function buildChartOption(
   return {
     // Title top-left, legend on its own row below — they no longer collide.
     title: { text: title, left: 0, top: 0, textStyle: { fontSize: 15, fontWeight: 600 } },
-    // Legacy hover precision: line plots 1 decimal, bar plots (precip) 2.
-    // Direction charts override per-series with the wind-rose formatter.
+    // Values format per-series (unit appended); the header date formats here —
+    // hourly charts "Wed Jul 30, 14:00", daily-aggregated charts date-only.
     tooltip: {
       trigger: 'axis',
-      valueFormatter: (value: unknown) =>
-        typeof value === 'number' ? value.toFixed(preset.decimals ?? (preset.bar ? 2 : 1)) : '–',
+      axisPointer: {
+        label: {
+          formatter: (params: { value: unknown }) =>
+            typeof params.value === 'number'
+              ? format(params.value, data.aggregated ? 'EEE MMM d, yyyy' : 'EEE MMM d, HH:mm')
+              : '',
+        },
+      },
     },
     legend: { top: 26, left: 0, type: 'scroll', data: lineSeries.map((s) => s.label) },
     // Right gutter only when a second y-axis sits there.

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -29,6 +29,7 @@ function rawSeries(
   yAxisIndex: number,
   color: string,
   symbolsOnly: boolean,
+  dashed: boolean,
 ): object[] {
   return [
     {
@@ -38,7 +39,7 @@ function rawSeries(
       yAxisIndex,
       showSymbol: symbolsOnly,
       symbolSize: 4,
-      lineStyle: symbolsOnly ? { opacity: 0 } : undefined,
+      lineStyle: symbolsOnly ? { opacity: 0 } : dashed ? { type: 'dashed' } : undefined,
       connectNulls: false,
       data: s.points,
       ...directionTooltip(symbolsOnly),
@@ -73,6 +74,7 @@ function dailySeries(
   s: GraphSeries & { kind: 'daily' },
   yAxisIndex: number,
   color: string,
+  dashed: boolean,
 ): object[] {
   return [
     {
@@ -81,6 +83,7 @@ function dailySeries(
       color,
       yAxisIndex,
       showSymbol: false,
+      lineStyle: dashed ? { type: 'dashed' } : undefined,
       data: s.days.map(([t, , mean]) => [t, mean]),
     },
   ]
@@ -91,9 +94,12 @@ function seriesFor(
   yAxisIndex: number,
   color: string,
   symbolsOnly: boolean,
+  dashed: boolean,
 ): object[] {
-  if (s.kind === 'raw') return rawSeries(s, yAxisIndex, color, symbolsOnly)
-  return symbolsOnly ? dailyMeanDots(s, yAxisIndex, color) : dailySeries(s, yAxisIndex, color)
+  if (s.kind === 'raw') return rawSeries(s, yAxisIndex, color, symbolsOnly, dashed)
+  return symbolsOnly
+    ? dailyMeanDots(s, yAxisIndex, color)
+    : dailySeries(s, yAxisIndex, color, dashed)
 }
 
 const AXIS_CARDINALS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW']
@@ -154,14 +160,21 @@ function directionTooltip(symbolsOnly: boolean): object {
   }
 }
 
-export function buildChartOption(data: GraphData, preset: GraphPreset): EChartOption {
+// `primaryStids` marks the page's own station(s); series from any other station
+// (a comparison pick) render dashed so overlapping stations stay readable.
+export function buildChartOption(
+  data: GraphData,
+  preset: GraphPreset,
+  primaryStids?: string[],
+): EChartOption {
   const title = preset.title
   const symbolsOnly = preset.symbolsOnly ?? false
   const axes = unitAxes(data.series)
   const series = data.series.flatMap((s, i) => {
     const yAxisIndex = axisIndexFor(s.unit, axes)
     const color = SERIES_COLORS[i % SERIES_COLORS.length]
-    const built = seriesFor(s, yAxisIndex, color, symbolsOnly)
+    const dashed = primaryStids !== undefined && !primaryStids.includes(s.stid)
+    const built = seriesFor(s, yAxisIndex, color, symbolsOnly, dashed)
     if (i === 0) Object.assign(built[0], refLineFor(preset))
     return built
   })

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -146,10 +146,14 @@ function bandSeries(pair: BandPair, yAxisIndex: number, color: string): object[]
     silent: true,
   }
   return [
-    { ...helper, name: `${pair.lower.label} band`, data: points.map((p) => [p.t, p.lower]) },
     {
       ...helper,
-      name: `${pair.upper.label} band`,
+      name: `${pair.lower.label} ${pair.lower.variable}`,
+      data: points.map((p) => [p.t, p.lower]),
+    },
+    {
+      ...helper,
+      name: `${pair.upper.label} ${pair.upper.variable}`,
       areaStyle: { color, opacity: 0.14 },
       data: points.map((p) => [p.t, p.delta]),
     },
@@ -204,7 +208,8 @@ export function buildChartOption(
     title: { text: title, left: 0, top: 0, textStyle: { fontSize: 15, fontWeight: 600 } },
     tooltip: { trigger: 'axis' },
     legend: { top: 26, left: 0, type: 'scroll', data: lineSeries.map((s) => s.label) },
-    grid: { left: 64, right: 64, top: 64, bottom: 64 },
+    // Right gutter only when a second y-axis sits there.
+    grid: { left: 64, right: axes.length > 1 ? 64 : 16, top: 64, bottom: 64 },
     xAxis: {
       type: 'time',
       axisLabel: {

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -4,14 +4,11 @@ import type { EChartOption } from './EChart'
 import type { GraphPreset } from './stationGraphPresets'
 
 // Builds the ECharts option for one preset chart from the graph-data response.
-// Raw series render as lines; daily-aggregated series render as a mean line
-// plus a shaded min→max band (two stacked helper series).
 
-// Fixed palette so a series' min-max band always shades in ITS line's color
-// (auto-assignment gave the invisible band helpers their own colors).
+// Fixed palette so a band always shades in its line's color (auto-assignment
+// gave the invisible band helpers their own colors).
 const SERIES_COLORS = ['#2563eb', '#dc2626', '#059669', '#d97706', '#7c3aed', '#0891b2']
 
-// Series grouped onto up to two y-axes by unit (°F and % on one chart, etc.).
 function unitAxes(series: GraphSeries[]): string[] {
   const units: string[] = []
   for (const s of series) {
@@ -25,10 +22,6 @@ function axisIndexFor(unit: string, axes: string[]): number {
   return index === -1 ? 0 : index
 }
 
-// One ECharts series per data series. Raw series plot their points;
-// daily-aggregated series plot their mean line. symbolsOnly (direction charts)
-// renders disconnected dots instead of a line; bar presets (precipitation)
-// render bars. Comparison stations dash their lines / fade their bars.
 function seriesFor(
   s: GraphSeries,
   yAxisIndex: number,
@@ -72,7 +65,6 @@ export function degreesToRose(deg: number): string {
   return ROSE_16[Math.round(deg / 22.5) % 16]
 }
 
-// Compass scale for wind direction: cardinal tick labels every 45°.
 function degreeAxisOverrides(symbolsOnly: boolean): object {
   if (!symbolsOnly) return {}
   return {
@@ -83,14 +75,14 @@ function degreeAxisOverrides(symbolsOnly: boolean): object {
   }
 }
 
-// Preset-pinned axis bounds (RH 0-100, ...), matching the legacy plot specs.
+// Legacy-pinned axis bounds (RH 0-100, ...).
 function presetAxisOverrides(preset: GraphPreset): object {
   if (!preset.axis) return {}
   return { ...preset.axis, scale: false }
 }
 
-// Legacy-style horizontal reference line (32°F freezing on temperature),
-// carried by its own empty series so it never inherits a real series' identity.
+// Reference line (32°F freezing on temperature) on its own empty series so it
+// never inherits a real series' identity.
 function refLineSeries(preset: GraphPreset): object[] {
   if (preset.refLine === undefined) return []
   return [
@@ -109,9 +101,8 @@ function refLineSeries(preset: GraphPreset): object[] {
   ]
 }
 
-// Mean points regardless of series kind — daily series plot and band on their means.
-// Unless the preset allows negatives (temperature), sub-zero readings are
-// sensor noise and clamp to zero.
+// Daily series plot and band on their means. Sub-zero readings are sensor
+// noise except on temperature; clamp to zero.
 function meanPoints(s: GraphSeries, allowNegative: boolean): [number, number | null][] {
   const points: [number, number | null][] =
     s.kind === 'raw' ? s.points : s.days.map(([t, , mean]) => [t, mean])
@@ -240,10 +231,9 @@ export function buildChartOption(
     )
   }
   return {
-    // Title top-left, legend on its own row below — they no longer collide.
+    // Legend on its own row below the title so they don't collide.
     title: { text: title, left: 0, top: 0, textStyle: { fontSize: 15, fontWeight: 600 } },
-    // Values format per-series (unit appended); the header date formats here —
-    // hourly charts "Wed Jul 30, 14:00", daily-aggregated charts date-only.
+    // Values format per-series; the header date formats here.
     tooltip: {
       trigger: 'axis',
       axisPointer: {
@@ -262,8 +252,7 @@ export function buildChartOption(
       type: 'time',
       axisLabel: {
         hideOverlap: true,
-        // Lead date-level ticks with the day of week ("Mon Jul 20"; hourly
-        // ticks "Mon 14:00") — forecasters think in storm days.
+        // Ticks lead with the day of week — forecasters think in storm days.
         formatter: {
           year: '{yyyy}',
           month: '{MMM} {yyyy}',
@@ -273,8 +262,7 @@ export function buildChartOption(
         },
       },
     },
-    // Unit reads along the axis (rotated, centered) instead of a clipped label
-    // floating above the axis top.
+    // Unit reads along the axis — a name above the axis top gets clipped.
     yAxis: axes.map((unit, i) => ({
       type: 'value',
       name: unit,

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -149,6 +149,62 @@ function refLineFor(preset: GraphPreset): object {
   }
 }
 
+// Mean points regardless of series kind — daily series band on their means.
+function meanPoints(s: GraphSeries): [number, number | null][] {
+  if (s.kind === 'raw') return s.points
+  return s.days.map(([t, , mean]) => [t, mean])
+}
+
+type BandPair = { lower: GraphSeries; upper: GraphSeries }
+
+// Per station: when both band edges are present they render as a shaded band
+// instead of their own lines. Stations missing an edge keep plain lines.
+function bandPairsByStid(
+  series: GraphSeries[],
+  band: NonNullable<GraphPreset['band']>,
+): Map<string, BandPair> {
+  const pairs = new Map<string, BandPair>()
+  for (const s of series) {
+    if (pairs.has(s.stid)) continue
+    const lower = series.find((c) => c.stid === s.stid && c.variable === band.lower)
+    const upper = series.find((c) => c.stid === s.stid && c.variable === band.upper)
+    if (lower && upper) pairs.set(s.stid, { lower, upper })
+  }
+  return pairs
+}
+
+// Lower→upper shaded band: a transparent "floor" line at the lower edge,
+// stacked with (upper − lower) area on top. Aligned by timestamp; gaps in
+// either edge break the band rather than guessing.
+function bandSeries(pair: BandPair, yAxisIndex: number, color: string): object[] {
+  const lowerByTime = new Map(meanPoints(pair.lower))
+  const points = meanPoints(pair.upper).map(([t, upper]) => {
+    const lower = lowerByTime.get(t) ?? null
+    return { t, lower, delta: lower !== null && upper !== null ? upper - lower : null }
+  })
+  const stack = `band-${pair.lower.stid}`
+  const helper = {
+    type: 'line',
+    color,
+    yAxisIndex,
+    stack,
+    showSymbol: false,
+    lineStyle: { opacity: 0 },
+    tooltip: { show: false },
+    legendHoverLink: false,
+    silent: true,
+  }
+  return [
+    { ...helper, name: `${pair.lower.label} band`, data: points.map((p) => [p.t, p.lower]) },
+    {
+      ...helper,
+      name: `${pair.upper.label} band`,
+      areaStyle: { color, opacity: 0.14 },
+      data: points.map((p) => [p.t, p.delta]),
+    },
+  ]
+}
+
 // Tooltip values as "SW (225°)" on direction charts.
 function directionTooltip(symbolsOnly: boolean): object {
   if (!symbolsOnly) return {}
@@ -169,20 +225,34 @@ export function buildChartOption(
 ): EChartOption {
   const title = preset.title
   const symbolsOnly = preset.symbolsOnly ?? false
-  const axes = unitAxes(data.series)
-  const series = data.series.flatMap((s, i) => {
+  const bands = preset.band
+    ? bandPairsByStid(data.series, preset.band)
+    : new Map<string, BandPair>()
+  const lineSeries = data.series.filter((s) => {
+    const pair = bands.get(s.stid)
+    return !pair || (s !== pair.lower && s !== pair.upper)
+  })
+  const axes = unitAxes(lineSeries)
+  const colorFor = (i: number) => SERIES_COLORS[i % SERIES_COLORS.length]
+  const series = lineSeries.flatMap((s, i) => {
     const yAxisIndex = axisIndexFor(s.unit, axes)
-    const color = SERIES_COLORS[i % SERIES_COLORS.length]
     const dashed = primaryStids !== undefined && !primaryStids.includes(s.stid)
-    const built = seriesFor(s, yAxisIndex, color, symbolsOnly, dashed)
+    const built = seriesFor(s, yAxisIndex, colorFor(i), symbolsOnly, dashed)
     if (i === 0) Object.assign(built[0], refLineFor(preset))
     return built
   })
+  // Each band shades in the color of its station's line so they read as one.
+  for (const [stid, pair] of bands) {
+    const lineIndex = lineSeries.findIndex((s) => s.stid === stid)
+    series.push(
+      ...bandSeries(pair, axisIndexFor(pair.lower.unit, axes), colorFor(Math.max(lineIndex, 0))),
+    )
+  }
   return {
     // Title top-left, legend on its own row below — they no longer collide.
     title: { text: title, left: 0, top: 0, textStyle: { fontSize: 15, fontWeight: 600 } },
     tooltip: { trigger: 'axis' },
-    legend: { top: 26, left: 0, type: 'scroll', data: data.series.map((s) => s.label) },
+    legend: { top: 26, left: 0, type: 'scroll', data: lineSeries.map((s) => s.label) },
     grid: { left: 64, right: 64, top: 64, bottom: 64 },
     xAxis: {
       type: 'time',

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -24,26 +24,34 @@ function axisIndexFor(unit: string, axes: string[]): number {
   return index === -1 ? 0 : index
 }
 
-// One ECharts line per series. Raw series plot their points; daily-aggregated
-// series plot their mean line. symbolsOnly (direction charts) renders
-// disconnected dots instead of a line.
+// One ECharts series per data series. Raw series plot their points;
+// daily-aggregated series plot their mean line. symbolsOnly (direction charts)
+// renders disconnected dots instead of a line; bar presets (precipitation)
+// render bars. Comparison stations dash their lines / fade their bars.
 function seriesFor(
   s: GraphSeries,
   yAxisIndex: number,
   color: string,
-  symbolsOnly: boolean,
+  preset: GraphPreset,
   dashed: boolean,
 ): object {
-  return {
+  const symbolsOnly = preset.symbolsOnly ?? false
+  const base = {
     name: s.label,
-    type: 'line',
     color,
     yAxisIndex,
+    data: meanPoints(s),
+  }
+  if (preset.bar) {
+    return { ...base, type: 'bar', itemStyle: dashed ? { opacity: 0.6 } : undefined }
+  }
+  return {
+    ...base,
+    type: 'line',
     showSymbol: symbolsOnly,
     symbolSize: 4,
     lineStyle: symbolsOnly ? { opacity: 0 } : dashed ? { type: 'dashed' } : undefined,
     connectNulls: false,
-    data: meanPoints(s),
     ...directionTooltip(symbolsOnly),
   }
 }
@@ -193,7 +201,7 @@ export function buildChartOption(
   const series: object[] = lineSeries.map((s, i) => {
     const yAxisIndex = axisIndexFor(s.unit, axes)
     const dashed = primaryStids !== undefined && !primaryStids.includes(s.stid)
-    return seriesFor(s, yAxisIndex, colorFor(i), symbolsOnly, dashed)
+    return seriesFor(s, yAxisIndex, colorFor(i), preset, dashed)
   })
   series.push(...refLineSeries(preset))
   // Each band shades in the color of its station's line so they read as one.
@@ -206,7 +214,13 @@ export function buildChartOption(
   return {
     // Title top-left, legend on its own row below — they no longer collide.
     title: { text: title, left: 0, top: 0, textStyle: { fontSize: 15, fontWeight: 600 } },
-    tooltip: { trigger: 'axis' },
+    // Legacy hover precision: line plots 1 decimal, bar plots (precip) 2.
+    // Direction charts override per-series with the wind-rose formatter.
+    tooltip: {
+      trigger: 'axis',
+      valueFormatter: (value: unknown) =>
+        typeof value === 'number' ? value.toFixed(preset.decimals ?? (preset.bar ? 2 : 1)) : '–',
+    },
     legend: { top: 26, left: 0, type: 'scroll', data: lineSeries.map((s) => s.label) },
     // Right gutter only when a second y-axis sits there.
     grid: { left: 64, right: axes.length > 1 ? 64 : 16, top: 64, bottom: 64 },

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -24,82 +24,28 @@ function axisIndexFor(unit: string, axes: string[]): number {
   return index === -1 ? 0 : index
 }
 
-function rawSeries(
-  s: GraphSeries & { kind: 'raw' },
-  yAxisIndex: number,
-  color: string,
-  symbolsOnly: boolean,
-  dashed: boolean,
-): object[] {
-  return [
-    {
-      name: s.label,
-      type: 'line',
-      color,
-      yAxisIndex,
-      showSymbol: symbolsOnly,
-      symbolSize: 4,
-      lineStyle: symbolsOnly ? { opacity: 0 } : dashed ? { type: 'dashed' } : undefined,
-      connectNulls: false,
-      data: s.points,
-      ...directionTooltip(symbolsOnly),
-    },
-  ]
-}
-
-// Daily vector-mean dots for direction charts on aggregated windows.
-function dailyMeanDots(
-  s: GraphSeries & { kind: 'daily' },
-  yAxisIndex: number,
-  color: string,
-): object[] {
-  return [
-    {
-      name: s.label,
-      type: 'line',
-      color,
-      yAxisIndex,
-      showSymbol: true,
-      symbolSize: 4,
-      lineStyle: { opacity: 0 },
-      data: s.days.map(([t, , mean]) => [t, mean]),
-      ...directionTooltip(true),
-    },
-  ]
-}
-
-// Daily-aggregated series render as the mean line (the min→max band was
-// dropped in review — it read as a stray shadow).
-function dailySeries(
-  s: GraphSeries & { kind: 'daily' },
-  yAxisIndex: number,
-  color: string,
-  dashed: boolean,
-): object[] {
-  return [
-    {
-      name: s.label,
-      type: 'line',
-      color,
-      yAxisIndex,
-      showSymbol: false,
-      lineStyle: dashed ? { type: 'dashed' } : undefined,
-      data: s.days.map(([t, , mean]) => [t, mean]),
-    },
-  ]
-}
-
+// One ECharts line per series. Raw series plot their points; daily-aggregated
+// series plot their mean line. symbolsOnly (direction charts) renders
+// disconnected dots instead of a line.
 function seriesFor(
   s: GraphSeries,
   yAxisIndex: number,
   color: string,
   symbolsOnly: boolean,
   dashed: boolean,
-): object[] {
-  if (s.kind === 'raw') return rawSeries(s, yAxisIndex, color, symbolsOnly, dashed)
-  return symbolsOnly
-    ? dailyMeanDots(s, yAxisIndex, color)
-    : dailySeries(s, yAxisIndex, color, dashed)
+): object {
+  return {
+    name: s.label,
+    type: 'line',
+    color,
+    yAxisIndex,
+    showSymbol: symbolsOnly,
+    symbolSize: 4,
+    lineStyle: symbolsOnly ? { opacity: 0 } : dashed ? { type: 'dashed' } : undefined,
+    connectNulls: false,
+    data: meanPoints(s),
+    ...directionTooltip(symbolsOnly),
+  }
 }
 
 const AXIS_CARDINALS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW']
@@ -135,21 +81,26 @@ function presetAxisOverrides(preset: GraphPreset): object {
 }
 
 // Legacy-style horizontal reference line (32°F freezing on temperature),
-// attached to the first series.
-function refLineFor(preset: GraphPreset): object {
-  if (preset.refLine === undefined) return {}
-  return {
-    markLine: {
+// carried by its own empty series so it never inherits a real series' identity.
+function refLineSeries(preset: GraphPreset): object[] {
+  if (preset.refLine === undefined) return []
+  return [
+    {
+      type: 'line',
+      data: [],
       silent: true,
-      symbol: 'none',
-      lineStyle: { type: 'dashed', color: '#94a3b8' },
-      label: { position: 'insideEndTop', formatter: String(preset.refLine) },
-      data: [{ yAxis: preset.refLine }],
+      markLine: {
+        silent: true,
+        symbol: 'none',
+        lineStyle: { type: 'dashed', color: '#94a3b8' },
+        label: { position: 'insideEndTop', formatter: String(preset.refLine) },
+        data: [{ yAxis: preset.refLine }],
+      },
     },
-  }
+  ]
 }
 
-// Mean points regardless of series kind — daily series band on their means.
+// Mean points regardless of series kind — daily series plot and band on their means.
 function meanPoints(s: GraphSeries): [number, number | null][] {
   if (s.kind === 'raw') return s.points
   return s.days.map(([t, , mean]) => [t, mean])
@@ -225,6 +176,7 @@ export function buildChartOption(
 ): EChartOption {
   const title = preset.title
   const symbolsOnly = preset.symbolsOnly ?? false
+  const minValueSpan = (data.aggregated ? 6 * 24 : 6) * 60 * 60 * 1000
   const bands = preset.band
     ? bandPairsByStid(data.series, preset.band)
     : new Map<string, BandPair>()
@@ -234,13 +186,12 @@ export function buildChartOption(
   })
   const axes = unitAxes(lineSeries)
   const colorFor = (i: number) => SERIES_COLORS[i % SERIES_COLORS.length]
-  const series = lineSeries.flatMap((s, i) => {
+  const series: object[] = lineSeries.map((s, i) => {
     const yAxisIndex = axisIndexFor(s.unit, axes)
     const dashed = primaryStids !== undefined && !primaryStids.includes(s.stid)
-    const built = seriesFor(s, yAxisIndex, colorFor(i), symbolsOnly, dashed)
-    if (i === 0) Object.assign(built[0], refLineFor(preset))
-    return built
+    return seriesFor(s, yAxisIndex, colorFor(i), symbolsOnly, dashed)
   })
+  series.push(...refLineSeries(preset))
   // Each band shades in the color of its station's line so they read as one.
   for (const [stid, pair] of bands) {
     const lineIndex = lineSeries.findIndex((s) => s.stid === stid)
@@ -284,13 +235,10 @@ export function buildChartOption(
       ...degreeAxisOverrides(symbolsOnly),
       ...presetAxisOverrides(preset),
     })),
-    dataZoom: (() => {
-      const minValueSpan = (data.aggregated ? 6 * 24 : 6) * 60 * 60 * 1000
-      return [
-        { type: 'inside', xAxisIndex: 0, minValueSpan },
-        { type: 'slider', xAxisIndex: 0, height: 18, bottom: 8, minValueSpan },
-      ]
-    })(),
+    dataZoom: [
+      { type: 'inside', xAxisIndex: 0, minValueSpan },
+      { type: 'slider', xAxisIndex: 0, height: 18, bottom: 8, minValueSpan },
+    ],
     series,
   }
 }

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -154,15 +154,17 @@ function bandSeries(pair: BandPair, yAxisIndex: number, color: string): object[]
     legendHoverLink: false,
     silent: true,
   }
+  // Helpers share the station's legend name so hiding the station via the
+  // legend hides its band too.
   return [
     {
       ...helper,
-      name: `${pair.lower.label} ${pair.lower.variable}`,
+      name: pair.lower.label,
       data: points.map((p) => [p.t, p.lower]),
     },
     {
       ...helper,
-      name: `${pair.upper.label} ${pair.upper.variable}`,
+      name: pair.upper.label,
       areaStyle: { color, opacity: 0.14 },
       data: points.map((p) => [p.t, p.delta]),
     },

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -34,7 +34,7 @@ function seriesFor(
     name: s.label,
     color,
     yAxisIndex,
-    data: meanPoints(s, preset.allowNegative ?? false),
+    data: meanPoints(s),
     ...(symbolsOnly ? directionTooltip() : unitTooltip(s.unit)),
   }
   if (preset.bar) {
@@ -101,13 +101,10 @@ function refLineSeries(preset: GraphPreset): object[] {
   ]
 }
 
-// Daily series plot and band on their means. Sub-zero readings are sensor
-// noise except on temperature; clamp to zero.
-function meanPoints(s: GraphSeries, allowNegative: boolean): [number, number | null][] {
-  const points: [number, number | null][] =
-    s.kind === 'raw' ? s.points : s.days.map(([t, , mean]) => [t, mean])
-  if (allowNegative) return points
-  return points.map(([t, v]) => [t, v === null ? v : Math.max(0, v)])
+// Daily series plot and band on their means.
+function meanPoints(s: GraphSeries): [number, number | null][] {
+  if (s.kind === 'raw') return s.points
+  return s.days.map(([t, , mean]) => [t, mean])
 }
 
 type BandPair = { lower: GraphSeries; upper: GraphSeries }
@@ -131,14 +128,9 @@ function bandPairsByStid(
 // Lower→upper shaded band: a transparent "floor" line at the lower edge,
 // stacked with (upper − lower) area on top. Aligned by timestamp; gaps in
 // either edge break the band rather than guessing.
-function bandSeries(
-  pair: BandPair,
-  yAxisIndex: number,
-  color: string,
-  allowNegative: boolean,
-): object[] {
-  const lowerByTime = new Map(meanPoints(pair.lower, allowNegative))
-  const points = meanPoints(pair.upper, allowNegative).map(([t, upper]) => {
+function bandSeries(pair: BandPair, yAxisIndex: number, color: string): object[] {
+  const lowerByTime = new Map(meanPoints(pair.lower))
+  const points = meanPoints(pair.upper).map(([t, upper]) => {
     const lower = lowerByTime.get(t) ?? null
     return { t, lower, delta: lower !== null && upper !== null ? upper - lower : null }
   })
@@ -222,12 +214,7 @@ export function buildChartOption(
   for (const [stid, pair] of bands) {
     const lineIndex = lineSeries.findIndex((s) => s.stid === stid)
     series.push(
-      ...bandSeries(
-        pair,
-        axisIndexFor(pair.lower.unit, axes),
-        colorFor(Math.max(lineIndex, 0)),
-        preset.allowNegative ?? false,
-      ),
+      ...bandSeries(pair, axisIndexFor(pair.lower.unit, axes), colorFor(Math.max(lineIndex, 0))),
     )
   }
   return {

--- a/src/components/WeatherStations/stationGraphPrefs.ts
+++ b/src/components/WeatherStations/stationGraphPrefs.ts
@@ -1,6 +1,5 @@
 // Per-browser chart arrangement for the station Graphs tab: preset order plus
-// hidden charts, persisted to localStorage. The reconciled shape is the seed of
-// the v2 self-serve builder's chart config.
+// hidden charts, persisted to localStorage.
 
 export type ChartPrefs = { order: string[]; hidden: string[] }
 

--- a/src/components/WeatherStations/stationGraphPrefs.ts
+++ b/src/components/WeatherStations/stationGraphPrefs.ts
@@ -1,0 +1,79 @@
+// Per-browser chart arrangement for the station Graphs tab: preset order plus
+// hidden charts, persisted to localStorage. The reconciled shape is the seed of
+// the v2 self-serve builder's chart config.
+
+export type ChartPrefs = { order: string[]; hidden: string[] }
+
+const STORAGE_KEY = 'nwac-station-graph-prefs'
+
+export function defaultChartPrefs(presetKeys: string[]): ChartPrefs {
+  return { order: [...presetKeys], hidden: [] }
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string')
+}
+
+function isStoredPrefs(value: unknown): value is ChartPrefs {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'order' in value &&
+    'hidden' in value &&
+    isStringArray(value.order) &&
+    isStringArray(value.hidden)
+  )
+}
+
+// Stored prefs survive preset changes: unknown keys drop out, presets added
+// since the save append in their default position.
+export function reconcileChartPrefs(stored: ChartPrefs, presetKeys: string[]): ChartPrefs {
+  const known = new Set(presetKeys)
+  const order = stored.order.filter((key) => known.has(key))
+  for (const key of presetKeys) {
+    if (!order.includes(key)) order.push(key)
+  }
+  return { order, hidden: stored.hidden.filter((key) => known.has(key)) }
+}
+
+export function loadChartPrefs(presetKeys: string[]): ChartPrefs {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return defaultChartPrefs(presetKeys)
+    const parsed: unknown = JSON.parse(raw)
+    if (!isStoredPrefs(parsed)) return defaultChartPrefs(presetKeys)
+    return reconcileChartPrefs(parsed, presetKeys)
+  } catch {
+    return defaultChartPrefs(presetKeys)
+  }
+}
+
+export function saveChartPrefs(prefs: ChartPrefs): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs))
+  } catch {
+    // Private mode / quota errors just lose persistence, never the feature.
+  }
+}
+
+// Swaps `key` with its nearest neighbor in `direction`, skipping keys the
+// caller marks unswappable (hidden charts, charts with no data on this
+// station). Returns `order` unchanged when there is no such neighbor.
+export function swapWithNeighbor(
+  order: string[],
+  key: string,
+  direction: -1 | 1,
+  isSkippable: (key: string) => boolean,
+): string[] {
+  const from = order.indexOf(key)
+  if (from === -1) return order
+  let to = from + direction
+  while (to >= 0 && to < order.length && isSkippable(order[to])) {
+    to += direction
+  }
+  if (to < 0 || to >= order.length) return order
+  const next = [...order]
+  next[from] = order[to]
+  next[to] = order[from]
+  return next
+}

--- a/src/components/WeatherStations/stationGraphPrefs.ts
+++ b/src/components/WeatherStations/stationGraphPrefs.ts
@@ -1,3 +1,5 @@
+import { readLocalStorage, writeLocalStorage } from '@/utilities/safeLocalStorage'
+
 // Per-browser chart arrangement for the station Graphs tab: preset order plus
 // hidden charts, persisted to localStorage.
 
@@ -36,23 +38,20 @@ export function reconcileChartPrefs(stored: ChartPrefs, presetKeys: string[]): C
 }
 
 export function loadChartPrefs(presetKeys: string[]): ChartPrefs {
+  const raw = readLocalStorage(STORAGE_KEY)
+  if (!raw) return defaultChartPrefs(presetKeys)
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY)
-    if (!raw) return defaultChartPrefs(presetKeys)
     const parsed: unknown = JSON.parse(raw)
-    if (!isStoredPrefs(parsed)) return defaultChartPrefs(presetKeys)
-    return reconcileChartPrefs(parsed, presetKeys)
+    return isStoredPrefs(parsed)
+      ? reconcileChartPrefs(parsed, presetKeys)
+      : defaultChartPrefs(presetKeys)
   } catch {
     return defaultChartPrefs(presetKeys)
   }
 }
 
 export function saveChartPrefs(prefs: ChartPrefs): void {
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs))
-  } catch {
-    // Private mode / quota errors just lose persistence, never the feature.
-  }
+  writeLocalStorage(STORAGE_KEY, JSON.stringify(prefs))
 }
 
 // Swaps `key` with its nearest non-skippable neighbor in `direction`;

--- a/src/components/WeatherStations/stationGraphPrefs.ts
+++ b/src/components/WeatherStations/stationGraphPrefs.ts
@@ -55,9 +55,8 @@ export function saveChartPrefs(prefs: ChartPrefs): void {
   }
 }
 
-// Swaps `key` with its nearest neighbor in `direction`, skipping keys the
-// caller marks unswappable (hidden charts, charts with no data on this
-// station). Returns `order` unchanged when there is no such neighbor.
+// Swaps `key` with its nearest non-skippable neighbor in `direction`;
+// returns `order` unchanged when there is none.
 export function swapWithNeighbor(
   order: string[],
   key: string,

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -1,0 +1,49 @@
+import type { WeatherStationGroup } from '@/constants/weatherStations'
+
+// Fixed public presets for the station Graphs tab (grill-me 2026-07-20): each
+// chart names the variables it wants; a station only gets the charts (and
+// variables) its registry columns actually configure.
+
+export type GraphPreset = {
+  key: string
+  title: string
+  variables: string[]
+}
+
+const PRESETS: GraphPreset[] = [
+  { key: 'temp', title: 'Temperature & Humidity', variables: ['air_temp', 'relative_humidity'] },
+  { key: 'wind', title: 'Wind', variables: ['wind_speed', 'wind_gust'] },
+  {
+    key: 'snow',
+    title: 'Snow Depth & Precipitation',
+    variables: ['snow_depth', 'snow_depth_24h', 'precip_accum_one_hour'],
+  },
+  { key: 'solar', title: 'Solar Radiation', variables: ['solar_radiation'] },
+]
+
+export type GraphWindow = { key: string; label: string; hours: number }
+
+export const GRAPH_WINDOWS: GraphWindow[] = [
+  { key: '24h', label: '24 hours', hours: 24 },
+  { key: '7d', label: '7 days', hours: 7 * 24 },
+  { key: '30d', label: '30 days', hours: 30 * 24 },
+  // "Season" = back to Oct 1; approximated as a trailing window server-side.
+  { key: 'season', label: 'Season', hours: 0 },
+]
+
+// Hours back to the most recent Oct 1 (the season anchor).
+export function seasonHours(now: Date): number {
+  const year = now.getMonth() >= 9 ? now.getFullYear() : now.getFullYear() - 1
+  const seasonStart = new Date(Date.UTC(year, 9, 1))
+  return Math.max(24, Math.ceil((now.getTime() - seasonStart.getTime()) / (60 * 60 * 1000)))
+}
+
+// The presets a station group supports, with variables trimmed to what its
+// registry columns configure.
+export function presetsForGroup(group: WeatherStationGroup): GraphPreset[] {
+  const configured = new Set(group.columns.map(([, variable]) => variable))
+  return PRESETS.flatMap((preset) => {
+    const variables = preset.variables.filter((v) => configured.has(v))
+    return variables.length > 0 ? [{ ...preset, variables }] : []
+  })
+}

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -28,6 +28,8 @@ export const GRAPH_WINDOWS: GraphWindow[] = [
   { key: '24h', label: '24 hours', hours: 24 },
   { key: '7d', label: '7 days', hours: 7 * 24 },
   { key: '30d', label: '30 days', hours: 30 * 24 },
+  { key: '3m', label: '3 months', hours: 91 * 24 },
+  { key: '6m', label: '6 months', hours: 182 * 24 },
   // "Season" = back to Oct 1; approximated as a trailing window server-side.
   { key: 'season', label: 'Season', hours: 0 },
 ]

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -10,11 +10,20 @@ export type GraphPreset = {
   variables: string[]
   /** Dots instead of a connected line (wind direction wraps at 360°). */
   symbolsOnly?: boolean
+  /** Fixed y-axis bounds (legacy pins some, e.g. RH 0-100). */
+  axis?: { min?: number; max?: number }
+  /** Horizontal reference line (legacy: 32°F freezing line on temperature). */
+  refLine?: number
 }
 
 const PRESETS: GraphPreset[] = [
-  { key: 'temp', title: 'Temperature', variables: ['air_temp'] },
-  { key: 'rh', title: 'Relative Humidity', variables: ['relative_humidity'] },
+  { key: 'temp', title: 'Temperature', variables: ['air_temp'], refLine: 32 },
+  {
+    key: 'rh',
+    title: 'Relative Humidity',
+    variables: ['relative_humidity'],
+    axis: { min: 0, max: 100 },
+  },
   {
     key: 'wind',
     title: 'Wind Speed',
@@ -26,8 +35,12 @@ const PRESETS: GraphPreset[] = [
   { key: 'snow24', title: '24 Hour Snow Total', variables: ['snow_depth_24h', 'snow_depth_24hr'] },
   { key: 'intersnow', title: 'Intermittent Snow', variables: ['intermittent_snow'] },
   { key: 'precip', title: 'Precipitation', variables: ['precip_accum_one_hour'] },
-  { key: 'solar', title: 'Solar Radiation', variables: ['solar_radiation'] },
+  // Legacy naming per the WP plugin's snowobs mapping: "Solar Radiation" is the
+  // net_solar sensor; "Solar Pyranometer" is snowobs solar_radiation.
+  { key: 'solar', title: 'Solar Radiation', variables: ['net_solar'] },
+  { key: 'pyranometer', title: 'Solar Pyranometer', variables: ['solar_radiation'] },
   { key: 'pressure', title: 'Barometric Pressure', variables: ['pressure'] },
+  { key: 'battery', title: 'Battery Voltage', variables: ['battery_voltage'] },
   { key: 'equiptemp', title: 'Equipment Temperature', variables: ['equip_temperature'] },
 ]
 

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -8,18 +8,27 @@ export type GraphPreset = {
   key: string
   title: string
   variables: string[]
+  /** Dots instead of a connected line (wind direction wraps at 360°). */
+  symbolsOnly?: boolean
 }
 
 const PRESETS: GraphPreset[] = [
   { key: 'temp', title: 'Temperature', variables: ['air_temp'] },
   { key: 'rh', title: 'Relative Humidity', variables: ['relative_humidity'] },
-  { key: 'wind', title: 'Wind', variables: ['wind_speed', 'wind_gust'] },
   {
-    key: 'snow',
-    title: 'Snow Depth & Precipitation',
-    variables: ['snow_depth', 'snow_depth_24h', 'precip_accum_one_hour'],
+    key: 'wind',
+    title: 'Wind Speed',
+    variables: ['wind_speed_min', 'wind_speed', 'wind_gust'],
   },
+  { key: 'winddir', title: 'Wind Direction', variables: ['wind_direction'], symbolsOnly: true },
+  { key: 'snowdepth', title: 'Total Snow Depth', variables: ['snow_depth'] },
+  // Both 24h-snow sensor spellings exist across the registry.
+  { key: 'snow24', title: '24 Hour Snow Total', variables: ['snow_depth_24h', 'snow_depth_24hr'] },
+  { key: 'intersnow', title: 'Intermittent Snow', variables: ['intermittent_snow'] },
+  { key: 'precip', title: 'Precipitation', variables: ['precip_accum_one_hour'] },
   { key: 'solar', title: 'Solar Radiation', variables: ['solar_radiation'] },
+  { key: 'pressure', title: 'Barometric Pressure', variables: ['pressure'] },
+  { key: 'equiptemp', title: 'Equipment Temperature', variables: ['equip_temperature'] },
 ]
 
 export type GraphWindow = { key: string; label: string; hours: number }
@@ -41,12 +50,9 @@ export function seasonHours(now: Date): number {
   return Math.max(24, Math.ceil((now.getTime() - seasonStart.getTime()) / (60 * 60 * 1000)))
 }
 
-// The presets a station group supports, with variables trimmed to what its
-// registry columns configure.
-export function presetsForGroup(group: WeatherStationGroup): GraphPreset[] {
-  const configured = new Set(group.columns.map(([, variable]) => variable))
-  return PRESETS.flatMap((preset) => {
-    const variables = preset.variables.filter((v) => configured.has(v))
-    return variables.length > 0 ? [{ ...preset, variables }] : []
-  })
+// All presets are offered to every station: the registry's columns only cover
+// the NOW-table subset, while loggers report more sensors (pressure, equip
+// temp, ...). Charts whose fetch returns no series hide themselves instead.
+export function presetsForGroup(_group: WeatherStationGroup): GraphPreset[] {
+  return PRESETS
 }

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -11,7 +11,8 @@ export type GraphPreset = {
 }
 
 const PRESETS: GraphPreset[] = [
-  { key: 'temp', title: 'Temperature & Humidity', variables: ['air_temp', 'relative_humidity'] },
+  { key: 'temp', title: 'Temperature', variables: ['air_temp'] },
+  { key: 'rh', title: 'Relative Humidity', variables: ['relative_humidity'] },
   { key: 'wind', title: 'Wind', variables: ['wind_speed', 'wind_gust'] },
   {
     key: 'snow',

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -15,6 +15,10 @@ export type GraphPreset = {
   /** Render these two variables as a shaded band instead of their own lines
    * (wind: min→gust around the speed line). */
   band?: { lower: string; upper: string }
+  /** Bars instead of a line (legacy renders precipitation as a bar plot). */
+  bar?: boolean
+  /** Tooltip decimal places; defaults to 1 (legacy line-plot hover), 2 on bars. */
+  decimals?: number
 }
 
 // Every station gets the full preset list: the registry's columns only cover
@@ -39,7 +43,7 @@ export const STATION_GRAPH_PRESETS: GraphPreset[] = [
   // Both 24h-snow sensor spellings exist across the registry.
   { key: 'snow24', title: '24 Hour Snow Total', variables: ['snow_depth_24h', 'snow_depth_24hr'] },
   { key: 'intersnow', title: 'Intermittent Snow', variables: ['intermittent_snow'] },
-  { key: 'precip', title: 'Precipitation', variables: ['precip_accum_one_hour'] },
+  { key: 'precip', title: 'Precipitation', variables: ['precip_accum_one_hour'], bar: true },
   // Legacy naming per the WP plugin's snowobs mapping: "Solar Radiation" is the
   // net_solar sensor; "Solar Pyranometer" is snowobs solar_radiation.
   { key: 'solar', title: 'Solar Radiation', variables: ['net_solar'] },

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -1,4 +1,5 @@
 import type { WeatherStationGroup } from '@/constants/weatherStations'
+import { differenceInHours } from 'date-fns'
 
 // Fixed public presets for the station Graphs tab (grill-me 2026-07-20): each
 // chart names the variables it wants; a station only gets the charts (and
@@ -64,7 +65,7 @@ export const GRAPH_WINDOWS: GraphWindow[] = [
 export function seasonHours(now: Date): number {
   const year = now.getMonth() >= 9 ? now.getFullYear() : now.getFullYear() - 1
   const seasonStart = new Date(Date.UTC(year, 9, 1))
-  return Math.max(24, Math.ceil((now.getTime() - seasonStart.getTime()) / (60 * 60 * 1000)))
+  return Math.max(24, differenceInHours(now, seasonStart, { roundingMethod: 'ceil' }))
 }
 
 // All presets are offered to every station: the registry's columns only cover

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -22,9 +22,8 @@ export type GraphPreset = {
   allowNegative?: boolean
 }
 
-// Every station gets the full preset list: the registry's columns only cover
-// the NOW-table subset, while loggers report more sensors (pressure, equip
-// temp, ...). Charts whose variables come back without data hide themselves.
+// Every station gets the full preset list — loggers report more sensors than
+// the registry's NOW-table columns. Charts with no data hide themselves.
 export const STATION_GRAPH_PRESETS: GraphPreset[] = [
   { key: 'temp', title: 'Temperature', variables: ['air_temp'], refLine: 32, allowNegative: true },
   {

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -14,6 +14,9 @@ export type GraphPreset = {
   axis?: { min?: number; max?: number }
   /** Horizontal reference line (legacy: 32°F freezing line on temperature). */
   refLine?: number
+  /** Render these two variables as a shaded band instead of their own lines
+   * (wind: min→gust around the speed line). */
+  band?: { lower: string; upper: string }
 }
 
 const PRESETS: GraphPreset[] = [
@@ -28,6 +31,7 @@ const PRESETS: GraphPreset[] = [
     key: 'wind',
     title: 'Wind Speed',
     variables: ['wind_speed_min', 'wind_speed', 'wind_gust'],
+    band: { lower: 'wind_speed_min', upper: 'wind_gust' },
   },
   { key: 'winddir', title: 'Wind Direction', variables: ['wind_direction'], symbolsOnly: true },
   { key: 'snowdepth', title: 'Total Snow Depth', variables: ['snow_depth'] },

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -17,13 +17,16 @@ export type GraphPreset = {
   band?: { lower: string; upper: string }
   /** Bars instead of a line (legacy renders precipitation as a bar plot). */
   bar?: boolean
+  /** Sub-zero readings are real (temperature); everywhere else they're sensor
+   * noise and clamp to zero. */
+  allowNegative?: boolean
 }
 
 // Every station gets the full preset list: the registry's columns only cover
 // the NOW-table subset, while loggers report more sensors (pressure, equip
 // temp, ...). Charts whose variables come back without data hide themselves.
 export const STATION_GRAPH_PRESETS: GraphPreset[] = [
-  { key: 'temp', title: 'Temperature', variables: ['air_temp'], refLine: 32 },
+  { key: 'temp', title: 'Temperature', variables: ['air_temp'], refLine: 32, allowNegative: true },
   {
     key: 'rh',
     title: 'Relative Humidity',

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -1,9 +1,6 @@
-import type { WeatherStationGroup } from '@/constants/weatherStations'
+import { NWAC_DISPLAY_TIMEZONE } from '@/services/snowobs/constants'
+import { TZDate } from '@date-fns/tz'
 import { differenceInHours } from 'date-fns'
-
-// Fixed public presets for the station Graphs tab (grill-me 2026-07-20): each
-// chart names the variables it wants; a station only gets the charts (and
-// variables) its registry columns actually configure.
 
 export type GraphPreset = {
   key: string
@@ -20,7 +17,10 @@ export type GraphPreset = {
   band?: { lower: string; upper: string }
 }
 
-const PRESETS: GraphPreset[] = [
+// Every station gets the full preset list: the registry's columns only cover
+// the NOW-table subset, while loggers report more sensors (pressure, equip
+// temp, ...). Charts whose variables come back without data hide themselves.
+export const STATION_GRAPH_PRESETS: GraphPreset[] = [
   { key: 'temp', title: 'Temperature', variables: ['air_temp'], refLine: 32 },
   {
     key: 'rh',
@@ -49,28 +49,25 @@ const PRESETS: GraphPreset[] = [
   { key: 'equiptemp', title: 'Equipment Temperature', variables: ['equip_temperature'] },
 ]
 
-export type GraphWindow = { key: string; label: string; hours: number }
-
-export const GRAPH_WINDOWS: GraphWindow[] = [
-  { key: '24h', label: '24 hours', hours: 24 },
-  { key: '7d', label: '7 days', hours: 7 * 24 },
-  { key: '30d', label: '30 days', hours: 30 * 24 },
-  { key: '3m', label: '3 months', hours: 91 * 24 },
-  { key: '6m', label: '6 months', hours: 182 * 24 },
-  // "Season" = back to Oct 1; approximated as a trailing window server-side.
-  { key: 'season', label: 'Season', hours: 0 },
-]
-
-// Hours back to the most recent Oct 1 (the season anchor).
+// Hours back to the most recent Oct 1 (the season anchor, display timezone).
 export function seasonHours(now: Date): number {
-  const year = now.getMonth() >= 9 ? now.getFullYear() : now.getFullYear() - 1
-  const seasonStart = new Date(Date.UTC(year, 9, 1))
+  const local = new TZDate(now.getTime(), NWAC_DISPLAY_TIMEZONE)
+  const year = local.getMonth() >= 9 ? local.getFullYear() : local.getFullYear() - 1
+  const seasonStart = new TZDate(year, 9, 1, NWAC_DISPLAY_TIMEZONE)
   return Math.max(24, differenceInHours(now, seasonStart, { roundingMethod: 'ceil' }))
 }
 
-// All presets are offered to every station: the registry's columns only cover
-// the NOW-table subset, while loggers report more sensors (pressure, equip
-// temp, ...). Charts whose fetch returns no series hide themselves instead.
-export function presetsForGroup(_group: WeatherStationGroup): GraphPreset[] {
-  return PRESETS
-}
+export type GraphWindow = { key: string; label: string; hoursBack: (now: Date) => number }
+
+const WEEK_WINDOW: GraphWindow = { key: '7d', label: '7 days', hoursBack: () => 7 * 24 }
+
+export const GRAPH_WINDOWS: GraphWindow[] = [
+  { key: '24h', label: '24 hours', hoursBack: () => 24 },
+  WEEK_WINDOW,
+  { key: '30d', label: '30 days', hoursBack: () => 30 * 24 },
+  { key: '3m', label: '3 months', hoursBack: () => 91 * 24 },
+  { key: '6m', label: '6 months', hoursBack: () => 182 * 24 },
+  { key: 'season', label: 'Season', hoursBack: seasonHours },
+]
+
+export const DEFAULT_GRAPH_WINDOW = WEEK_WINDOW

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -49,7 +49,12 @@ export const STATION_GRAPH_PRESETS: GraphPreset[] = [
   { key: 'solar', title: 'Solar Radiation', variables: ['net_solar'] },
   { key: 'pyranometer', title: 'Solar Pyranometer', variables: ['solar_radiation'] },
   { key: 'pressure', title: 'Barometric Pressure', variables: ['pressure'] },
-  { key: 'equiptemp', title: 'Equipment Temperature', variables: ['equip_temperature'] },
+  {
+    key: 'equiptemp',
+    title: 'Equipment Temperature',
+    variables: ['equip_temperature'],
+    allowNegative: true,
+  },
 ]
 
 // Hours back to the most recent Oct 1 (the season anchor, display timezone).

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -47,7 +47,6 @@ export const STATION_GRAPH_PRESETS: GraphPreset[] = [
   { key: 'solar', title: 'Solar Radiation', variables: ['net_solar'] },
   { key: 'pyranometer', title: 'Solar Pyranometer', variables: ['solar_radiation'] },
   { key: 'pressure', title: 'Barometric Pressure', variables: ['pressure'] },
-  { key: 'battery', title: 'Battery Voltage', variables: ['battery_voltage'] },
   { key: 'equiptemp', title: 'Equipment Temperature', variables: ['equip_temperature'] },
 ]
 

--- a/src/components/WeatherStations/stationGraphPresets.ts
+++ b/src/components/WeatherStations/stationGraphPresets.ts
@@ -17,8 +17,6 @@ export type GraphPreset = {
   band?: { lower: string; upper: string }
   /** Bars instead of a line (legacy renders precipitation as a bar plot). */
   bar?: boolean
-  /** Tooltip decimal places; defaults to 1 (legacy line-plot hover), 2 on bars. */
-  decimals?: number
 }
 
 // Every station gets the full preset list: the registry's columns only cover

--- a/src/components/WeatherStations/stationGraphUnits.ts
+++ b/src/components/WeatherStations/stationGraphUnits.ts
@@ -1,0 +1,65 @@
+import type { GraphData, GraphSeries } from '@/services/snowobs/graph'
+import type { GraphPreset } from './stationGraphPresets'
+import type { UnitSystem } from './UnitToggle'
+
+// Metric display for the Graphs tab: SnowObs data stays imperial end-to-end
+// (fetch, cache, CSV); charts convert client-side so toggling is instant and
+// the graph-data CDN cache stays single-variant.
+
+type Conversion = { unit: string; convert: (v: number) => number }
+
+const toCelsius: Conversion = { unit: '°C', convert: (v) => ((v - 32) * 5) / 9 }
+const toKmh: Conversion = { unit: 'km/h', convert: (v) => v * 1.609344 }
+const toCm: Conversion = { unit: 'cm', convert: (v) => v * 2.54 }
+
+// Keyed by variable rather than unit so inches can convert to cm (snow) or
+// mm (precip). Variables without an entry (%, degrees, W/m², pressure) render
+// as reported.
+const METRIC_CONVERSIONS: Record<string, Conversion> = {
+  air_temp: toCelsius,
+  equip_temperature: toCelsius,
+  wind_speed: toKmh,
+  wind_speed_min: toKmh,
+  wind_gust: toKmh,
+  snow_depth: toCm,
+  snow_depth_24h: toCm,
+  snow_depth_24hr: toCm,
+  intermittent_snow: toCm,
+  precip_accum_one_hour: { unit: 'mm', convert: (v) => v * 25.4 },
+}
+
+function convertSeries(s: GraphSeries, c: Conversion): GraphSeries {
+  if (s.kind === 'raw') {
+    return {
+      ...s,
+      unit: c.unit,
+      points: s.points.map(([t, v]) => [t, v === null ? null : c.convert(v)]),
+    }
+  }
+  return {
+    ...s,
+    unit: c.unit,
+    days: s.days.map(([t, min, mean, max]) => [t, c.convert(min), c.convert(mean), c.convert(max)]),
+  }
+}
+
+export function convertGraphData(data: GraphData, system: UnitSystem): GraphData {
+  if (system === 'imperial') return data
+  return {
+    ...data,
+    series: data.series.map((s) => {
+      const conversion = METRIC_CONVERSIONS[s.variable]
+      return conversion ? convertSeries(s, conversion) : s
+    }),
+  }
+}
+
+// The only unit-ful preset config is the reference line (32°F freezing);
+// pinned axis bounds are all unitless (RH 0-100 %).
+export function convertPreset(preset: GraphPreset, system: UnitSystem): GraphPreset {
+  if (system === 'imperial' || preset.refLine === undefined) return preset
+  const conversion = METRIC_CONVERSIONS[preset.variables[0]]
+  return conversion
+    ? { ...preset, refLine: Math.round(conversion.convert(preset.refLine)) }
+    : preset
+}

--- a/src/components/WeatherStations/stationGraphUnits.ts
+++ b/src/components/WeatherStations/stationGraphUnits.ts
@@ -43,6 +43,29 @@ function convertSeries(s: GraphSeries, c: Conversion): GraphSeries {
   }
 }
 
+// Sub-zero readings on non-temperature sensors are noise. Clamp in the
+// sensor's native imperial units BEFORE metric conversion, so legitimately
+// negative °C values survive (a 25°F equipment temp is -3.9°C, not 0).
+export function clampNegativeValues(data: GraphData): GraphData {
+  return {
+    ...data,
+    series: data.series.map((s) => {
+      if (s.kind === 'raw') {
+        return { ...s, points: s.points.map(([t, v]) => [t, v === null ? v : Math.max(0, v)]) }
+      }
+      return {
+        ...s,
+        days: s.days.map(([t, min, mean, max]) => [
+          t,
+          Math.max(0, min),
+          Math.max(0, mean),
+          Math.max(0, max),
+        ]),
+      }
+    }),
+  }
+}
+
 export function convertGraphData(data: GraphData, system: UnitSystem): GraphData {
   if (system === 'imperial') return data
   return {

--- a/src/components/WeatherStations/useChartArrangement.ts
+++ b/src/components/WeatherStations/useChartArrangement.ts
@@ -1,0 +1,64 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { ChartPrefs } from './stationGraphPrefs'
+import {
+  defaultChartPrefs,
+  loadChartPrefs,
+  saveChartPrefs,
+  swapWithNeighbor,
+} from './stationGraphPrefs'
+import type { GraphPreset } from './stationGraphPresets'
+
+// Chart order and visibility for the Graphs tab, persisted per browser.
+// Prefs load after mount (localStorage is browser-only); saves wait for that
+// load so defaults never clobber a stored arrangement. Moves swap with the
+// nearest chart the user can actually see: hidden charts and charts whose
+// fetch came back empty (sensor absent on this station) are skipped.
+export function useChartArrangement(presets: GraphPreset[]) {
+  const presetKeys = useMemo(() => presets.map((p) => p.key), [presets])
+  const [prefs, setPrefs] = useState<ChartPrefs>(() => defaultChartPrefs(presetKeys))
+  const [prefsLoaded, setPrefsLoaded] = useState(false)
+  useEffect(() => {
+    setPrefs(loadChartPrefs(presetKeys))
+    setPrefsLoaded(true)
+  }, [presetKeys])
+  useEffect(() => {
+    if (prefsLoaded) saveChartPrefs(prefs)
+  }, [prefs, prefsLoaded])
+
+  const [emptyKeys, setEmptyKeys] = useState<ReadonlySet<string>>(new Set())
+  const onEmptyChange = useCallback((key: string, empty: boolean) => {
+    setEmptyKeys((prev) => {
+      if (prev.has(key) === empty) return prev
+      const next = new Set(prev)
+      if (empty) next.add(key)
+      else next.delete(key)
+      return next
+    })
+  }, [])
+
+  const presetByKey = useMemo(() => new Map(presets.map((p) => [p.key, p])), [presets])
+  const orderedPresets = useMemo(
+    () => prefs.order.flatMap((key) => presetByKey.get(key) ?? []),
+    [prefs.order, presetByKey],
+  )
+
+  const isSkippable = (key: string) => prefs.hidden.includes(key) || emptyKeys.has(key)
+
+  return {
+    visiblePresets: orderedPresets.filter((p) => !prefs.hidden.includes(p.key)),
+    hiddenPresets: orderedPresets.filter((p) => prefs.hidden.includes(p.key)),
+    canMove: (key: string, direction: -1 | 1) =>
+      swapWithNeighbor(prefs.order, key, direction, isSkippable) !== prefs.order,
+    moveChart: (key: string, direction: -1 | 1) =>
+      setPrefs((prev) => ({
+        ...prev,
+        order: swapWithNeighbor(prev.order, key, direction, isSkippable),
+      })),
+    hideChart: (key: string) => setPrefs((prev) => ({ ...prev, hidden: [...prev.hidden, key] })),
+    showChart: (key: string) =>
+      setPrefs((prev) => ({ ...prev, hidden: prev.hidden.filter((k) => k !== key) })),
+    onEmptyChange,
+  }
+}

--- a/src/components/WeatherStations/useChartArrangement.ts
+++ b/src/components/WeatherStations/useChartArrangement.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { ChartPrefs } from './stationGraphPrefs'
 import {
   defaultChartPrefs,
@@ -12,10 +12,10 @@ import type { GraphPreset } from './stationGraphPresets'
 
 // Chart order and visibility for the Graphs tab, persisted per browser.
 // Prefs load after mount (localStorage is browser-only); saves wait for that
-// load so defaults never clobber a stored arrangement. Moves swap with the
-// nearest chart the user can actually see: hidden charts and charts whose
-// fetch came back empty (sensor absent on this station) are skipped.
-export function useChartArrangement(presets: GraphPreset[]) {
+// load so defaults never clobber a stored arrangement. Prefs track every
+// preset — `emptyKeys` (sensors absent on this station) only filters what
+// renders, so one station's missing sensors never rewrite the stored order.
+export function useChartArrangement(presets: GraphPreset[], emptyKeys: ReadonlySet<string>) {
   const presetKeys = useMemo(() => presets.map((p) => p.key), [presets])
   const [prefs, setPrefs] = useState<ChartPrefs>(() => defaultChartPrefs(presetKeys))
   const [prefsLoaded, setPrefsLoaded] = useState(false)
@@ -27,17 +27,6 @@ export function useChartArrangement(presets: GraphPreset[]) {
     if (prefsLoaded) saveChartPrefs(prefs)
   }, [prefs, prefsLoaded])
 
-  const [emptyKeys, setEmptyKeys] = useState<ReadonlySet<string>>(new Set())
-  const onEmptyChange = useCallback((key: string, empty: boolean) => {
-    setEmptyKeys((prev) => {
-      if (prev.has(key) === empty) return prev
-      const next = new Set(prev)
-      if (empty) next.add(key)
-      else next.delete(key)
-      return next
-    })
-  }, [])
-
   const presetByKey = useMemo(() => new Map(presets.map((p) => [p.key, p])), [presets])
   const orderedPresets = useMemo(
     () => prefs.order.flatMap((key) => presetByKey.get(key) ?? []),
@@ -47,8 +36,12 @@ export function useChartArrangement(presets: GraphPreset[]) {
   const isSkippable = (key: string) => prefs.hidden.includes(key) || emptyKeys.has(key)
 
   return {
-    visiblePresets: orderedPresets.filter((p) => !prefs.hidden.includes(p.key)),
-    hiddenPresets: orderedPresets.filter((p) => prefs.hidden.includes(p.key)),
+    visiblePresets: orderedPresets.filter(
+      (p) => !prefs.hidden.includes(p.key) && !emptyKeys.has(p.key),
+    ),
+    hiddenPresets: orderedPresets.filter(
+      (p) => prefs.hidden.includes(p.key) && !emptyKeys.has(p.key),
+    ),
     canMove: (key: string, direction: -1 | 1) =>
       swapWithNeighbor(prefs.order, key, direction, isSkippable) !== prefs.order,
     moveChart: (key: string, direction: -1 | 1) =>
@@ -59,6 +52,5 @@ export function useChartArrangement(presets: GraphPreset[]) {
     hideChart: (key: string) => setPrefs((prev) => ({ ...prev, hidden: [...prev.hidden, key] })),
     showChart: (key: string) =>
       setPrefs((prev) => ({ ...prev, hidden: prev.hidden.filter((k) => k !== key) })),
-    onEmptyChange,
   }
 }

--- a/src/components/WeatherStations/useChartArrangement.ts
+++ b/src/components/WeatherStations/useChartArrangement.ts
@@ -10,11 +10,10 @@ import {
 } from './stationGraphPrefs'
 import type { GraphPreset } from './stationGraphPresets'
 
-// Chart order and visibility for the Graphs tab, persisted per browser.
-// Prefs load after mount (localStorage is browser-only); saves wait for that
-// load so defaults never clobber a stored arrangement. Prefs track every
-// preset — `emptyKeys` (sensors absent on this station) only filters what
-// renders, so one station's missing sensors never rewrite the stored order.
+// Chart order and visibility, persisted per browser. Saves wait for the
+// post-mount localStorage load so defaults never clobber a stored arrangement.
+// `emptyKeys` (sensors absent on this station) only filters what renders, so
+// one station's missing sensors never rewrite the stored order.
 export function useChartArrangement(presets: GraphPreset[], emptyKeys: ReadonlySet<string>) {
   const presetKeys = useMemo(() => presets.map((p) => p.key), [presets])
   const [prefs, setPrefs] = useState<ChartPrefs>(() => defaultChartPrefs(presetKeys))

--- a/src/constants/weatherStations.ts
+++ b/src/constants/weatherStations.ts
@@ -608,8 +608,7 @@ export function getStationGroup(slug: string): WeatherStationGroup | undefined {
   return STATION_GROUPS_BY_SLUG.get(slug)
 }
 
-// Graphs-tab comparison cap: keeps charts legible and bounds graph-data
-// request size (the route derives its station cap from this).
+// Graphs-tab comparison cap; the graph-data route derives its station cap from this.
 export const MAX_COMPARE_STATIONS = 3
 
 // Every station with a configured hourly-precip column — the row set for the

--- a/src/constants/weatherStations.ts
+++ b/src/constants/weatherStations.ts
@@ -608,6 +608,10 @@ export function getStationGroup(slug: string): WeatherStationGroup | undefined {
   return STATION_GROUPS_BY_SLUG.get(slug)
 }
 
+// Graphs-tab comparison cap: keeps charts legible and bounds graph-data
+// request size (the route derives its station cap from this).
+export const MAX_COMPARE_STATIONS = 3
+
 // Every station with a configured hourly-precip column — the row set for the
 // Accumulated Precipitation page (legacy /data-portal/accumulations/precipitation/).
 export const PRECIP_STATION_STIDS = Array.from(

--- a/src/services/snowobs/graph.ts
+++ b/src/services/snowobs/graph.ts
@@ -1,0 +1,151 @@
+import { DISPLAY_TIMEZONE, fallbackSensorLabel, SENSOR_LABELS, UNIT_LABELS } from './constants'
+import type { SnowObsTimeseriesResponse } from './types/schemas'
+
+// The graph engine's data contract (grill-me 2026-07-20): one shape feeds both
+// the public station Graphs tab and the future self-serve builder. Series come
+// back either raw (hourly points) or daily-aggregated — windows longer than
+// DECIMATION_THRESHOLD_DAYS auto-aggregate server-side, no client knob.
+
+export const DECIMATION_THRESHOLD_DAYS = 30
+
+export type RawGraphSeries = {
+  kind: 'raw'
+  stid: string
+  stationName: string
+  variable: string
+  label: string
+  unit: string
+  /** [ms epoch, value|null] pairs, time-ascending. */
+  points: [number, number | null][]
+}
+
+export type DailyGraphSeries = {
+  kind: 'daily'
+  stid: string
+  stationName: string
+  variable: string
+  label: string
+  unit: string
+  /** [day-start ms epoch (display TZ), min, mean, max], time-ascending. */
+  days: [number, number, number, number][]
+}
+
+export type GraphSeries = RawGraphSeries | DailyGraphSeries
+
+export type GraphData = {
+  series: GraphSeries[]
+  aggregated: boolean
+  timezone: string
+}
+
+type ResponseStation = SnowObsTimeseriesResponse['STATION'][number]
+
+// yyyy-mm-dd in the display timezone — the daily-aggregation bucket key.
+const dayFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: DISPLAY_TIMEZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+function seriesLabel(stationName: string, variable: string): string {
+  return `${stationName} · ${SENSOR_LABELS[variable] ?? fallbackSensorLabel(variable)}`
+}
+
+function seriesUnit(units: Record<string, string>, variable: string): string {
+  const raw = units[variable]
+  return raw ? (UNIT_LABELS[raw] ?? raw) : ''
+}
+
+// Time-ascending [ms, value] pairs for one station variable; null values kept
+// so gaps render as gaps rather than interpolated lines.
+function rawPoints(station: ResponseStation, variable: string): [number, number | null][] {
+  const obs = station.observations
+  const times = obs['date_time'] ?? []
+  const values = obs[variable] ?? []
+  const points: [number, number | null][] = []
+  times.forEach((iso, i) => {
+    const t = typeof iso === 'string' ? new Date(iso).getTime() : NaN
+    if (!Number.isFinite(t)) return
+    const v = values[i]
+    points.push([t, typeof v === 'number' ? v : null])
+  })
+  points.sort((a, b) => a[0] - b[0])
+  return points
+}
+
+// Collapse raw points into per-day [dayStart, min, mean, max] rows (display
+// timezone days); days with no numeric observations are omitted.
+export function aggregateDaily(
+  points: [number, number | null][],
+): [number, number, number, number][] {
+  const byDay = new Map<string, { t: number; values: number[] }>()
+  for (const [t, v] of points) {
+    if (v === null) continue
+    const key = dayFormatter.format(t)
+    const bucket = byDay.get(key)
+    if (bucket) {
+      bucket.values.push(v)
+      bucket.t = Math.min(bucket.t, t)
+    } else {
+      byDay.set(key, { t, values: [v] })
+    }
+  }
+  return Array.from(byDay.values())
+    .sort((a, b) => a.t - b.t)
+    .map(({ t, values }) => {
+      const min = Math.min(...values)
+      const max = Math.max(...values)
+      const mean = values.reduce((acc, v) => acc + v, 0) / values.length
+      return [t, round2(min), round2(mean), round2(max)]
+    })
+}
+
+function round2(v: number): number {
+  return Number(v.toFixed(2))
+}
+
+function buildSeries(
+  station: ResponseStation,
+  variable: string,
+  units: Record<string, string>,
+  aggregated: boolean,
+): GraphSeries | null {
+  if (!station.observations[variable]) return null
+  const points = rawPoints(station, variable)
+  if (points.length === 0) return null
+  const base = {
+    stid: station.stid,
+    stationName: station.name ?? station.stid,
+    variable,
+    label: seriesLabel(station.name ?? station.stid, variable),
+    unit: seriesUnit(units, variable),
+  }
+  if (aggregated) return { kind: 'daily', ...base, days: aggregateDaily(points) }
+  return { kind: 'raw', ...base, points }
+}
+
+export function windowExceedsThreshold(from: Date, to: Date): boolean {
+  const days = (to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000)
+  return days > DECIMATION_THRESHOLD_DAYS
+}
+
+// One series per requested (station, variable) pair that actually has data.
+export function buildGraphData(
+  response: SnowObsTimeseriesResponse,
+  stids: string[],
+  variables: string[],
+  aggregated: boolean,
+): GraphData {
+  const stationByStid = new Map(response.STATION.map((s) => [s.stid, s]))
+  const series: GraphSeries[] = []
+  for (const stid of stids) {
+    const station = stationByStid.get(stid)
+    if (!station) continue
+    for (const variable of variables) {
+      const built = buildSeries(station, variable, response.UNITS, aggregated)
+      if (built) series.push(built)
+    }
+  }
+  return { series, aggregated, timezone: DISPLAY_TIMEZONE }
+}

--- a/src/services/snowobs/graph.ts
+++ b/src/services/snowobs/graph.ts
@@ -75,9 +75,11 @@ function rawPoints(station: ResponseStation, variable: string): [number, number 
 }
 
 // Collapse raw points into per-day [dayStart, min, mean, max] rows (display
-// timezone days); days with no numeric observations are omitted.
+// timezone days); days with no numeric observations are omitted. Circular
+// variables get a vector mean with min/max pinned to it (no meaningful band).
 export function aggregateDaily(
   points: [number, number | null][],
+  circular = false,
 ): [number, number, number, number][] {
   const byDay = new Map<string, { t: number; values: number[] }>()
   for (const [t, v] of points) {
@@ -93,17 +95,35 @@ export function aggregateDaily(
   }
   return Array.from(byDay.values())
     .sort((a, b) => a.t - b.t)
-    .map(({ t, values }) => {
-      const min = Math.min(...values)
-      const max = Math.max(...values)
-      const mean = values.reduce((acc, v) => acc + v, 0) / values.length
-      return [t, round2(min), round2(mean), round2(max)]
-    })
+    .map(({ t, values }) => dayRow(t, values, circular))
+}
+
+function dayRow(t: number, values: number[], circular: boolean): [number, number, number, number] {
+  if (circular) {
+    const mean = vectorMeanDegrees(values)
+    return [t, mean, mean, mean]
+  }
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const mean = values.reduce((acc, v) => acc + v, 0) / values.length
+  return [t, round2(min), round2(mean), round2(max)]
 }
 
 function round2(v: number): number {
   return Number(v.toFixed(2))
 }
+
+// Vector (circular) mean of compass degrees — 350° and 10° average to 0°, not
+// 180°. Ports the legacy compute_aggregates _vector_mean behavior.
+export function vectorMeanDegrees(values: number[]): number {
+  const toRad = Math.PI / 180
+  const x = values.reduce((acc, d) => acc + Math.cos(d * toRad), 0)
+  const y = values.reduce((acc, d) => acc + Math.sin(d * toRad), 0)
+  const deg = (Math.atan2(y, x) * 180) / Math.PI
+  return round2((deg + 360) % 360)
+}
+
+const CIRCULAR_VARIABLES = new Set(['wind_direction'])
 
 function buildSeries(
   station: ResponseStation,
@@ -121,7 +141,13 @@ function buildSeries(
     label: seriesLabel(station.name ?? station.stid, variable),
     unit: seriesUnit(units, variable),
   }
-  if (aggregated) return { kind: 'daily', ...base, days: aggregateDaily(points) }
+  if (aggregated) {
+    return {
+      kind: 'daily',
+      ...base,
+      days: aggregateDaily(points, CIRCULAR_VARIABLES.has(variable)),
+    }
+  }
   return { kind: 'raw', ...base, points }
 }
 

--- a/src/services/snowobs/graph.ts
+++ b/src/services/snowobs/graph.ts
@@ -1,4 +1,4 @@
-import { DISPLAY_TIMEZONE, fallbackSensorLabel, SENSOR_LABELS, UNIT_LABELS } from './constants'
+import { fallbackSensorLabel, NWAC_DISPLAY_TIMEZONE, SENSOR_LABELS, UNIT_LABELS } from './constants'
 import type { SnowObsTimeseriesResponse } from './types/schemas'
 
 // The graph engine's data contract (grill-me 2026-07-20): one shape feeds both
@@ -42,7 +42,7 @@ type ResponseStation = SnowObsTimeseriesResponse['STATION'][number]
 
 // yyyy-mm-dd in the display timezone — the daily-aggregation bucket key.
 const dayFormatter = new Intl.DateTimeFormat('en-CA', {
-  timeZone: DISPLAY_TIMEZONE,
+  timeZone: NWAC_DISPLAY_TIMEZONE,
   year: 'numeric',
   month: '2-digit',
   day: '2-digit',
@@ -173,5 +173,5 @@ export function buildGraphData(
       if (built) series.push(built)
     }
   }
-  return { series, aggregated, timezone: DISPLAY_TIMEZONE }
+  return { series, aggregated, timezone: NWAC_DISPLAY_TIMEZONE }
 }

--- a/src/services/snowobs/graph.ts
+++ b/src/services/snowobs/graph.ts
@@ -1,9 +1,10 @@
-import { fallbackSensorLabel, NWAC_DISPLAY_TIMEZONE, SENSOR_LABELS, UNIT_LABELS } from './constants'
+import { differenceInHours } from 'date-fns'
+import { displayUnit, fallbackSensorLabel, NWAC_DISPLAY_TIMEZONE, SENSOR_LABELS } from './constants'
 import type { SnowObsTimeseriesResponse } from './types/schemas'
 
-// The graph engine's data contract (grill-me 2026-07-20): one shape feeds both
-// the public station Graphs tab and the future self-serve builder. Series come
-// back either raw (hourly points) or daily-aggregated — windows longer than
+// The graph engine's data contract: one shape feeds both the public station
+// Graphs tab and the future self-serve builder. Series come back either raw
+// (hourly points) or daily-aggregated — windows longer than
 // DECIMATION_THRESHOLD_DAYS auto-aggregate server-side, no client knob.
 
 export const DECIMATION_THRESHOLD_DAYS = 30
@@ -41,6 +42,8 @@ export type GraphData = {
 type ResponseStation = SnowObsTimeseriesResponse['STATION'][number]
 
 // yyyy-mm-dd in the display timezone — the daily-aggregation bucket key.
+// A cached Intl formatter (not date-fns `format` + tz) because this runs per
+// point in the aggregation loop.
 const dayFormatter = new Intl.DateTimeFormat('en-CA', {
   timeZone: NWAC_DISPLAY_TIMEZONE,
   year: 'numeric',
@@ -52,26 +55,31 @@ function seriesLabel(stationName: string, variable: string): string {
   return `${stationName} · ${SENSOR_LABELS[variable] ?? fallbackSensorLabel(variable)}`
 }
 
-function seriesUnit(units: Record<string, string>, variable: string): string {
-  const raw = units[variable]
-  return raw ? (UNIT_LABELS[raw] ?? raw) : ''
+// The station's date_time series parsed and time-sorted once, so building
+// points doesn't re-parse and re-sort it for every variable.
+type ParsedTimes = { t: number; i: number }[]
+
+function parsedTimes(station: ResponseStation): ParsedTimes {
+  const times = station.observations['date_time'] ?? []
+  const parsed: ParsedTimes = []
+  times.forEach((iso, i) => {
+    const t = typeof iso === 'string' ? new Date(iso).getTime() : NaN
+    if (Number.isFinite(t)) parsed.push({ t, i })
+  })
+  parsed.sort((a, b) => a.t - b.t)
+  return parsed
 }
 
 // Time-ascending [ms, value] pairs for one station variable; null values kept
 // so gaps render as gaps rather than interpolated lines.
-function rawPoints(station: ResponseStation, variable: string): [number, number | null][] {
-  const obs = station.observations
-  const times = obs['date_time'] ?? []
-  const values = obs[variable] ?? []
-  const points: [number, number | null][] = []
-  times.forEach((iso, i) => {
-    const t = typeof iso === 'string' ? new Date(iso).getTime() : NaN
-    if (!Number.isFinite(t)) return
+function rawPoints(
+  times: ParsedTimes,
+  values: (string | number | null)[],
+): [number, number | null][] {
+  return times.map(({ t, i }) => {
     const v = values[i]
-    points.push([t, typeof v === 'number' ? v : null])
+    return [t, typeof v === 'number' ? v : null]
   })
-  points.sort((a, b) => a[0] - b[0])
-  return points
 }
 
 // Collapse raw points into per-day [dayStart, min, mean, max] rows (display
@@ -127,19 +135,21 @@ const CIRCULAR_VARIABLES = new Set(['wind_direction'])
 
 function buildSeries(
   station: ResponseStation,
+  times: ParsedTimes,
   variable: string,
   units: Record<string, string>,
   aggregated: boolean,
 ): GraphSeries | null {
-  if (!station.observations[variable]) return null
-  const points = rawPoints(station, variable)
+  const values = station.observations[variable]
+  if (!values) return null
+  const points = rawPoints(times, values)
   if (points.length === 0) return null
   const base = {
     stid: station.stid,
     stationName: station.name ?? station.stid,
     variable,
     label: seriesLabel(station.name ?? station.stid, variable),
-    unit: seriesUnit(units, variable),
+    unit: displayUnit(units[variable]),
   }
   if (aggregated) {
     return {
@@ -152,8 +162,7 @@ function buildSeries(
 }
 
 export function windowExceedsThreshold(from: Date, to: Date): boolean {
-  const days = (to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000)
-  return days > DECIMATION_THRESHOLD_DAYS
+  return differenceInHours(to, from, { roundingMethod: 'ceil' }) > DECIMATION_THRESHOLD_DAYS * 24
 }
 
 // One series per requested (station, variable) pair that actually has data.
@@ -168,8 +177,9 @@ export function buildGraphData(
   for (const stid of stids) {
     const station = stationByStid.get(stid)
     if (!station) continue
+    const times = parsedTimes(station)
     for (const variable of variables) {
-      const built = buildSeries(station, variable, response.UNITS, aggregated)
+      const built = buildSeries(station, times, variable, response.UNITS, aggregated)
       if (built) series.push(built)
     }
   }

--- a/src/services/snowobs/graph.ts
+++ b/src/services/snowobs/graph.ts
@@ -2,10 +2,9 @@ import { differenceInHours } from 'date-fns'
 import { displayUnit, NWAC_DISPLAY_TIMEZONE } from './constants'
 import type { SnowObsTimeseriesResponse } from './types/schemas'
 
-// The graph engine's data contract: one shape feeds both the public station
-// Graphs tab and the future self-serve builder. Series come back either raw
-// (hourly points) or daily-aggregated — windows longer than
-// DECIMATION_THRESHOLD_DAYS auto-aggregate server-side, no client knob.
+// The graph-data contract: series come back either raw (hourly points) or
+// daily-aggregated — windows longer than DECIMATION_THRESHOLD_DAYS
+// auto-aggregate server-side, no client knob.
 
 export const DECIMATION_THRESHOLD_DAYS = 30
 
@@ -41,9 +40,8 @@ export type GraphData = {
 
 type ResponseStation = SnowObsTimeseriesResponse['STATION'][number]
 
-// yyyy-mm-dd in the display timezone — the daily-aggregation bucket key.
-// A cached Intl formatter (not date-fns `format` + tz) because this runs per
-// point in the aggregation loop.
+// Daily-aggregation bucket key (yyyy-mm-dd, display timezone). A cached Intl
+// formatter because this runs per point in the aggregation loop.
 const dayFormatter = new Intl.DateTimeFormat('en-CA', {
   timeZone: NWAC_DISPLAY_TIMEZONE,
   year: 'numeric',
@@ -51,15 +49,14 @@ const dayFormatter = new Intl.DateTimeFormat('en-CA', {
   day: '2-digit',
 })
 
-// Station + elevation (feet) only, e.g. "Hurricane Ridge (5,250')" — the chart
-// title already names the variable, so the legend just distinguishes stations.
+// e.g. "Hurricane Ridge (5,250')" — the chart title already names the
+// variable, so the legend just distinguishes stations.
 function seriesLabel(station: ResponseStation): string {
   const name = station.name ?? station.stid
   return station.elevation != null ? `${name} (${station.elevation.toLocaleString()}')` : name
 }
 
-// The station's date_time series parsed and time-sorted once, so building
-// points doesn't re-parse and re-sort it for every variable.
+// date_time parsed and sorted once per station, not per variable.
 type ParsedTimes = { t: number; i: number }[]
 
 function parsedTimes(station: ResponseStation): ParsedTimes {
@@ -73,8 +70,7 @@ function parsedTimes(station: ResponseStation): ParsedTimes {
   return parsed
 }
 
-// Time-ascending [ms, value] pairs for one station variable; null values kept
-// so gaps render as gaps rather than interpolated lines.
+// Nulls kept so gaps render as gaps rather than interpolated lines.
 function rawPoints(
   times: ParsedTimes,
   values: (string | number | null)[],
@@ -85,8 +81,7 @@ function rawPoints(
   })
 }
 
-// Collapse raw points into per-day [dayStart, min, mean, max] rows (display
-// timezone days); days with no numeric observations are omitted. Circular
+// Per-day [dayStart, min, mean, max] rows (display-timezone days). Circular
 // variables get a vector mean with min/max pinned to it (no meaningful band).
 export function aggregateDaily(
   points: [number, number | null][],
@@ -168,7 +163,6 @@ export function windowExceedsThreshold(from: Date, to: Date): boolean {
   return differenceInHours(to, from, { roundingMethod: 'ceil' }) > DECIMATION_THRESHOLD_DAYS * 24
 }
 
-// One series per requested (station, variable) pair that actually has data.
 export function buildGraphData(
   response: SnowObsTimeseriesResponse,
   stids: string[],

--- a/src/services/snowobs/graph.ts
+++ b/src/services/snowobs/graph.ts
@@ -1,5 +1,5 @@
 import { differenceInHours } from 'date-fns'
-import { displayUnit, fallbackSensorLabel, NWAC_DISPLAY_TIMEZONE, SENSOR_LABELS } from './constants'
+import { displayUnit, NWAC_DISPLAY_TIMEZONE } from './constants'
 import type { SnowObsTimeseriesResponse } from './types/schemas'
 
 // The graph engine's data contract: one shape feeds both the public station
@@ -51,8 +51,11 @@ const dayFormatter = new Intl.DateTimeFormat('en-CA', {
   day: '2-digit',
 })
 
-function seriesLabel(stationName: string, variable: string): string {
-  return `${stationName} · ${SENSOR_LABELS[variable] ?? fallbackSensorLabel(variable)}`
+// Station + elevation (feet) only, e.g. "Hurricane Ridge (5,250')" — the chart
+// title already names the variable, so the legend just distinguishes stations.
+function seriesLabel(station: ResponseStation): string {
+  const name = station.name ?? station.stid
+  return station.elevation != null ? `${name} (${station.elevation.toLocaleString()}')` : name
 }
 
 // The station's date_time series parsed and time-sorted once, so building
@@ -148,7 +151,7 @@ function buildSeries(
     stid: station.stid,
     stationName: station.name ?? station.stid,
     variable,
-    label: seriesLabel(station.name ?? station.stid, variable),
+    label: seriesLabel(station),
     unit: displayUnit(units[variable]),
   }
   if (aggregated) {

--- a/src/services/snowobs/snowobs.ts
+++ b/src/services/snowobs/snowobs.ts
@@ -31,6 +31,9 @@ type FetchOptions = {
   start?: Date
   end?: Date
   revalidate?: number
+  // Skip SnowObs' server-side rounding (values come back integer-rounded by
+  // default). Graphs want full precision; tables keep the rounded default.
+  rawData?: boolean
 }
 
 // Build the timeseries request URL. Defaults to a trailing window (last 24h)
@@ -56,6 +59,7 @@ function buildTimeseriesUrl(stids: string[], options: FetchOptions): string {
     start_date: formatSnowObsDate(start),
     end_date: formatSnowObsDate(end),
   })
+  if (options.rawData) params.set('raw_data', 'true')
   return `${SNOWOBS_API}/station/data/timeseries/?${params.toString()}`
 }
 

--- a/src/services/snowobs/snowobs.ts
+++ b/src/services/snowobs/snowobs.ts
@@ -31,8 +31,7 @@ type FetchOptions = {
   start?: Date
   end?: Date
   revalidate?: number
-  // Skip SnowObs' server-side rounding (values come back integer-rounded by
-  // default). Graphs want full precision; tables keep the rounded default.
+  // Skip SnowObs' default integer rounding (graphs want full precision).
   rawData?: boolean
 }
 

--- a/src/utilities/safeLocalStorage.ts
+++ b/src/utilities/safeLocalStorage.ts
@@ -1,0 +1,20 @@
+// localStorage can throw on any access: SecurityError when the browser blocks
+// site data, QuotaExceededError when full (legacy Safari private mode threw on
+// every write). Persistence is always optional — failures degrade to
+// "works but forgets", never break the feature.
+
+export function readLocalStorage(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+export function writeLocalStorage(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value)
+  } catch {
+    // Losing persistence is the accepted fallback.
+  }
+}


### PR DESCRIPTION
## Description

Adds a **Graphs** tab to the weather station pages, replacing the legacy nwac.us station graphs. Each station gets an interactive chart per sensor, powered by ECharts and fed by SnowObs data through a new server-side route.

## Related Issues

- Closes #1107 (NWAC Wx Station Graphs)
- Linear [NWA-20](https://linear.app/nwac/issue/NWA-20)
- Part of #1106

## Key Changes

**What you'll see**

- **A chart for every sensor the station reports**: temperature (with a 32°F freezing line), humidity, wind speed, wind direction on a compass scale, snow depth, 24-hour snow, precipitation, solar, pressure, and equipment temperature. Charts for sensors a station doesn't have simply don't appear.
- **Wind speed shows a shaded band** from the minimum to the gust around the average line, like the old graphs did.
- **Time windows** from 24 hours to the full season (back to Oct 1). All charts zoom and pan together.
- **Compare stations**: add up to 3 other stations and their data overlays every chart as dashed lines. Remove them with the chips below the toolbar.
- **Rearrange to taste**: move charts up/down or hide them; hidden charts come back from chips. Your arrangement is remembered in the browser.
- **Imperial/Metric toggle**: one switch converts every chart at once (°F→°C, mph→km/h, snow to cm, precip to mm, freezing line to 0°C). Also remembered.
- **No bogus negatives**: sensor noise below zero is clamped on every chart except the two temperature charts, where negative readings are real.

**Under the hood**

- A new `/weather/graph-data` route reads SnowObs on the server, so the API token never reaches the browser. Requests are validated against the station registry and capped in size. Only NWAC gets the route — other centers 404.
- Each view makes **one request** covering every chart, with timestamps rounded so the same URL is shared across charts and visitors and cached at the CDN for 5 minutes.
- Windows longer than 30 days are aggregated server-side to daily min/mean/max (wind direction uses a vector mean so 350° and 10° average to 0°, not 180°).
- Unit conversion happens in the browser, so toggling is instant and doesn't double the cache.
- The CI build's memory limit is raised — the compile grew with ECharts and started running out of memory on the 2-vCPU Blacksmith runners.

## How to test

- On this branch: `pnpm dev`, then `nwac.localhost:3000/weather/stations/hurricane-ridge?range=graphs` (needs `SNOWOBS_TOKEN` in `.env`).
- Switch time windows; zoom one chart and watch the others follow. The network tab should show a single `graph-data` request per change.
- Add comparison stations, reorder/hide charts, and reload — the arrangement should stick.
- Flip the Imperial/Metric toggle: every chart converts, the freezing line moves to 0, and the choice survives a reload.
- Check the wind speed band and the wind direction compass dots.
- Spot-check values against the legacy graphs at nwac.us. (Verified against production: the tables match the SnowObs feed byte-for-byte; the legacy d3 graphs show slightly more decimal precision than SnowObs serves anywhere.)
- Confirm other centers (dvac/sac/snfac) 404 on `/weather/graph-data`.
- `pnpm test` covers the data layer, chart options, conversions, compare picker, and arrangement behavior.

## Screenshots / Demo video
<img width="1417" height="4082" alt="Alpental-Ski-Area-Northwest-Avalanche-Center-08-04-2026_04_09_PM" src="https://github.com/user-attachments/assets/1e8ae01a-6fa5-4927-9b23-7e4f2e3b7707" />


## Migration Explanation

None needed — no schema changes.

## Future enhancements / Questions

Tracked in the follow-up checklist on #1107 (from forecaster feedback):

- Stock view excluding diagnostic charts (solar, equipment temp) by default
- Mesowest + Snotel cross-network comparison stations
- Y-axis clamps for bad sensor readings beyond the negative-value clamp shipped here (needed before winter, not MVP)
- Self-serve graph builder (v2 — the data layer and route already serve arbitrary station/variable configs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
