### PR TITLE
Move Mode of Travel above Course Type in A3 course filters (#1163)

### DIFF
--- a/drift.lock
+++ b/drift.lock
@@ -103,7 +103,7 @@ sig = "557bf3262bf05be3"
 [[bindings]]
 doc = "docs/a3-embeds.md"
 target = "src/app/(embeds)/embeds/courses/CoursesFilters.tsx"
-sig = "d0a25443fa42a1ea"
+sig = "d68a6a972aed9b7d"
 
 [[bindings]]
 doc = "docs/a3-embeds.md"

--- a/src/app/(embeds)/embeds/courses/CoursesFilters.tsx
+++ b/src/app/(embeds)/embeds/courses/CoursesFilters.tsx
@@ -33,6 +33,7 @@ export const CoursesFilters = ({
         defaultOpen={true}
         titleClassName="text-lg"
       />
+      <ModesOfTravelFilter titleClassName="text-lg" />
       <CheckboxFilter
         title="Course Type"
         urlParam="types"
@@ -41,8 +42,7 @@ export const CoursesFilters = ({
       />
       <ProvidersFilter providers={providers} titleClassName="text-lg" />
       <StatesFilter states={states} titleClassName="text-lg" />
-      <AffinityGroupsFilter titleClassName="text-lg" />
-      <ModesOfTravelFilter showBottomBorder={false} titleClassName="text-lg" />
+      <AffinityGroupsFilter showBottomBorder={false} titleClassName="text-lg" />
     </>
   )
 }


### PR DESCRIPTION
## Description

Reorders the filter list in the A3 course embed so **Mode of Travel** sits directly below Date and above Course Type, as requested in #1163.

Before: Date → Course Type → Provider → State → Interest Group → Mode of Travel
After: **Date → Mode of Travel → Course Type → Provider → State → Interest Group**

## Related Issues

Fixes #1163

## Key Changes

- **`src/app/(embeds)/embeds/courses/CoursesFilters.tsx`** — move `<ModesOfTravelFilter>` to the second position, and move the last-item `showBottomBorder={false}` from it to `<AffinityGroupsFilter>` (Interest Group), which is now the last filter, so the "no divider under the last filter" styling stays correct.

No logic, API, or schema changes.

## How to test

1. `pnpm dev`, open the courses embed with filters shown: `http://localhost:3000/embeds/courses?showFilters=true`.
2. Confirm the filter order is Date Range → Mode of Travel → Course Type → Provider → State → Interest Group, and that only the last filter (Interest Group) has no bottom divider.

**Verification performed:** loaded the embed in the running dev server and confirmed from the rendered HTML that the filter titles appear in the new order, that Mode of Travel now renders with a `border-b` divider, and that Interest Group (new last item) renders without one. `pnpm tsc`, `pnpm lint`, and `pnpm fallow:audit` all pass.

## Migration Explanation

None.

## Future enhancements / Questions

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s7MJjeP8Mr3KRiRA22WwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016s7MJjeP8Mr3KRiRA22WwJ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787433138&installation_model_id=426131&pr_number=1164&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1164&signature=c11c93afb76b9ad1d7533f8f98f86f7cbff924e9f2396809531dddfb6e5e7d2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->