### PR TITLE
Allow the classy attribute in Form Embed sanitization

### DIFF
--- a/__tests__/client/blocks/FormEmbed.client.test.tsx
+++ b/__tests__/client/blocks/FormEmbed.client.test.tsx
@@ -1,0 +1,43 @@
+import { FORM_EMBED_POLICY } from '@/blocks/FormEmbed/Component'
+import DOMPurify from 'dompurify'
+
+// Sanitize the same way EmbedFrame does so the policy is exercised against real provider snippets.
+const sanitize = (html: string) =>
+  DOMPurify.sanitize(html, {
+    ADD_TAGS: FORM_EMBED_POLICY.addTags,
+    ADD_ATTR: FORM_EMBED_POLICY.addAttr,
+    FORCE_BODY: true,
+  })
+
+describe('FORM_EMBED_POLICY sanitization', () => {
+  it('keeps the GoFundMe Pro (Classy) embed snippet intact', () => {
+    const sanitized = sanitize(
+      '<script async="" src="https://giving.gofundme.com/embedded/api/checkout/sdk/js/84977"></script>' +
+        '<div id="nnaqF4a0O1iSXBsTk93L2" classy="802015"></div>',
+    )
+
+    expect(sanitized).toContain(
+      '<script async="" src="https://giving.gofundme.com/embedded/api/checkout/sdk/js/84977">',
+    )
+    expect(sanitized).toContain('id="nnaqF4a0O1iSXBsTk93L2"')
+    expect(sanitized).toContain('classy="802015"')
+  })
+
+  it('keeps the DonorBox embed snippet intact', () => {
+    const sanitized = sanitize(
+      '<script src="https://donorbox.org/widget.js" paypalexpress="false"></script>' +
+        '<iframe src="https://donorbox.org/embed/example" name="donorbox" allowpaymentrequest="allowpaymentrequest" seamless="seamless" frameborder="0" scrolling="no" height="900px" width="100%"></iframe>',
+    )
+
+    expect(sanitized).toContain('<iframe')
+    expect(sanitized).toContain('allowpaymentrequest="allowpaymentrequest"')
+    expect(sanitized).toContain('src="https://donorbox.org/embed/example"')
+  })
+
+  it('strips event-handler attributes', () => {
+    const sanitized = sanitize('<div classy="802015" onclick="alert(1)"></div>')
+
+    expect(sanitized).toContain('classy="802015"')
+    expect(sanitized).not.toContain('onclick')
+  })
+})

--- a/src/blocks/FormEmbed/Component.tsx
+++ b/src/blocks/FormEmbed/Component.tsx
@@ -7,9 +7,9 @@ type Props = FormEmbedBlockProps & {
   className?: string
 }
 
-const FORM_EMBED_POLICY = {
+export const FORM_EMBED_POLICY = {
   addTags: ['iframe', 'script', 'style', 'dbox-widget'],
-  addAttr: [...BASE_ADD_ATTR, 'allowpaymentrequest', 'campaign', 'enable-auto-scroll'],
+  addAttr: [...BASE_ADD_ATTR, 'allowpaymentrequest', 'campaign', 'classy', 'enable-auto-scroll'],
   sandbox:
     'allow-scripts allow-presentation allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox',
 }


### PR DESCRIPTION
## Description

GoFundMe Pro (Classy) embeds consist of a checkout SDK `<script>` plus a mount-point `<div id="..." classy="<campaign id>">`. The Form Embed block's DOMPurify policy didn't allowlist the `classy` attribute, so it was stripped during sanitization — the SDK loaded but couldn't find its target element, and the donation form rendered blank.

This adds `classy` to the Form Embed attribute allowlist.

## Related Issues

Fixes #1155

## Key Changes

- Add `classy` to `FORM_EMBED_POLICY.addAttr` in `src/blocks/FormEmbed/Component.tsx` (exported the policy so tests can exercise it)
- Add `__tests__/client/blocks/FormEmbed.client.test.tsx` — runs the real GoFundMe Pro and DonorBox snippets through the same DOMPurify call `EmbedFrame` uses, and verifies event-handler attributes are still stripped

## How to test

1. `pnpm test -- --testPathPattern FormEmbed`
2. Or end-to-end: on a page, add a **Form Embed** block and paste both snippets from #1155 (the `<script>` and the `<div>` together). The donation form should render. Note the embedding domain must be whitelisted in GoFundMe Pro's settings (avy-fx.org already is).

## Screenshots / Demo video

<img width="3380" height="3930" alt="image" src="https://github.com/user-attachments/assets/85cb118b-32c5-48e6-b1ce-f74efb9b811d" />

## Migration Explanation

No schema changes, no migration.

## Future enhancements / Questions

- Onboarding should ask new centers which donation provider they use so provider-specific attributes can be allowlisted ahead of time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788629682&installation_model_id=426131&pr_number=1173&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1173&signature=27bab52d584189fbc83e40fb7ecad9464e8387df2c83f901db819c154ea5ee6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->