### PR TITLE
Remove location from A3 provider pop-up and reorder contacts (#1165)

### DIFF
--- a/docs/a3-embeds.md
+++ b/docs/a3-embeds.md
@@ -64,7 +64,7 @@ With a custom title:
 
 - Providers are grouped by their `statesServiced` field (a provider can appear under multiple states)
 - States are sorted alphabetically and split into two columns
-- Clicking a provider opens a modal with details: name, course types offered, location, website, email, and phone
+- Clicking a provider opens a modal with details: name, course types offered, email, phone, and website
 
 ## Courses Embed
 

--- a/drift.lock
+++ b/drift.lock
@@ -3,7 +3,7 @@ version = 1
 [[bindings]]
 doc = "CLAUDE.md"
 target = "docs/a3-embeds.md"
-sig = "999978b9f92288dc"
+sig = "797bb91d1e86ae6c"
 
 [[bindings]]
 doc = "CLAUDE.md"
@@ -138,7 +138,7 @@ sig = "0c9d89ddd42a7f7d"
 [[bindings]]
 doc = "docs/a3-embeds.md"
 target = "src/components/ProviderPreview.tsx"
-sig = "ca73d8c96121819f"
+sig = "2433d2218a295ca5"
 
 [[bindings]]
 doc = "docs/coding-guide.md"

--- a/src/components/ProviderPreview.tsx
+++ b/src/components/ProviderPreview.tsx
@@ -5,10 +5,9 @@ import Link from 'next/link'
 import type { Provider } from '@/payload-types'
 
 import { courseTypesData } from '@/constants/courseTypes'
-import { getStateLabel } from '@/fields/location/states'
 import { cn } from '@/utilities/ui'
 import { isValidFullUrl } from '@/utilities/validateUrl'
-import { ExternalLink, Mail, MapPin, Phone } from 'lucide-react'
+import { ExternalLink, Mail, Phone } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from './ui/dialog'
 
 export const ProviderPreview = (props: { doc?: Provider }) => {
@@ -16,18 +15,7 @@ export const ProviderPreview = (props: { doc?: Provider }) => {
 
   if (!doc) return null
 
-  const { name, details, location, website, email, phone, courseTypes } = doc
-
-  const getLocationText = () => {
-    if (!location) return null
-    if (location.state === 'INTL') return getStateLabel(location.state)
-    if (location.city && location.state) return `${location.city}, ${location.state}`
-    if (location.city) return location.city
-    if (location.state) return location.state
-    return 'Location'
-  }
-
-  const locationText = getLocationText()
+  const { name, details, website, email, phone, courseTypes } = doc
 
   const courseTypeLabels = courseTypes
     ?.map((ct) => courseTypesData.find((ctd) => ctd.value === ct)?.label)
@@ -35,7 +23,7 @@ export const ProviderPreview = (props: { doc?: Provider }) => {
 
   const validWebsite = website && isValidFullUrl(website) ? website : null
 
-  const contactItems = [locationText, validWebsite, email, phone].filter(Boolean)
+  const contactItems = [email, phone, validWebsite].filter(Boolean)
 
   return (
     <Dialog>
@@ -51,23 +39,6 @@ export const ProviderPreview = (props: { doc?: Provider }) => {
         )}
         {details && <p className="hidden md:block text-sm leading-tight">{details}</p>}
         <div className={cn('space-y-1', contactItems.length > 1 && 'md:columns-2')}>
-          {locationText && (
-            <div className="flex gap-1 text-sm">
-              <MapPin className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
-              <span>{locationText}</span>
-            </div>
-          )}
-          {validWebsite && (
-            <Link
-              href={validWebsite}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex gap-1 text-sm text-blue-600 hover:text-blue-800 hover:underline"
-            >
-              <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
-              <span>Website</span>
-            </Link>
-          )}
           {email && (
             <a href={`mailto:${email}`} className="flex gap-1 text-sm">
               <Mail className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
@@ -79,6 +50,17 @@ export const ProviderPreview = (props: { doc?: Provider }) => {
               <Phone className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
               <span>{phone}</span>
             </a>
+          )}
+          {validWebsite && (
+            <Link
+              href={validWebsite}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex gap-1 text-sm text-blue-600 hover:text-blue-800 hover:underline"
+            >
+              <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
+              <span>Website</span>
+            </Link>
           )}
         </div>
       </DialogContent>


### PR DESCRIPTION
## Description

In the A3 provider embed pop-up, remove the **Location** field (and its map-pin icon) and rearrange the contact block so **Email** and **Phone** are on the left and **Website** is on the right, per #1165.

## Related Issues

Fixes #1165

## Key Changes

- **`src/components/ProviderPreview.tsx`** — drop the Location block, and reorder the remaining contact items to DOM order **Email → Phone → Website**. The block uses a two-column layout (`md:columns-2`), which fills top-to-bottom by column, so this renders Email/Phone in the left column and Website in the right. Removed the now-unused `getLocationText` helper, the `location` destructure, and the `getStateLabel` / `MapPin` imports.

No logic, API, or schema changes.

## How to test

1. `pnpm dev`, open the providers embed: `http://localhost:3000/embeds/providers`, expand a state, and click a provider with contact details.
2. Confirm the pop-up shows no Location line or pin icon, and that Email/Phone appear on the left with Website on the right.

**Verification performed:** drove the embed in a headless browser — expanded a state, opened a provider pop-up, and confirmed (via the rendered dialog + a screenshot) that the map-pin/Location is gone and the contacts render Email + Phone (left) / Website (right). Contact DOM order confirmed as `[email, phone, website]`. `pnpm tsc`, `pnpm lint`, and `pnpm fallow:audit` all pass. (Seeded providers don't populate contact fields, so I temporarily set them on one provider in my local DB just to render the popup — no seed/source changes are included.)

## Migration Explanation

None.

## Future enhancements / Questions

The left/right split relies on CSS multi-column balancing, which is reliable for these short items. If you ever want guaranteed placement regardless of content length, a two-flex-column layout would be more deterministic — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s7MJjeP8Mr3KRiRA22WwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016s7MJjeP8Mr3KRiRA22WwJ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787433969&installation_model_id=426131&pr_number=1166&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1166&signature=7e3b28cd5abc554634245e8d747f8d4170d01dbdd93b15a68580de06243d48f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->