### PR TITLE
Fix Blog List block ignoring its tag/sort filters (#1159)

### DIFF
--- a/src/blocks/BlogList/Component.tsx
+++ b/src/blocks/BlogList/Component.tsx
@@ -41,29 +41,25 @@ export const BlogListBlockComponent = (args: BlogListComponentProps) => {
       const tenantSlug = typeof tenant === 'object' && tenant?.slug
       if (!tenantSlug) return
 
-      const params = new URLSearchParams({
-        limit: String(maxPosts || 4),
-      })
-
-      // params supported by the posts page
-      const postsPageParams = new URLSearchParams()
-
       const filterByTagsSlugs = filterValidRelationships(filterByTags).map(({ slug }) => slug)
 
-      const blogLinkQueryParams = new URLSearchParams()
-      if (sortBy !== undefined) {
-        blogLinkQueryParams.set('sort', sortBy)
+      // Filters shared by both the posts API fetch and the "View all" /blog link.
+      // The /blog listing page reads the same `sort` and `tags` query params.
+      const filterParams = new URLSearchParams()
+      if (sortBy) {
+        filterParams.set('sort', sortBy)
+      }
+      if (filterByTagsSlugs.length > 0) {
+        filterParams.set('tags', filterByTagsSlugs.join(','))
       }
 
-      if (filterByTagsSlugs && filterByTagsSlugs.length > 0) {
-        blogLinkQueryParams.set('tags', filterByTagsSlugs.join(','))
-      }
+      setPostsPageParams(filterParams.toString())
 
-      setPostsPageParams(postsPageParams.toString())
+      // The API fetch additionally needs the result limit.
+      const apiParams = new URLSearchParams(filterParams)
+      apiParams.set('limit', String(maxPosts || 4))
 
-      const allParams = new URLSearchParams([...params, ...postsPageParams])
-
-      const response = await fetch(`/api/${tenantSlug}/posts?${allParams.toString()}`, {
+      const response = await fetch(`/api/${tenantSlug}/posts?${apiParams.toString()}`, {
         cache: 'no-store',
       })
 
@@ -76,7 +72,7 @@ export const BlogListBlockComponent = (args: BlogListComponentProps) => {
     }
 
     fetchPosts()
-  }, [tenant, postsPageParams, filterByTags, sortBy, postOptions, maxPosts])
+  }, [tenant, filterByTags, sortBy, postOptions, maxPosts])
 
   let posts: Post[] = filterValidPublishedRelationships(staticPosts)
 


### PR DESCRIPTION
## Description

The Blog List block's dynamic mode ignored its **Filter by Tag(s)** (and sort) selection — e.g. on the MSAC Climbing Forecast page, a block filtered to `Climbing Forecast` also showed a `News`-tagged post (#1159, confirmed reproducible across tenants).

**Root cause:** the block resolved the selected tag slugs + sort into a local `URLSearchParams` that was then never used. The request it actually issued was `/api/[center]/posts?limit=N` with **no `tags`**, so the API returned unfiltered recent posts. The "View all" link had the same defect (built from the empty params object), so it dropped the filters too. The posts API and `getPosts` query already filter on `tags.slug` and apply `sort` correctly — the bug was entirely in the block's client component.

## Related Issues

Fixes #1159

## Key Changes

- **`src/blocks/BlogList/Component.tsx`** — build one `filterParams` (`sort` + comma-joined `tags` slugs) and actually send it: the posts API fetch gets `filterParams` + `limit`, and the "View all" link reuses `filterParams` (the `/blog` listing reads the same `tags`/`sort` params). Also dropped the write-only `postsPageParams` from the effect's dependency array so the fetch no longer runs twice on mount.

No API/query changes — the backend was already correct.

## How to test

1. `pnpm seed`, then `pnpm dev`.
2. On a center with a dynamic Blog List block filtered by a tag, confirm only posts carrying that tag appear, and that the "View all" button lands on a `/blog` view filtered to the same tag.
3. A block with no tag selected still shows recent posts up to its limit.

**Verification performed:** drove the exact contract the component now uses against a seeded DB via the running dev server — `/api/nwac/posts` with no filter returned all 3 posts (including off-tag ones, i.e. the bug), `?tags=education` returned only the matching post, and `?tags=education,gear` returned both (OR semantics). The component now sends `tags`/`sort` into that fetch.

Automated: `pnpm tsc`, `pnpm lint`, `pnpm test` (525 passing), `pnpm fallow:audit` and `pnpm fallow:check` all green.

## Migration Explanation

None — no schema changes.

## Future enhancements / Questions

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s7MJjeP8Mr3KRiRA22WwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016s7MJjeP8Mr3KRiRA22WwJ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787248945&installation_model_id=426131&pr_number=1160&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1160&signature=cb8fe731dba8e86773640f93f10c44ddfe4d5126cca31b783f4fe0475bcb01ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->