### PR TITLE
Rework station graph controls: inline toolbar, Edit graphs modal, shadcn dropdowns

### DIFF
--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -14,29 +14,8 @@ jest.mock('next/dynamic', () => () => {
   return Noop
 })
 
-// jsdom lacks the layout APIs Radix Select's popper positioning touches.
-beforeAll(() => {
-  window.HTMLElement.prototype.scrollIntoView = jest.fn()
-  class ResizeObserverStub {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  }
-  globalThis.ResizeObserver = ResizeObserverStub
-})
-
 function openEditView() {
   fireEvent.click(screen.getByRole('button', { name: /Edit graphs/ }))
-}
-
-// Radix Select: a click (initial pointer type "touch") both opens the
-// trigger and commits an option.
-function openSelect(name: string) {
-  fireEvent.click(screen.getByRole('combobox', { name }))
-}
-
-function pickOption(name: string) {
-  fireEvent.click(screen.getByRole('option', { name }))
 }
 
 function series(stid: string, variable = 'air_temp'): GraphData['series'][number] {
@@ -220,21 +199,23 @@ describe('StationGraphs compare picker', () => {
 
   it('excludes the current station from the compare options', () => {
     renderGraphs()
-    openSelect('Compare with')
-    expect(screen.queryByRole('option', { name: current.displayName })).not.toBeInTheDocument()
-    expect(screen.getByRole('option', { name: other.displayName })).toBeInTheDocument()
+    const select = screen.getByLabelText(/Compare with/)
+    const values = Array.from(select.querySelectorAll('option')).map((o) => o.value)
+    expect(values).not.toContain(current.slug)
+    expect(values).toContain(other.slug)
   })
 
-  function renderWithCompares(...groups: (typeof current)[]) {
+  function renderWithCompares(...slugs: string[]): HTMLElement {
     renderGraphs()
-    for (const group of groups) {
-      openSelect('Compare with')
-      pickOption(group.displayName)
+    const select = screen.getByLabelText(/Compare with/)
+    for (const slug of slugs) {
+      fireEvent.change(select, { target: { value: slug } })
     }
+    return select
   }
 
   it('refetches with the stids of each added station appended', () => {
-    renderWithCompares(other, third)
+    renderWithCompares(other.slug, third.slug)
 
     const expected = [...current.stids, ...other.stids, ...third.stids].join(',')
     expect(fetchedUrls().some((url) => url.includes(`stids=${encodeURIComponent(expected)}`))).toBe(
@@ -243,7 +224,7 @@ describe('StationGraphs compare picker', () => {
   })
 
   it('removes a station via its toolbar chip', () => {
-    renderWithCompares(other, third)
+    renderWithCompares(other.slug, third.slug)
     fireEvent.click(screen.getByLabelText(`Remove ${other.displayName}`))
 
     const urls = fetchedUrls()
@@ -252,23 +233,21 @@ describe('StationGraphs compare picker', () => {
   })
 
   it('shows removable chips for compared stations in the toolbar', () => {
-    renderWithCompares(other, third)
+    renderWithCompares(other.slug, third.slug)
     expect(screen.getByLabelText(`Remove ${other.displayName}`)).toBeInTheDocument()
     expect(screen.getByLabelText(`Remove ${third.displayName}`)).toBeInTheDocument()
   })
 
   it('hides selected stations from the options and disables the select at the cap', () => {
-    renderWithCompares(other)
-    const combobox = () => screen.getByRole('combobox', { name: 'Compare with' })
-    expect(combobox()).not.toBeDisabled()
+    const select = renderWithCompares(other.slug)
 
-    openSelect('Compare with')
-    expect(screen.queryByRole('option', { name: other.displayName })).not.toBeInTheDocument()
-    pickOption(third.displayName)
+    const values = Array.from(select.querySelectorAll('option')).map((o) => o.value)
+    expect(values).not.toContain(other.slug)
+    expect(select).not.toBeDisabled()
 
-    openSelect('Compare with')
-    pickOption(fourth.displayName)
-    expect(combobox()).toBeDisabled()
+    fireEvent.change(select, { target: { value: third.slug } })
+    fireEvent.change(select, { target: { value: fourth.slug } })
+    expect(select).toBeDisabled()
   })
 })
 

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -14,6 +14,10 @@ jest.mock('next/dynamic', () => () => {
   return Noop
 })
 
+function openEditView() {
+  fireEvent.click(screen.getByRole('button', { name: /Edit view/ }))
+}
+
 function series(stid: string, variable = 'air_temp'): GraphData['series'][number] {
   return {
     kind: 'raw',
@@ -195,6 +199,7 @@ describe('StationGraphs compare picker', () => {
 
   it('excludes the current station from the compare options', () => {
     renderGraphs()
+    openEditView()
     const select = screen.getByLabelText(/Compare with/)
     const values = Array.from(select.querySelectorAll('option')).map((o) => o.value)
     expect(values).not.toContain(current.slug)
@@ -203,6 +208,7 @@ describe('StationGraphs compare picker', () => {
 
   function renderWithCompares(...slugs: string[]): HTMLElement {
     renderGraphs()
+    openEditView()
     const select = screen.getByLabelText(/Compare with/)
     for (const slug of slugs) {
       fireEvent.change(select, { target: { value: slug } })
@@ -226,6 +232,11 @@ describe('StationGraphs compare picker', () => {
     const urls = fetchedUrls()
     const expected = [...current.stids, ...third.stids].join(',')
     expect(urls[urls.length - 1]).toContain(`stids=${encodeURIComponent(expected)}`)
+  })
+
+  it('summarizes compared stations in the toolbar', () => {
+    renderWithCompares(other.slug, third.slug)
+    expect(screen.getByText(`· vs ${other.displayName}, ${third.displayName}`)).toBeInTheDocument()
   })
 
   it('hides selected stations from the options and disables the select at the cap', () => {
@@ -266,10 +277,6 @@ describe('StationGraphs chart arrangement', () => {
         currentSlug={current.slug}
       />,
     )
-  }
-
-  function openEditView() {
-    fireEvent.click(screen.getByRole('button', { name: /Edit view/ }))
   }
 
   function graphCheckbox(title: string): HTMLElement {

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -3,7 +3,7 @@ import { buildChartOption } from '@/components/WeatherStations/stationGraphOptio
 import { NWAC_WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
 import type { GraphData } from '@/services/snowobs/graph'
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 const TEMP_PRESET = { key: 'temp', title: 'Temperature', variables: ['air_temp'] }
 const RH_PRESET = { key: 'rh', title: 'Relative Humidity', variables: ['relative_humidity'] }
@@ -268,44 +268,72 @@ describe('StationGraphs chart arrangement', () => {
     )
   }
 
-  async function expectChartOrder(titles: string[]): Promise<void> {
+  function openEditView() {
+    fireEvent.click(screen.getByRole('button', { name: /Edit view/ }))
+  }
+
+  function graphCheckbox(title: string): HTMLElement {
+    return screen.getByRole('checkbox', { name: title })
+  }
+
+  async function expectRowOrder(titles: string[]): Promise<void> {
     const buttons = await screen.findAllByLabelText(/^Move .* down$/)
     const labels = buttons.map((b) => b.getAttribute('aria-label') ?? '')
     expect(labels).toEqual(titles.map((title) => `Move ${title} down`))
   }
 
-  it('moves a chart down past its neighbor', async () => {
+  it('moves a graph down past its neighbor', async () => {
     renderGraphs()
-    await expectChartOrder(['Temperature', 'Relative Humidity'])
+    openEditView()
+    await expectRowOrder(['Temperature', 'Relative Humidity'])
 
     fireEvent.click(screen.getByLabelText('Move Temperature down'))
-    await expectChartOrder(['Relative Humidity', 'Temperature'])
+    await expectRowOrder(['Relative Humidity', 'Temperature'])
   })
 
-  it('hides a chart into a restorable chip', async () => {
+  it('hides a graph into a restorable chip', async () => {
     renderGraphs()
-    fireEvent.click(await screen.findByLabelText('Hide Temperature'))
-    expect(screen.queryByLabelText('Hide Temperature')).not.toBeInTheDocument()
+    openEditView()
+    fireEvent.click(graphCheckbox('Temperature'))
+    expect(graphCheckbox('Temperature')).not.toBeChecked()
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
 
     fireEvent.click(screen.getByLabelText('Show Temperature'))
-    expect(await screen.findByLabelText('Hide Temperature')).toBeInTheDocument()
+    openEditView()
+    expect(graphCheckbox('Temperature')).toBeChecked()
   })
 
   it('persists the arrangement to localStorage', async () => {
     renderGraphs()
-    fireEvent.click(await screen.findByLabelText('Hide Temperature'))
+    openEditView()
+    fireEvent.click(graphCheckbox('Temperature'))
 
     const stored = window.localStorage.getItem('nwac-station-graph-prefs') ?? ''
     expect(stored).toContain('"hidden":["temp"]')
   })
 
-  it('drops charts whose variables no station reports', async () => {
+  it('resets order and visibility to defaults', async () => {
+    renderGraphs()
+    openEditView()
+    fireEvent.click(screen.getByLabelText('Move Temperature down'))
+    fireEvent.click(graphCheckbox('Relative Humidity'))
+    await expectRowOrder(['Relative Humidity', 'Temperature'])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset to defaults' }))
+    await expectRowOrder(['Temperature', 'Relative Humidity'])
+    expect(graphCheckbox('Relative Humidity')).toBeChecked()
+  })
+
+  it('disables graphs whose variables no station reports', async () => {
     fetchMock.mockResolvedValue({
       ok: true,
       json: async () => ({ ...dataWithSeries, series: [series('1', 'air_temp')] }),
     })
     renderGraphs()
-    await expectChartOrder(['Temperature'])
-    expect(screen.queryByLabelText('Hide Relative Humidity')).not.toBeInTheDocument()
+    openEditView()
+    const rh = () => screen.getByRole('checkbox', { name: /Relative Humidity/ })
+    await waitFor(() => expect(rh()).toBeDisabled())
+    expect(rh()).not.toBeChecked()
+    expect(screen.getByText('No data')).toBeInTheDocument()
   })
 })

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -14,8 +14,29 @@ jest.mock('next/dynamic', () => () => {
   return Noop
 })
 
+// jsdom lacks the layout APIs Radix Select's popper positioning touches.
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn()
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  globalThis.ResizeObserver = ResizeObserverStub
+})
+
 function openEditView() {
-  fireEvent.click(screen.getByRole('button', { name: /Edit view/ }))
+  fireEvent.click(screen.getByRole('button', { name: /Edit graphs/ }))
+}
+
+// Radix Select: a click (initial pointer type "touch") both opens the
+// trigger and commits an option.
+function openSelect(name: string) {
+  fireEvent.click(screen.getByRole('combobox', { name }))
+}
+
+function pickOption(name: string) {
+  fireEvent.click(screen.getByRole('option', { name }))
 }
 
 function series(stid: string, variable = 'air_temp'): GraphData['series'][number] {
@@ -199,25 +220,21 @@ describe('StationGraphs compare picker', () => {
 
   it('excludes the current station from the compare options', () => {
     renderGraphs()
-    openEditView()
-    const select = screen.getByLabelText(/Compare with/)
-    const values = Array.from(select.querySelectorAll('option')).map((o) => o.value)
-    expect(values).not.toContain(current.slug)
-    expect(values).toContain(other.slug)
+    openSelect('Compare with')
+    expect(screen.queryByRole('option', { name: current.displayName })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: other.displayName })).toBeInTheDocument()
   })
 
-  function renderWithCompares(...slugs: string[]): HTMLElement {
+  function renderWithCompares(...groups: (typeof current)[]) {
     renderGraphs()
-    openEditView()
-    const select = screen.getByLabelText(/Compare with/)
-    for (const slug of slugs) {
-      fireEvent.change(select, { target: { value: slug } })
+    for (const group of groups) {
+      openSelect('Compare with')
+      pickOption(group.displayName)
     }
-    return select
   }
 
   it('refetches with the stids of each added station appended', () => {
-    renderWithCompares(other.slug, third.slug)
+    renderWithCompares(other, third)
 
     const expected = [...current.stids, ...other.stids, ...third.stids].join(',')
     expect(fetchedUrls().some((url) => url.includes(`stids=${encodeURIComponent(expected)}`))).toBe(
@@ -225,8 +242,8 @@ describe('StationGraphs compare picker', () => {
     )
   })
 
-  it('removes a station via its chip', () => {
-    renderWithCompares(other.slug, third.slug)
+  it('removes a station via its toolbar chip', () => {
+    renderWithCompares(other, third)
     fireEvent.click(screen.getByLabelText(`Remove ${other.displayName}`))
 
     const urls = fetchedUrls()
@@ -234,21 +251,24 @@ describe('StationGraphs compare picker', () => {
     expect(urls[urls.length - 1]).toContain(`stids=${encodeURIComponent(expected)}`)
   })
 
-  it('summarizes compared stations in the toolbar', () => {
-    renderWithCompares(other.slug, third.slug)
-    expect(screen.getByText(`· vs ${other.displayName}, ${third.displayName}`)).toBeInTheDocument()
+  it('shows removable chips for compared stations in the toolbar', () => {
+    renderWithCompares(other, third)
+    expect(screen.getByLabelText(`Remove ${other.displayName}`)).toBeInTheDocument()
+    expect(screen.getByLabelText(`Remove ${third.displayName}`)).toBeInTheDocument()
   })
 
   it('hides selected stations from the options and disables the select at the cap', () => {
-    const select = renderWithCompares(other.slug)
+    renderWithCompares(other)
+    const combobox = () => screen.getByRole('combobox', { name: 'Compare with' })
+    expect(combobox()).not.toBeDisabled()
 
-    const values = Array.from(select.querySelectorAll('option')).map((o) => o.value)
-    expect(values).not.toContain(other.slug)
-    expect(select).not.toBeDisabled()
+    openSelect('Compare with')
+    expect(screen.queryByRole('option', { name: other.displayName })).not.toBeInTheDocument()
+    pickOption(third.displayName)
 
-    fireEvent.change(select, { target: { value: third.slug } })
-    fireEvent.change(select, { target: { value: fourth.slug } })
-    expect(select).toBeDisabled()
+    openSelect('Compare with')
+    pickOption(fourth.displayName)
+    expect(combobox()).toBeDisabled()
   })
 })
 
@@ -298,16 +318,20 @@ describe('StationGraphs chart arrangement', () => {
     await expectRowOrder(['Relative Humidity', 'Temperature'])
   })
 
-  it('hides a graph into a restorable chip', async () => {
+  it('hides a graph, counts it on the trigger, and restores it from the dialog', async () => {
     renderGraphs()
     openEditView()
     fireEvent.click(graphCheckbox('Temperature'))
     expect(graphCheckbox('Temperature')).not.toBeChecked()
     fireEvent.click(screen.getByRole('button', { name: 'Done' }))
 
-    fireEvent.click(screen.getByLabelText('Show Temperature'))
+    expect(screen.getByRole('button', { name: 'Edit graphs 1 hidden' })).toBeInTheDocument()
+
     openEditView()
+    fireEvent.click(graphCheckbox('Temperature'))
     expect(graphCheckbox('Temperature')).toBeChecked()
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(screen.getByRole('button', { name: 'Edit graphs' })).toBeInTheDocument()
   })
 
   it('persists the arrangement to localStorage', async () => {

--- a/__tests__/client/components/StationGraphs.client.test.tsx
+++ b/__tests__/client/components/StationGraphs.client.test.tsx
@@ -14,8 +14,29 @@ jest.mock('next/dynamic', () => () => {
   return Noop
 })
 
+// jsdom lacks the layout APIs Radix Select's positioning touches.
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn()
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  globalThis.ResizeObserver = ResizeObserverStub
+})
+
 function openEditView() {
   fireEvent.click(screen.getByRole('button', { name: /Edit graphs/ }))
+}
+
+// Radix Select: a click (initial pointer type "touch") both opens the
+// trigger and commits an option.
+function openSelect(name: string) {
+  fireEvent.click(screen.getByRole('combobox', { name }))
+}
+
+function pickOption(name: string) {
+  fireEvent.click(screen.getByRole('option', { name }))
 }
 
 function series(stid: string, variable = 'air_temp'): GraphData['series'][number] {
@@ -199,23 +220,21 @@ describe('StationGraphs compare picker', () => {
 
   it('excludes the current station from the compare options', () => {
     renderGraphs()
-    const select = screen.getByLabelText(/Compare with/)
-    const values = Array.from(select.querySelectorAll('option')).map((o) => o.value)
-    expect(values).not.toContain(current.slug)
-    expect(values).toContain(other.slug)
+    openSelect('Compare with')
+    expect(screen.queryByRole('option', { name: current.displayName })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: other.displayName })).toBeInTheDocument()
   })
 
-  function renderWithCompares(...slugs: string[]): HTMLElement {
+  function renderWithCompares(...groups: (typeof current)[]) {
     renderGraphs()
-    const select = screen.getByLabelText(/Compare with/)
-    for (const slug of slugs) {
-      fireEvent.change(select, { target: { value: slug } })
+    for (const group of groups) {
+      openSelect('Compare with')
+      pickOption(group.displayName)
     }
-    return select
   }
 
   it('refetches with the stids of each added station appended', () => {
-    renderWithCompares(other.slug, third.slug)
+    renderWithCompares(other, third)
 
     const expected = [...current.stids, ...other.stids, ...third.stids].join(',')
     expect(fetchedUrls().some((url) => url.includes(`stids=${encodeURIComponent(expected)}`))).toBe(
@@ -224,7 +243,7 @@ describe('StationGraphs compare picker', () => {
   })
 
   it('removes a station via its toolbar chip', () => {
-    renderWithCompares(other.slug, third.slug)
+    renderWithCompares(other, third)
     fireEvent.click(screen.getByLabelText(`Remove ${other.displayName}`))
 
     const urls = fetchedUrls()
@@ -233,21 +252,23 @@ describe('StationGraphs compare picker', () => {
   })
 
   it('shows removable chips for compared stations in the toolbar', () => {
-    renderWithCompares(other.slug, third.slug)
+    renderWithCompares(other, third)
     expect(screen.getByLabelText(`Remove ${other.displayName}`)).toBeInTheDocument()
     expect(screen.getByLabelText(`Remove ${third.displayName}`)).toBeInTheDocument()
   })
 
   it('hides selected stations from the options and disables the select at the cap', () => {
-    const select = renderWithCompares(other.slug)
+    renderWithCompares(other)
+    const combobox = () => screen.getByRole('combobox', { name: 'Compare with' })
+    expect(combobox()).not.toBeDisabled()
 
-    const values = Array.from(select.querySelectorAll('option')).map((o) => o.value)
-    expect(values).not.toContain(other.slug)
-    expect(select).not.toBeDisabled()
+    openSelect('Compare with')
+    expect(screen.queryByRole('option', { name: other.displayName })).not.toBeInTheDocument()
+    pickOption(third.displayName)
 
-    fireEvent.change(select, { target: { value: third.slug } })
-    fireEvent.change(select, { target: { value: fourth.slug } })
-    expect(select).toBeDisabled()
+    openSelect('Compare with')
+    pickOption(fourth.displayName)
+    expect(combobox()).toBeDisabled()
   })
 })
 

--- a/__tests__/client/components/stationGraphPrefs.client.test.ts
+++ b/__tests__/client/components/stationGraphPrefs.client.test.ts
@@ -1,5 +1,6 @@
 import {
   loadChartPrefs,
+  moveToKey,
   reconcileChartPrefs,
   saveChartPrefs,
   swapWithNeighbor,
@@ -30,21 +31,27 @@ describe('load/save round trip', () => {
 })
 
 describe('swapWithNeighbor', () => {
-  const none = () => false
-
   it('swaps with the adjacent key', () => {
-    expect(swapWithNeighbor(['a', 'b', 'c'], 'b', -1, none)).toEqual(['b', 'a', 'c'])
-  })
-
-  it('skips keys the caller marks unswappable', () => {
-    const skipB = (key: string) => key === 'b'
-    expect(swapWithNeighbor(['a', 'b', 'c'], 'a', 1, skipB)).toEqual(['c', 'b', 'a'])
+    expect(swapWithNeighbor(['a', 'b', 'c'], 'b', -1)).toEqual(['b', 'a', 'c'])
   })
 
   it('returns the order untouched at a boundary', () => {
     const order = ['a', 'b']
-    expect(swapWithNeighbor(order, 'a', -1, none)).toBe(order)
-    const skipA = (key: string) => key === 'a'
-    expect(swapWithNeighbor(order, 'b', -1, skipA)).toBe(order)
+    expect(swapWithNeighbor(order, 'a', -1)).toBe(order)
+    expect(swapWithNeighbor(order, 'b', 1)).toBe(order)
+  })
+})
+
+describe('moveToKey', () => {
+  it('moves a key to the target position, shifting the keys between', () => {
+    expect(moveToKey(['a', 'b', 'c', 'd'], 'a', 'c')).toEqual(['b', 'c', 'a', 'd'])
+    expect(moveToKey(['a', 'b', 'c', 'd'], 'd', 'b')).toEqual(['a', 'd', 'b', 'c'])
+  })
+
+  it('returns the order untouched for unknown or identical keys', () => {
+    const order = ['a', 'b']
+    expect(moveToKey(order, 'a', 'a')).toBe(order)
+    expect(moveToKey(order, 'x', 'a')).toBe(order)
+    expect(moveToKey(order, 'a', 'x')).toBe(order)
   })
 })

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
   },
   "dependencies": {
     "@date-fns/tz": "^1.4.1",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@libsql/client": "^0.17.2",
     "@open-iframe-resizer/react": "^2.1.0",
     "@payloadcms/admin-bar": "3.81.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,15 @@ importers:
       '@date-fns/tz':
         specifier: ^1.4.1
         version: 1.4.1
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.5)
       '@libsql/client':
         specifier: ^0.17.2
         version: 0.17.2

--- a/src/app/(frontend)/[center]/weather/stations/page.tsx
+++ b/src/app/(frontend)/[center]/weather/stations/page.tsx
@@ -28,7 +28,7 @@ export default async function Page({ params }: Args) {
 
   return (
     <div className="flex flex-col gap-6 mb-10">
-      <div className="container flex flex-wrap items-start justify-between gap-3 pb-4">
+      <div className="container flex flex-wrap items-end justify-between gap-3 pb-4">
         <div className="prose dark:prose-invert max-w-none">
           <h1 className="font-bold">Weather Stations</h1>
         </div>

--- a/src/app/(frontend)/[center]/weather/stations/page.tsx
+++ b/src/app/(frontend)/[center]/weather/stations/page.tsx
@@ -28,11 +28,13 @@ export default async function Page({ params }: Args) {
 
   return (
     <div className="flex flex-col gap-6 mb-10">
-      <div className="container flex justify-between gap-3 pb-4">
+      <div className="container flex flex-wrap items-start justify-between gap-3 pb-4">
         <div className="prose dark:prose-invert max-w-none">
           <h1 className="font-bold">Weather Stations</h1>
         </div>
-        <StationPicker />
+        <div className="flex flex-col items-end">
+          <StationPicker />
+        </div>
       </div>
 
       <div className="container columns-1 gap-6 sm:columns-2 lg:columns-3 xl:columns-4">

--- a/src/app/(frontend)/[center]/weather/stations/page.tsx
+++ b/src/app/(frontend)/[center]/weather/stations/page.tsx
@@ -28,7 +28,7 @@ export default async function Page({ params }: Args) {
 
   return (
     <div className="flex flex-col gap-6 mb-10">
-      <div className="container flex flex-wrap items-end justify-between gap-3 pb-4">
+      <div className="container flex flex-wrap items-start justify-between gap-3 pb-4">
         <div className="prose dark:prose-invert max-w-none">
           <h1 className="font-bold">Weather Stations</h1>
         </div>

--- a/src/components/WeatherStations/EChart.tsx
+++ b/src/components/WeatherStations/EChart.tsx
@@ -53,7 +53,14 @@ export function EChart({
     }
     const observer = new ResizeObserver(() => chart.resize())
     observer.observe(container)
+
+    const gateWheel = (event: WheelEvent) => {
+      if (!event.ctrlKey) event.stopPropagation()
+    }
+    container.addEventListener('wheel', gateWheel, { capture: true, passive: true })
+
     return () => {
+      container.removeEventListener('wheel', gateWheel, { capture: true })
       observer.disconnect()
       chart.dispose()
       chartRef.current = null

--- a/src/components/WeatherStations/EditViewDialog.tsx
+++ b/src/components/WeatherStations/EditViewDialog.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import type { UnitSystem } from '@/services/snowobs/metricUnits'
+import { cn } from '@/utilities/ui'
+import type { DragEndEvent } from '@dnd-kit/core'
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { ArrowDown, ArrowUp, GripVertical, SlidersHorizontal } from 'lucide-react'
+import type { GraphPreset } from './stationGraphPresets'
+import { UnitToggle } from './UnitToggle'
+import type { useChartArrangement } from './useChartArrangement'
+
+const rowButtonClass =
+  'rounded-md p-1 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:hover:text-muted-foreground'
+
+function GraphRow({
+  preset,
+  empty,
+  arrangement,
+}: {
+  preset: GraphPreset
+  empty: boolean
+  arrangement: ReturnType<typeof useChartArrangement>
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: preset.key,
+    disabled: empty,
+  })
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        'flex items-center gap-2 rounded-md px-1 py-1.5',
+        isDragging && 'z-10 bg-muted shadow-sm',
+        empty && 'opacity-50',
+      )}
+    >
+      <button
+        type="button"
+        aria-label={`Drag to reorder ${preset.title}`}
+        disabled={empty}
+        className={cn(rowButtonClass, !empty && 'cursor-grab active:cursor-grabbing touch-none')}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <Checkbox
+        id={`graph-row-${preset.key}`}
+        checked={!empty && !arrangement.isHidden(preset.key)}
+        disabled={empty}
+        onCheckedChange={(checked) =>
+          checked ? arrangement.showChart(preset.key) : arrangement.hideChart(preset.key)
+        }
+      />
+      <label
+        htmlFor={`graph-row-${preset.key}`}
+        className={cn('flex-1 text-sm', empty ? 'cursor-not-allowed' : 'cursor-pointer')}
+      >
+        {preset.title}
+        {empty && <span className="ml-2 text-xs text-muted-foreground">No data</span>}
+      </label>
+      <button
+        type="button"
+        aria-label={`Move ${preset.title} up`}
+        disabled={empty || !arrangement.canMove(preset.key, -1)}
+        onClick={() => arrangement.moveChart(preset.key, -1)}
+        className={rowButtonClass}
+      >
+        <ArrowUp className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        aria-label={`Move ${preset.title} down`}
+        disabled={empty || !arrangement.canMove(preset.key, 1)}
+        onClick={() => arrangement.moveChart(preset.key, 1)}
+        className={rowButtonClass}
+      >
+        <ArrowDown className="h-4 w-4" />
+      </button>
+    </li>
+  )
+}
+
+function GraphList({
+  arrangement,
+  emptyKeys,
+}: {
+  arrangement: ReturnType<typeof useChartArrangement>
+  emptyKeys: ReadonlySet<string>
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  const onDragEnd = ({ active, over }: DragEndEvent) => {
+    if (over && active.id !== over.id) arrangement.reorderChart(String(active.id), String(over.id))
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+      <SortableContext
+        items={arrangement.orderedPresets.map((p) => p.key)}
+        strategy={verticalListSortingStrategy}
+      >
+        <ul className="mt-1">
+          {arrangement.orderedPresets.map((preset) => (
+            <GraphRow
+              key={preset.key}
+              preset={preset}
+              empty={emptyKeys.has(preset.key)}
+              arrangement={arrangement}
+            />
+          ))}
+        </ul>
+      </SortableContext>
+    </DndContext>
+  )
+}
+
+type EditViewProps = {
+  arrangement: ReturnType<typeof useChartArrangement>
+  emptyKeys: ReadonlySet<string>
+  unitSystem: UnitSystem
+  onUnitChange: (system: UnitSystem) => void
+}
+
+function EditViewPanel({ arrangement, emptyKeys, unitSystem, onUnitChange }: EditViewProps) {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Edit view</DialogTitle>
+        <DialogDescription>
+          Choose units, show or hide graphs, and drag to reorder them.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm font-medium">Units</span>
+        <UnitToggle unit={unitSystem} onChange={onUnitChange} />
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <span className="text-sm font-medium">Graphs</span>
+        <GraphList arrangement={arrangement} emptyKeys={emptyKeys} />
+      </div>
+      <DialogFooter className="sm:justify-between">
+        <Button variant="ghost" size="sm" onClick={arrangement.resetArrangement}>
+          Reset to defaults
+        </Button>
+        <DialogClose asChild>
+          <Button size="sm">Done</Button>
+        </DialogClose>
+      </DialogFooter>
+    </>
+  )
+}
+
+export function EditViewDialog(props: EditViewProps) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-2">
+          <SlidersHorizontal className="h-4 w-4" />
+          Edit view
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-md">
+        <EditViewPanel {...props} />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/WeatherStations/EditViewDialog.tsx
+++ b/src/components/WeatherStations/EditViewDialog.tsx
@@ -12,6 +12,15 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { getStationGroup, MAX_COMPARE_STATIONS } from '@/constants/weatherStations'
+import type { UnitSystem } from '@/services/snowobs/metricUnits'
 import { cn } from '@/utilities/ui'
 import type { DragEndEvent } from '@dnd-kit/core'
 import {
@@ -29,12 +38,146 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { ArrowDown, ArrowUp, GripVertical, SlidersHorizontal } from 'lucide-react'
+import { ArrowDown, ArrowUp, GripVertical, SlidersHorizontal, X } from 'lucide-react'
 import type { GraphPreset } from './stationGraphPresets'
+import type { StationPeriod } from './stationPeriods'
+import { DEFAULT_GRAPH_PERIOD, GRAPH_PERIODS } from './stationPeriods'
+import { StationSelectGroups, stationSelectTriggerClass } from './StationPicker'
+import { UnitToggle } from './UnitToggle'
 import type { useChartArrangement } from './useChartArrangement'
 
 const rowButtonClass =
-  'rounded-md p-1 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:hover:text-muted-foreground'
+  'rounded-md p-1.5 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:hover:text-muted-foreground'
+
+const sectionLabelClass = 'text-sm font-medium'
+
+export const chipClass = 'inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm'
+
+export function PeriodSelect({
+  active,
+  onChange,
+  className,
+}: {
+  active: StationPeriod
+  onChange: (period: StationPeriod) => void
+  className?: string
+}) {
+  return (
+    <Select
+      value={active.key}
+      onValueChange={(key) =>
+        onChange(GRAPH_PERIODS.find((p) => p.key === key) ?? DEFAULT_GRAPH_PERIOD)
+      }
+    >
+      <SelectTrigger
+        aria-label="Date range"
+        className={cn(stationSelectTriggerClass, 'py-1.5', className)}
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent position="item-aligned">
+        {GRAPH_PERIODS.map((period) => (
+          <SelectItem key={period.key} value={period.key}>
+            {period.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+export function CompareSelect({
+  currentSlug,
+  compareSlugs,
+  onCompareChange,
+  className,
+}: {
+  currentSlug: string
+  compareSlugs: string[]
+  onCompareChange: (slugs: string[]) => void
+  className?: string
+}) {
+  const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
+  return (
+    <Select
+      value=""
+      disabled={atCap}
+      onValueChange={(slug) => onCompareChange([...compareSlugs, slug])}
+    >
+      <SelectTrigger
+        aria-label="Compare with"
+        className={cn(stationSelectTriggerClass, 'py-1.5', className)}
+      >
+        <SelectValue
+          placeholder={atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
+        />
+      </SelectTrigger>
+      <SelectContent position="item-aligned">
+        <StationSelectGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
+      </SelectContent>
+    </Select>
+  )
+}
+
+export function CompareChips({
+  compareSlugs,
+  onRemove,
+}: {
+  compareSlugs: string[]
+  onRemove: (slug: string) => void
+}) {
+  const selected = compareSlugs.flatMap((slug) => getStationGroup(slug) ?? [])
+
+  return selected.map((group) => (
+    <span key={group.slug} className={chipClass}>
+      {group.displayName}
+      <button
+        type="button"
+        aria-label={`Remove ${group.displayName}`}
+        onClick={() => onRemove(group.slug)}
+        className="text-muted-foreground hover:text-foreground"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </span>
+  ))
+}
+
+// The toolbar controls, repeated inside the dialog for small screens where
+// the toolbar shows only the Edit graphs button.
+function MobileViewControls(props: EditViewProps) {
+  return (
+    <div className="flex flex-col gap-4 sm:hidden">
+      <div className="flex items-center justify-between gap-3">
+        <span className={sectionLabelClass}>Date range</span>
+        <PeriodSelect active={props.graphPeriod} onChange={props.onPeriodChange} />
+      </div>
+      <div className="flex items-center justify-between gap-3">
+        <span className={sectionLabelClass}>Units</span>
+        <UnitToggle unit={props.unitSystem} onChange={props.onUnitChange} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className={sectionLabelClass}>Compare stations</span>
+        <CompareSelect
+          currentSlug={props.currentSlug}
+          compareSlugs={props.compareSlugs}
+          onCompareChange={props.onCompareChange}
+          className="w-full"
+        />
+        {props.compareSlugs.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2">
+            <CompareChips
+              compareSlugs={props.compareSlugs}
+              onRemove={(slug) =>
+                props.onCompareChange(props.compareSlugs.filter((s) => s !== slug))
+              }
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
 
 function GraphRow({
   preset,
@@ -144,23 +287,32 @@ function GraphList({
   )
 }
 
-type EditViewProps = {
+export type EditViewProps = {
+  graphPeriod: StationPeriod
+  onPeriodChange: (period: StationPeriod) => void
+  unitSystem: UnitSystem
+  onUnitChange: (system: UnitSystem) => void
+  currentSlug: string
+  compareSlugs: string[]
+  onCompareChange: (slugs: string[]) => void
   arrangement: ReturnType<typeof useChartArrangement>
   emptyKeys: ReadonlySet<string>
 }
 
-function EditGraphsPanel({ arrangement, emptyKeys }: EditViewProps) {
+function EditGraphsPanel(props: EditViewProps) {
   return (
     <>
       <DialogHeader>
         <DialogTitle>Edit graphs</DialogTitle>
         <DialogDescription>Show, hide, and drag to reorder graphs.</DialogDescription>
       </DialogHeader>
+      <MobileViewControls {...props} />
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <GraphList arrangement={arrangement} emptyKeys={emptyKeys} />
+        <span className={cn(sectionLabelClass, 'sm:hidden')}>Graphs</span>
+        <GraphList arrangement={props.arrangement} emptyKeys={props.emptyKeys} />
       </div>
       <DialogFooter className="sm:justify-between">
-        <Button variant="ghost" size="sm" onClick={arrangement.resetArrangement}>
+        <Button variant="ghost" size="sm" onClick={props.arrangement.resetArrangement}>
           Reset to defaults
         </Button>
         <DialogClose asChild>
@@ -176,7 +328,7 @@ export function EditViewDialog(props: EditViewProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline" className="gap-2">
+        <Button variant="outline" className="w-full gap-2 sm:w-auto">
           <SlidersHorizontal className="h-4 w-4" />
           Edit graphs
           {hiddenCount > 0 && (
@@ -187,7 +339,7 @@ export function EditViewDialog(props: EditViewProps) {
           )}
         </Button>
       </DialogTrigger>
-      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-md">
+      <DialogContent className="flex max-h-[85dvh] flex-col sm:max-w-md">
         <EditGraphsPanel {...props} />
       </DialogContent>
     </Dialog>

--- a/src/components/WeatherStations/EditViewDialog.tsx
+++ b/src/components/WeatherStations/EditViewDialog.tsx
@@ -12,8 +12,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { getStationGroup, MAX_COMPARE_STATIONS } from '@/constants/weatherStations'
-import type { UnitSystem } from '@/services/snowobs/metricUnits'
 import { cn } from '@/utilities/ui'
 import type { DragEndEvent } from '@dnd-kit/core'
 import {
@@ -31,107 +29,12 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { ArrowDown, ArrowUp, GripVertical, SlidersHorizontal, X } from 'lucide-react'
-import { ChipGroup } from './ChipGroup'
+import { ArrowDown, ArrowUp, GripVertical, SlidersHorizontal } from 'lucide-react'
 import type { GraphPreset } from './stationGraphPresets'
-import type { StationPeriod } from './stationPeriods'
-import { DEFAULT_GRAPH_PERIOD, GRAPH_PERIODS } from './stationPeriods'
-import { StationOptGroups, stationSelectClass } from './StationPicker'
-import { UnitToggle } from './UnitToggle'
 import type { useChartArrangement } from './useChartArrangement'
-
-export const chipClass = 'inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm'
-
-const sectionLabelClass = 'text-sm font-medium'
 
 const rowButtonClass =
   'rounded-md p-1 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:hover:text-muted-foreground'
-
-const GRAPH_PERIOD_CHIPS = GRAPH_PERIODS.map((p) => ({ key: p.key, label: p.label }))
-
-function PeriodSection({
-  active,
-  onChange,
-}: {
-  active: StationPeriod
-  onChange: (period: StationPeriod) => void
-}) {
-  return (
-    <div className="flex flex-col gap-2">
-      <span className={sectionLabelClass}>Date range</span>
-      <ChipGroup
-        chips={GRAPH_PERIOD_CHIPS}
-        activeKey={active.key}
-        onSelect={(key) =>
-          onChange(GRAPH_PERIODS.find((p) => p.key === key) ?? DEFAULT_GRAPH_PERIOD)
-        }
-      />
-    </div>
-  )
-}
-
-export function CompareChips({
-  compareSlugs,
-  onRemove,
-}: {
-  compareSlugs: string[]
-  onRemove: (slug: string) => void
-}) {
-  const selected = compareSlugs.flatMap((slug) => getStationGroup(slug) ?? [])
-
-  return selected.map((group) => (
-    <span key={group.slug} className={chipClass}>
-      {group.displayName}
-      <button
-        type="button"
-        aria-label={`Remove ${group.displayName}`}
-        onClick={() => onRemove(group.slug)}
-        className="text-muted-foreground hover:text-foreground"
-      >
-        <X className="h-3.5 w-3.5" />
-      </button>
-    </span>
-  ))
-}
-
-function CompareSection({
-  currentSlug,
-  compareSlugs,
-  onCompareChange,
-}: {
-  currentSlug: string
-  compareSlugs: string[]
-  onCompareChange: (slugs: string[]) => void
-}) {
-  const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
-  return (
-    <div className="flex flex-col gap-2">
-      <span className={sectionLabelClass}>Compare stations</span>
-      <select
-        value=""
-        disabled={atCap}
-        aria-label="Compare with"
-        onChange={(event) => {
-          if (event.target.value) onCompareChange([...compareSlugs, event.target.value])
-        }}
-        className={cn(stationSelectClass, 'px-3 py-1.5 disabled:opacity-50')}
-      >
-        <option value="">
-          {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
-        </option>
-        <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
-      </select>
-      {compareSlugs.length > 0 && (
-        <div className="flex flex-wrap gap-2">
-          <CompareChips
-            compareSlugs={compareSlugs}
-            onRemove={(slug) => onCompareChange(compareSlugs.filter((s) => s !== slug))}
-          />
-        </div>
-      )}
-    </div>
-  )
-}
 
 function GraphRow({
   preset,
@@ -226,7 +129,7 @@ function GraphList({
         items={arrangement.orderedPresets.map((p) => p.key)}
         strategy={verticalListSortingStrategy}
       >
-        <ul className="mt-1">
+        <ul>
           {arrangement.orderedPresets.map((preset) => (
             <GraphRow
               key={preset.key}
@@ -241,43 +144,23 @@ function GraphList({
   )
 }
 
-export type EditViewProps = {
-  graphPeriod: StationPeriod
-  onPeriodChange: (period: StationPeriod) => void
-  unitSystem: UnitSystem
-  onUnitChange: (system: UnitSystem) => void
-  currentSlug: string
-  compareSlugs: string[]
-  onCompareChange: (slugs: string[]) => void
+type EditViewProps = {
   arrangement: ReturnType<typeof useChartArrangement>
   emptyKeys: ReadonlySet<string>
 }
 
-function EditViewPanel(props: EditViewProps) {
+function EditGraphsPanel({ arrangement, emptyKeys }: EditViewProps) {
   return (
     <>
       <DialogHeader>
-        <DialogTitle>Edit view</DialogTitle>
-        <DialogDescription>
-          Choose the date range, units, comparison stations, and graphs shown.
-        </DialogDescription>
+        <DialogTitle>Edit graphs</DialogTitle>
+        <DialogDescription>Show, hide, and drag to reorder graphs.</DialogDescription>
       </DialogHeader>
-      <PeriodSection active={props.graphPeriod} onChange={props.onPeriodChange} />
-      <div className="flex items-center justify-between gap-3">
-        <span className={sectionLabelClass}>Units</span>
-        <UnitToggle unit={props.unitSystem} onChange={props.onUnitChange} />
-      </div>
-      <CompareSection
-        currentSlug={props.currentSlug}
-        compareSlugs={props.compareSlugs}
-        onCompareChange={props.onCompareChange}
-      />
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <span className={sectionLabelClass}>Graphs</span>
-        <GraphList arrangement={props.arrangement} emptyKeys={props.emptyKeys} />
+        <GraphList arrangement={arrangement} emptyKeys={emptyKeys} />
       </div>
       <DialogFooter className="sm:justify-between">
-        <Button variant="ghost" size="sm" onClick={props.arrangement.resetArrangement}>
+        <Button variant="ghost" size="sm" onClick={arrangement.resetArrangement}>
           Reset to defaults
         </Button>
         <DialogClose asChild>
@@ -289,16 +172,23 @@ function EditViewPanel(props: EditViewProps) {
 }
 
 export function EditViewDialog(props: EditViewProps) {
+  const hiddenCount = props.arrangement.hiddenPresets.length
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-2">
+        <Button variant="outline" className="gap-2">
           <SlidersHorizontal className="h-4 w-4" />
-          Edit view
+          Edit graphs
+          {hiddenCount > 0 && (
+            <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-2 text-xs text-primary-foreground">
+              {hiddenCount}
+              <span className="sr-only"> hidden</span>
+            </span>
+          )}
         </Button>
       </DialogTrigger>
       <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-md">
-        <EditViewPanel {...props} />
+        <EditGraphsPanel {...props} />
       </DialogContent>
     </Dialog>
   )

--- a/src/components/WeatherStations/EditViewDialog.tsx
+++ b/src/components/WeatherStations/EditViewDialog.tsx
@@ -143,8 +143,6 @@ export function CompareChips({
   ))
 }
 
-// The toolbar controls, repeated inside the dialog for small screens where
-// the toolbar shows only the Edit graphs button.
 function MobileViewControls(props: EditViewProps) {
   return (
     <div className="flex flex-col gap-4 sm:hidden">

--- a/src/components/WeatherStations/EditViewDialog.tsx
+++ b/src/components/WeatherStations/EditViewDialog.tsx
@@ -12,6 +12,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
+import { getStationGroup, MAX_COMPARE_STATIONS } from '@/constants/weatherStations'
 import type { UnitSystem } from '@/services/snowobs/metricUnits'
 import { cn } from '@/utilities/ui'
 import type { DragEndEvent } from '@dnd-kit/core'
@@ -30,13 +31,107 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { ArrowDown, ArrowUp, GripVertical, SlidersHorizontal } from 'lucide-react'
+import { ArrowDown, ArrowUp, GripVertical, SlidersHorizontal, X } from 'lucide-react'
+import { ChipGroup } from './ChipGroup'
 import type { GraphPreset } from './stationGraphPresets'
+import type { StationPeriod } from './stationPeriods'
+import { DEFAULT_GRAPH_PERIOD, GRAPH_PERIODS } from './stationPeriods'
+import { StationOptGroups, stationSelectClass } from './StationPicker'
 import { UnitToggle } from './UnitToggle'
 import type { useChartArrangement } from './useChartArrangement'
 
+export const chipClass = 'inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm'
+
+const sectionLabelClass = 'text-sm font-medium'
+
 const rowButtonClass =
   'rounded-md p-1 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:hover:text-muted-foreground'
+
+const GRAPH_PERIOD_CHIPS = GRAPH_PERIODS.map((p) => ({ key: p.key, label: p.label }))
+
+function PeriodSection({
+  active,
+  onChange,
+}: {
+  active: StationPeriod
+  onChange: (period: StationPeriod) => void
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className={sectionLabelClass}>Date range</span>
+      <ChipGroup
+        chips={GRAPH_PERIOD_CHIPS}
+        activeKey={active.key}
+        onSelect={(key) =>
+          onChange(GRAPH_PERIODS.find((p) => p.key === key) ?? DEFAULT_GRAPH_PERIOD)
+        }
+      />
+    </div>
+  )
+}
+
+export function CompareChips({
+  compareSlugs,
+  onRemove,
+}: {
+  compareSlugs: string[]
+  onRemove: (slug: string) => void
+}) {
+  const selected = compareSlugs.flatMap((slug) => getStationGroup(slug) ?? [])
+
+  return selected.map((group) => (
+    <span key={group.slug} className={chipClass}>
+      {group.displayName}
+      <button
+        type="button"
+        aria-label={`Remove ${group.displayName}`}
+        onClick={() => onRemove(group.slug)}
+        className="text-muted-foreground hover:text-foreground"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </span>
+  ))
+}
+
+function CompareSection({
+  currentSlug,
+  compareSlugs,
+  onCompareChange,
+}: {
+  currentSlug: string
+  compareSlugs: string[]
+  onCompareChange: (slugs: string[]) => void
+}) {
+  const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
+  return (
+    <div className="flex flex-col gap-2">
+      <span className={sectionLabelClass}>Compare stations</span>
+      <select
+        value=""
+        disabled={atCap}
+        aria-label="Compare with"
+        onChange={(event) => {
+          if (event.target.value) onCompareChange([...compareSlugs, event.target.value])
+        }}
+        className={cn(stationSelectClass, 'px-3 py-1.5 disabled:opacity-50')}
+      >
+        <option value="">
+          {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
+        </option>
+        <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
+      </select>
+      {compareSlugs.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          <CompareChips
+            compareSlugs={compareSlugs}
+            onRemove={(slug) => onCompareChange(compareSlugs.filter((s) => s !== slug))}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
 
 function GraphRow({
   preset,
@@ -146,32 +241,43 @@ function GraphList({
   )
 }
 
-type EditViewProps = {
-  arrangement: ReturnType<typeof useChartArrangement>
-  emptyKeys: ReadonlySet<string>
+export type EditViewProps = {
+  graphPeriod: StationPeriod
+  onPeriodChange: (period: StationPeriod) => void
   unitSystem: UnitSystem
   onUnitChange: (system: UnitSystem) => void
+  currentSlug: string
+  compareSlugs: string[]
+  onCompareChange: (slugs: string[]) => void
+  arrangement: ReturnType<typeof useChartArrangement>
+  emptyKeys: ReadonlySet<string>
 }
 
-function EditViewPanel({ arrangement, emptyKeys, unitSystem, onUnitChange }: EditViewProps) {
+function EditViewPanel(props: EditViewProps) {
   return (
     <>
       <DialogHeader>
         <DialogTitle>Edit view</DialogTitle>
         <DialogDescription>
-          Choose units, show or hide graphs, and drag to reorder them.
+          Choose the date range, units, comparison stations, and graphs shown.
         </DialogDescription>
       </DialogHeader>
+      <PeriodSection active={props.graphPeriod} onChange={props.onPeriodChange} />
       <div className="flex items-center justify-between gap-3">
-        <span className="text-sm font-medium">Units</span>
-        <UnitToggle unit={unitSystem} onChange={onUnitChange} />
+        <span className={sectionLabelClass}>Units</span>
+        <UnitToggle unit={props.unitSystem} onChange={props.onUnitChange} />
       </div>
+      <CompareSection
+        currentSlug={props.currentSlug}
+        compareSlugs={props.compareSlugs}
+        onCompareChange={props.onCompareChange}
+      />
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <span className="text-sm font-medium">Graphs</span>
-        <GraphList arrangement={arrangement} emptyKeys={emptyKeys} />
+        <span className={sectionLabelClass}>Graphs</span>
+        <GraphList arrangement={props.arrangement} emptyKeys={props.emptyKeys} />
       </div>
       <DialogFooter className="sm:justify-between">
-        <Button variant="ghost" size="sm" onClick={arrangement.resetArrangement}>
+        <Button variant="ghost" size="sm" onClick={props.arrangement.resetArrangement}>
           Reset to defaults
         </Button>
         <DialogClose asChild>

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -1,5 +1,12 @@
 'use client'
 
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { getStationGroup, MAX_COMPARE_STATIONS } from '@/constants/weatherStations'
 import type { GraphData } from '@/services/snowobs/graph'
 import type { UnitSystem } from '@/services/snowobs/metricUnits'
@@ -15,7 +22,7 @@ import type { GraphPreset } from './stationGraphPresets'
 import { clampNegativeValues, convertGraphData, convertPreset } from './stationGraphUnits'
 import type { StationPeriod } from './stationPeriods'
 import { DEFAULT_GRAPH_PERIOD, GRAPH_PERIODS } from './stationPeriods'
-import { StationOptGroups, stationSelectClass } from './StationPicker'
+import { StationSelectGroups, stationSelectTriggerClass } from './StationPicker'
 import { UnitToggle, useUnitSystem } from './UnitToggle'
 import { useChartArrangement } from './useChartArrangement'
 
@@ -95,20 +102,23 @@ function PeriodSelect({
   onChange: (period: StationPeriod) => void
 }) {
   return (
-    <select
+    <Select
       value={active.key}
-      aria-label="Date range"
-      onChange={(event) =>
-        onChange(GRAPH_PERIODS.find((p) => p.key === event.target.value) ?? DEFAULT_GRAPH_PERIOD)
+      onValueChange={(key) =>
+        onChange(GRAPH_PERIODS.find((p) => p.key === key) ?? DEFAULT_GRAPH_PERIOD)
       }
-      className={cn(stationSelectClass, 'px-3 py-1.5')}
     >
-      {GRAPH_PERIODS.map((period) => (
-        <option key={period.key} value={period.key}>
-          {period.label}
-        </option>
-      ))}
-    </select>
+      <SelectTrigger aria-label="Date range" className={cn(stationSelectTriggerClass, 'py-1.5')}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent position="item-aligned">
+        {GRAPH_PERIODS.map((period) => (
+          <SelectItem key={period.key} value={period.key}>
+            {period.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   )
 }
 
@@ -123,20 +133,20 @@ function CompareSelect({
 }) {
   const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
   return (
-    <select
+    <Select
       value=""
       disabled={atCap}
-      aria-label="Compare with"
-      onChange={(event) => {
-        if (event.target.value) onCompareChange([...compareSlugs, event.target.value])
-      }}
-      className={cn(stationSelectClass, 'px-3 py-1.5 disabled:opacity-50')}
+      onValueChange={(slug) => onCompareChange([...compareSlugs, slug])}
     >
-      <option value="">
-        {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
-      </option>
-      <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
-    </select>
+      <SelectTrigger aria-label="Compare with" className={cn(stationSelectTriggerClass, 'py-1.5')}>
+        <SelectValue
+          placeholder={atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
+        />
+      </SelectTrigger>
+      <SelectContent position="item-aligned">
+        <StationSelectGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
+      </SelectContent>
+    </Select>
   )
 }
 

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -1,12 +1,5 @@
 'use client'
 
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { getStationGroup, MAX_COMPARE_STATIONS } from '@/constants/weatherStations'
 import type { GraphData } from '@/services/snowobs/graph'
 import type { UnitSystem } from '@/services/snowobs/metricUnits'
@@ -22,7 +15,7 @@ import type { GraphPreset } from './stationGraphPresets'
 import { clampNegativeValues, convertGraphData, convertPreset } from './stationGraphUnits'
 import type { StationPeriod } from './stationPeriods'
 import { DEFAULT_GRAPH_PERIOD, GRAPH_PERIODS } from './stationPeriods'
-import { StationSelectGroups, stationSelectTriggerClass } from './StationPicker'
+import { StationOptGroups, stationSelectClass } from './StationPicker'
 import { UnitToggle, useUnitSystem } from './UnitToggle'
 import { useChartArrangement } from './useChartArrangement'
 
@@ -102,23 +95,20 @@ function PeriodSelect({
   onChange: (period: StationPeriod) => void
 }) {
   return (
-    <Select
+    <select
       value={active.key}
-      onValueChange={(key) =>
-        onChange(GRAPH_PERIODS.find((p) => p.key === key) ?? DEFAULT_GRAPH_PERIOD)
+      aria-label="Date range"
+      onChange={(event) =>
+        onChange(GRAPH_PERIODS.find((p) => p.key === event.target.value) ?? DEFAULT_GRAPH_PERIOD)
       }
+      className={cn(stationSelectClass, 'px-3 py-1.5')}
     >
-      <SelectTrigger aria-label="Date range" className={cn(stationSelectTriggerClass, 'py-1.5')}>
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        {GRAPH_PERIODS.map((period) => (
-          <SelectItem key={period.key} value={period.key}>
-            {period.label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+      {GRAPH_PERIODS.map((period) => (
+        <option key={period.key} value={period.key}>
+          {period.label}
+        </option>
+      ))}
+    </select>
   )
 }
 
@@ -133,20 +123,20 @@ function CompareSelect({
 }) {
   const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
   return (
-    <Select
+    <select
       value=""
       disabled={atCap}
-      onValueChange={(slug) => onCompareChange([...compareSlugs, slug])}
+      aria-label="Compare with"
+      onChange={(event) => {
+        if (event.target.value) onCompareChange([...compareSlugs, event.target.value])
+      }}
+      className={cn(stationSelectClass, 'px-3 py-1.5 disabled:opacity-50')}
     >
-      <SelectTrigger aria-label="Compare with" className={cn(stationSelectTriggerClass, 'py-1.5')}>
-        <SelectValue
-          placeholder={atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
-        />
-      </SelectTrigger>
-      <SelectContent>
-        <StationSelectGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
-      </SelectContent>
-    </Select>
+      <option value="">
+        {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
+      </option>
+      <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
+    </select>
   )
 }
 
@@ -271,25 +261,27 @@ function GraphsToolbar({
   emptyKeys: ReadonlySet<string>
 }) {
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex flex-wrap items-center justify-end gap-2">
-        <PeriodSelect active={graphPeriod} onChange={onPeriodChange} />
-        <UnitToggle unit={unitSystem} onChange={onUnitChange} />
+    <div className="flex flex-wrap items-center justify-between gap-4">
+      <div className="flex flex-wrap items-center gap-4">
         <CompareSelect
           currentSlug={currentSlug}
           compareSlugs={compareSlugs}
           onCompareChange={onCompareChange}
         />
+        {compareSlugs.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2">
+            <CompareChips
+              compareSlugs={compareSlugs}
+              onRemove={(slug) => onCompareChange(compareSlugs.filter((s) => s !== slug))}
+            />
+          </div>
+        )}
+      </div>
+      <div className="flex flex-wrap items-center gap-4">
+        <PeriodSelect active={graphPeriod} onChange={onPeriodChange} />
+        <UnitToggle unit={unitSystem} onChange={onUnitChange} />
         <EditViewDialog arrangement={arrangement} emptyKeys={emptyKeys} />
       </div>
-      {compareSlugs.length > 0 && (
-        <div className="flex flex-wrap items-center gap-2">
-          <CompareChips
-            compareSlugs={compareSlugs}
-            onRemove={(slug) => onCompareChange(compareSlugs.filter((s) => s !== slug))}
-          />
-        </div>
-      )}
     </div>
   )
 }

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -1,28 +1,21 @@
 'use client'
 
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import { getStationGroup, MAX_COMPARE_STATIONS } from '@/constants/weatherStations'
+import { getStationGroup } from '@/constants/weatherStations'
 import type { GraphData } from '@/services/snowobs/graph'
 import type { UnitSystem } from '@/services/snowobs/metricUnits'
 import { cn } from '@/utilities/ui'
 import { subHours } from 'date-fns'
-import { Loader2, X } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
-import { EditViewDialog } from './EditViewDialog'
+import type { EditViewProps } from './EditViewDialog'
+import { CompareChips, CompareSelect, EditViewDialog, PeriodSelect } from './EditViewDialog'
 import { buildChartOption } from './stationGraphOptions'
 import type { GraphPreset } from './stationGraphPresets'
 import { clampNegativeValues, convertGraphData, convertPreset } from './stationGraphUnits'
 import type { StationPeriod } from './stationPeriods'
-import { DEFAULT_GRAPH_PERIOD, GRAPH_PERIODS } from './stationPeriods'
-import { StationSelectGroups, stationSelectTriggerClass } from './StationPicker'
+import { DEFAULT_GRAPH_PERIOD } from './stationPeriods'
 import { UnitToggle, useUnitSystem } from './UnitToggle'
 import { useChartArrangement } from './useChartArrangement'
 
@@ -90,88 +83,6 @@ function ChartFrame({ loading, children }: { loading: boolean; children: ReactNo
       )}
     </div>
   )
-}
-
-const chipClass = 'inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm'
-
-function PeriodSelect({
-  active,
-  onChange,
-}: {
-  active: StationPeriod
-  onChange: (period: StationPeriod) => void
-}) {
-  return (
-    <Select
-      value={active.key}
-      onValueChange={(key) =>
-        onChange(GRAPH_PERIODS.find((p) => p.key === key) ?? DEFAULT_GRAPH_PERIOD)
-      }
-    >
-      <SelectTrigger aria-label="Date range" className={cn(stationSelectTriggerClass, 'py-1.5')}>
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent position="item-aligned">
-        {GRAPH_PERIODS.map((period) => (
-          <SelectItem key={period.key} value={period.key}>
-            {period.label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  )
-}
-
-function CompareSelect({
-  currentSlug,
-  compareSlugs,
-  onCompareChange,
-}: {
-  currentSlug: string
-  compareSlugs: string[]
-  onCompareChange: (slugs: string[]) => void
-}) {
-  const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
-  return (
-    <Select
-      value=""
-      disabled={atCap}
-      onValueChange={(slug) => onCompareChange([...compareSlugs, slug])}
-    >
-      <SelectTrigger aria-label="Compare with" className={cn(stationSelectTriggerClass, 'py-1.5')}>
-        <SelectValue
-          placeholder={atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
-        />
-      </SelectTrigger>
-      <SelectContent position="item-aligned">
-        <StationSelectGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
-      </SelectContent>
-    </Select>
-  )
-}
-
-function CompareChips({
-  compareSlugs,
-  onRemove,
-}: {
-  compareSlugs: string[]
-  onRemove: (slug: string) => void
-}) {
-  const selected = compareSlugs.flatMap((slug) => getStationGroup(slug) ?? [])
-
-  return selected.map((group) => (
-    <span key={group.slug} className={chipClass}>
-      {group.displayName}
-      <button
-        type="button"
-        aria-label={`Remove ${group.displayName}`}
-        onClick={() => onRemove(group.slug)}
-        className="text-muted-foreground hover:text-foreground"
-      >
-        <X className="h-3.5 w-3.5" />
-      </button>
-    </span>
-  ))
 }
 
 function PresetChart({
@@ -249,49 +160,36 @@ function GraphsCharts({
   )
 }
 
-function GraphsToolbar({
-  graphPeriod,
-  onPeriodChange,
-  unitSystem,
-  onUnitChange,
-  currentSlug,
-  compareSlugs,
-  onCompareChange,
-  arrangement,
-  emptyKeys,
-}: {
-  graphPeriod: StationPeriod
-  onPeriodChange: (period: StationPeriod) => void
-  unitSystem: UnitSystem
-  onUnitChange: (system: UnitSystem) => void
-  currentSlug: string
-  compareSlugs: string[]
-  onCompareChange: (slugs: string[]) => void
-  arrangement: ReturnType<typeof useChartArrangement>
-  emptyKeys: ReadonlySet<string>
-}) {
+// On small screens the toolbar collapses to the Edit graphs button (plus any
+// compare chips); the dialog then hosts the period/units/compare controls.
+function GraphsToolbar(props: EditViewProps) {
+  const { compareSlugs, onCompareChange } = props
   return (
-    <div className="flex flex-wrap items-center justify-between gap-4">
-      <div className="flex flex-wrap items-center gap-4">
+    <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
+      <div className="hidden sm:contents">
         <CompareSelect
-          currentSlug={currentSlug}
+          currentSlug={props.currentSlug}
           compareSlugs={compareSlugs}
           onCompareChange={onCompareChange}
         />
-        {compareSlugs.length > 0 && (
-          <div className="flex flex-wrap items-center gap-2">
-            <CompareChips
-              compareSlugs={compareSlugs}
-              onRemove={(slug) => onCompareChange(compareSlugs.filter((s) => s !== slug))}
-            />
-          </div>
-        )}
       </div>
-      <div className="flex flex-wrap items-center gap-4">
-        <PeriodSelect active={graphPeriod} onChange={onPeriodChange} />
-        <UnitToggle unit={unitSystem} onChange={onUnitChange} />
-        <EditViewDialog arrangement={arrangement} emptyKeys={emptyKeys} />
+      {compareSlugs.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <CompareChips
+            compareSlugs={compareSlugs}
+            onRemove={(slug) => onCompareChange(compareSlugs.filter((s) => s !== slug))}
+          />
+        </div>
+      )}
+      <div className="hidden sm:contents">
+        <PeriodSelect
+          active={props.graphPeriod}
+          onChange={props.onPeriodChange}
+          className="sm:ml-auto"
+        />
+        <UnitToggle unit={props.unitSystem} onChange={props.onUnitChange} />
       </div>
+      <EditViewDialog {...props} />
     </div>
   )
 }

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -5,18 +5,19 @@ import type { GraphData } from '@/services/snowobs/graph'
 import type { UnitSystem } from '@/services/snowobs/metricUnits'
 import { cn } from '@/utilities/ui'
 import { subHours } from 'date-fns'
-import { ArrowDown, ArrowUp, Eye, EyeOff, Loader2, X } from 'lucide-react'
+import { Eye, Loader2, X } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { ChipGroup } from './ChipGroup'
+import { EditViewDialog } from './EditViewDialog'
 import { buildChartOption } from './stationGraphOptions'
 import type { GraphPreset } from './stationGraphPresets'
 import { clampNegativeValues, convertGraphData, convertPreset } from './stationGraphUnits'
 import type { StationPeriod } from './stationPeriods'
 import { DEFAULT_GRAPH_PERIOD, GRAPH_PERIODS } from './stationPeriods'
 import { StationOptGroups, stationSelectClass } from './StationPicker'
-import { UnitToggle, useUnitSystem } from './UnitToggle'
+import { useUnitSystem } from './UnitToggle'
 import { useChartArrangement } from './useChartArrangement'
 
 function ChartSkeleton() {
@@ -157,48 +158,6 @@ function CompareChips({
   ))
 }
 
-function ChartControls({
-  title,
-  canUp,
-  canDown,
-  onMove,
-  onHide,
-}: {
-  title: string
-  canUp: boolean
-  canDown: boolean
-  onMove: (direction: -1 | 1) => void
-  onHide: () => void
-}) {
-  const buttonClass =
-    'rounded-md p-1 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:hover:text-muted-foreground'
-  return (
-    <div className="flex justify-end gap-1">
-      <button
-        type="button"
-        aria-label={`Move ${title} up`}
-        disabled={!canUp}
-        onClick={() => onMove(-1)}
-        className={buttonClass}
-      >
-        <ArrowUp className="h-4 w-4" />
-      </button>
-      <button
-        type="button"
-        aria-label={`Move ${title} down`}
-        disabled={!canDown}
-        onClick={() => onMove(1)}
-        className={buttonClass}
-      >
-        <ArrowDown className="h-4 w-4" />
-      </button>
-      <button type="button" aria-label={`Hide ${title}`} onClick={onHide} className={buttonClass}>
-        <EyeOff className="h-4 w-4" />
-      </button>
-    </div>
-  )
-}
-
 function HiddenChartChips({
   presets,
   onShow,
@@ -231,13 +190,11 @@ function PresetChart({
   data,
   primaryStids,
   unitSystem,
-  controls,
 }: {
   preset: GraphPreset
   data: GraphData
   primaryStids: string[]
   unitSystem: UnitSystem
-  controls: ReactNode
 }) {
   const presetData = useMemo(() => {
     const filtered = {
@@ -251,12 +208,7 @@ function PresetChart({
     () => buildChartOption(presetData, convertPreset(preset, unitSystem), primaryStids),
     [presetData, preset, unitSystem, primaryStids],
   )
-  return (
-    <div className="relative">
-      <div className="absolute right-0 top-0 z-10">{controls}</div>
-      <EChart option={option} group="station-graphs" />
-    </div>
-  )
+  return <EChart option={option} group="station-graphs" />
 }
 
 function GraphsChipRow({
@@ -324,15 +276,6 @@ function GraphsCharts({
             data={data}
             primaryStids={primaryStids}
             unitSystem={unitSystem}
-            controls={
-              <ChartControls
-                title={preset.title}
-                canUp={arrangement.canMove(preset.key, -1)}
-                canDown={arrangement.canMove(preset.key, 1)}
-                onMove={(direction) => arrangement.moveChart(preset.key, direction)}
-                onHide={() => arrangement.hideChart(preset.key)}
-              />
-            }
           />
         ))}
       </div>
@@ -349,6 +292,7 @@ function GraphsToolbar({
   compareSlugs,
   onCompareChange,
   arrangement,
+  emptyKeys,
 }: {
   graphPeriod: StationPeriod
   onPeriodChange: (period: StationPeriod) => void
@@ -358,6 +302,7 @@ function GraphsToolbar({
   compareSlugs: string[]
   onCompareChange: (slugs: string[]) => void
   arrangement: ReturnType<typeof useChartArrangement>
+  emptyKeys: ReadonlySet<string>
 }) {
   return (
     <div className="flex flex-col gap-2">
@@ -368,7 +313,12 @@ function GraphsToolbar({
           compareSlugs={compareSlugs}
           onAdd={(slug) => onCompareChange([...compareSlugs, slug])}
         />
-        <UnitToggle unit={unitSystem} onChange={onUnitChange} />
+        <EditViewDialog
+          arrangement={arrangement}
+          emptyKeys={emptyKeys}
+          unitSystem={unitSystem}
+          onUnitChange={onUnitChange}
+        />
       </div>
       <GraphsChipRow
         compareSlugs={compareSlugs}
@@ -431,6 +381,7 @@ export function StationGraphs({
         compareSlugs={compareSlugs}
         onCompareChange={setCompareSlugs}
         arrangement={arrangement}
+        emptyKeys={emptyKeys}
       />
       <GraphsCharts
         presets={presets}

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -1,22 +1,29 @@
 'use client'
 
-import { getStationGroup } from '@/constants/weatherStations'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { getStationGroup, MAX_COMPARE_STATIONS } from '@/constants/weatherStations'
 import type { GraphData } from '@/services/snowobs/graph'
 import type { UnitSystem } from '@/services/snowobs/metricUnits'
 import { cn } from '@/utilities/ui'
 import { subHours } from 'date-fns'
-import { Eye, Loader2 } from 'lucide-react'
+import { Loader2, X } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
-import type { EditViewProps } from './EditViewDialog'
-import { chipClass, EditViewDialog } from './EditViewDialog'
+import { EditViewDialog } from './EditViewDialog'
 import { buildChartOption } from './stationGraphOptions'
 import type { GraphPreset } from './stationGraphPresets'
 import { clampNegativeValues, convertGraphData, convertPreset } from './stationGraphUnits'
 import type { StationPeriod } from './stationPeriods'
-import { DEFAULT_GRAPH_PERIOD } from './stationPeriods'
-import { useUnitSystem } from './UnitToggle'
+import { DEFAULT_GRAPH_PERIOD, GRAPH_PERIODS } from './stationPeriods'
+import { StationSelectGroups, stationSelectTriggerClass } from './StationPicker'
+import { UnitToggle, useUnitSystem } from './UnitToggle'
 import { useChartArrangement } from './useChartArrangement'
 
 function ChartSkeleton() {
@@ -85,31 +92,86 @@ function ChartFrame({ loading, children }: { loading: boolean; children: ReactNo
   )
 }
 
-function HiddenChartChips({
-  presets,
-  onShow,
+const chipClass = 'inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm'
+
+function PeriodSelect({
+  active,
+  onChange,
 }: {
-  presets: GraphPreset[]
-  onShow: (key: string) => void
+  active: StationPeriod
+  onChange: (period: StationPeriod) => void
 }) {
-  if (presets.length === 0) return null
   return (
-    <>
-      <span className="text-sm text-muted-foreground">Hidden:</span>
-      {presets.map((preset) => (
-        <button
-          key={preset.key}
-          type="button"
-          aria-label={`Show ${preset.title}`}
-          onClick={() => onShow(preset.key)}
-          className={cn(chipClass, 'text-muted-foreground hover:text-foreground')}
-        >
-          {preset.title}
-          <Eye className="h-3.5 w-3.5" />
-        </button>
-      ))}
-    </>
+    <Select
+      value={active.key}
+      onValueChange={(key) =>
+        onChange(GRAPH_PERIODS.find((p) => p.key === key) ?? DEFAULT_GRAPH_PERIOD)
+      }
+    >
+      <SelectTrigger aria-label="Date range" className={cn(stationSelectTriggerClass, 'py-1.5')}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {GRAPH_PERIODS.map((period) => (
+          <SelectItem key={period.key} value={period.key}>
+            {period.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   )
+}
+
+function CompareSelect({
+  currentSlug,
+  compareSlugs,
+  onCompareChange,
+}: {
+  currentSlug: string
+  compareSlugs: string[]
+  onCompareChange: (slugs: string[]) => void
+}) {
+  const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
+  return (
+    <Select
+      value=""
+      disabled={atCap}
+      onValueChange={(slug) => onCompareChange([...compareSlugs, slug])}
+    >
+      <SelectTrigger aria-label="Compare with" className={cn(stationSelectTriggerClass, 'py-1.5')}>
+        <SelectValue
+          placeholder={atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
+        />
+      </SelectTrigger>
+      <SelectContent>
+        <StationSelectGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
+      </SelectContent>
+    </Select>
+  )
+}
+
+function CompareChips({
+  compareSlugs,
+  onRemove,
+}: {
+  compareSlugs: string[]
+  onRemove: (slug: string) => void
+}) {
+  const selected = compareSlugs.flatMap((slug) => getStationGroup(slug) ?? [])
+
+  return selected.map((group) => (
+    <span key={group.slug} className={chipClass}>
+      {group.displayName}
+      <button
+        type="button"
+        aria-label={`Remove ${group.displayName}`}
+        onClick={() => onRemove(group.slug)}
+        className="text-muted-foreground hover:text-foreground"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </span>
+  ))
 }
 
 function PresetChart({
@@ -187,17 +249,47 @@ function GraphsCharts({
   )
 }
 
-function GraphsToolbar(props: EditViewProps) {
-  const { graphPeriod, compareSlugs, arrangement } = props
-  const compareNames = compareSlugs.flatMap((slug) => getStationGroup(slug)?.displayName ?? [])
+function GraphsToolbar({
+  graphPeriod,
+  onPeriodChange,
+  unitSystem,
+  onUnitChange,
+  currentSlug,
+  compareSlugs,
+  onCompareChange,
+  arrangement,
+  emptyKeys,
+}: {
+  graphPeriod: StationPeriod
+  onPeriodChange: (period: StationPeriod) => void
+  unitSystem: UnitSystem
+  onUnitChange: (system: UnitSystem) => void
+  currentSlug: string
+  compareSlugs: string[]
+  onCompareChange: (slugs: string[]) => void
+  arrangement: ReturnType<typeof useChartArrangement>
+  emptyKeys: ReadonlySet<string>
+}) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3">
-      <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-        <span>{graphPeriod.label}</span>
-        {compareNames.length > 0 && <span>· vs {compareNames.join(', ')}</span>}
-        <HiddenChartChips presets={arrangement.hiddenPresets} onShow={arrangement.showChart} />
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <PeriodSelect active={graphPeriod} onChange={onPeriodChange} />
+        <UnitToggle unit={unitSystem} onChange={onUnitChange} />
+        <CompareSelect
+          currentSlug={currentSlug}
+          compareSlugs={compareSlugs}
+          onCompareChange={onCompareChange}
+        />
+        <EditViewDialog arrangement={arrangement} emptyKeys={emptyKeys} />
       </div>
-      <EditViewDialog {...props} />
+      {compareSlugs.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <CompareChips
+            compareSlugs={compareSlugs}
+            onRemove={(slug) => onCompareChange(compareSlugs.filter((s) => s !== slug))}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/WeatherStations/StationGraphs.tsx
+++ b/src/components/WeatherStations/StationGraphs.tsx
@@ -1,22 +1,21 @@
 'use client'
 
-import { getStationGroup, MAX_COMPARE_STATIONS } from '@/constants/weatherStations'
+import { getStationGroup } from '@/constants/weatherStations'
 import type { GraphData } from '@/services/snowobs/graph'
 import type { UnitSystem } from '@/services/snowobs/metricUnits'
 import { cn } from '@/utilities/ui'
 import { subHours } from 'date-fns'
-import { Eye, Loader2, X } from 'lucide-react'
+import { Eye, Loader2 } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
-import { ChipGroup } from './ChipGroup'
-import { EditViewDialog } from './EditViewDialog'
+import type { EditViewProps } from './EditViewDialog'
+import { chipClass, EditViewDialog } from './EditViewDialog'
 import { buildChartOption } from './stationGraphOptions'
 import type { GraphPreset } from './stationGraphPresets'
 import { clampNegativeValues, convertGraphData, convertPreset } from './stationGraphUnits'
 import type { StationPeriod } from './stationPeriods'
-import { DEFAULT_GRAPH_PERIOD, GRAPH_PERIODS } from './stationPeriods'
-import { StationOptGroups, stationSelectClass } from './StationPicker'
+import { DEFAULT_GRAPH_PERIOD } from './stationPeriods'
 import { useUnitSystem } from './UnitToggle'
 import { useChartArrangement } from './useChartArrangement'
 
@@ -75,24 +74,6 @@ function useGraphData(stids: string[], variables: string[], period: StationPerio
   return { data, error, loading }
 }
 
-const GRAPH_PERIOD_CHIPS = GRAPH_PERIODS.map((p) => ({ key: p.key, label: p.label }))
-
-function PeriodPicker({
-  active,
-  onChange,
-}: {
-  active: StationPeriod
-  onChange: (period: StationPeriod) => void
-}) {
-  return (
-    <ChipGroup
-      chips={GRAPH_PERIOD_CHIPS}
-      activeKey={active.key}
-      onSelect={(key) => onChange(GRAPH_PERIODS.find((p) => p.key === key) ?? DEFAULT_GRAPH_PERIOD)}
-    />
-  )
-}
-
 function ChartFrame({ loading, children }: { loading: boolean; children: ReactNode }) {
   return (
     <div className="relative" aria-busy={loading}>
@@ -102,60 +83,6 @@ function ChartFrame({ loading, children }: { loading: boolean; children: ReactNo
       )}
     </div>
   )
-}
-
-const chipClass = 'inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-sm'
-
-function CompareStationPicker({
-  currentSlug,
-  compareSlugs,
-  onAdd,
-}: {
-  currentSlug: string
-  compareSlugs: string[]
-  onAdd: (slug: string) => void
-}) {
-  const atCap = compareSlugs.length >= MAX_COMPARE_STATIONS
-  return (
-    <select
-      value=""
-      disabled={atCap}
-      aria-label="Compare with"
-      onChange={(event) => {
-        if (event.target.value) onAdd(event.target.value)
-      }}
-      className={cn(stationSelectClass, 'px-3 py-1.5 disabled:opacity-50')}
-    >
-      <option value="">
-        {atCap ? `Up to ${MAX_COMPARE_STATIONS} stations` : 'Add a station…'}
-      </option>
-      <StationOptGroups excludeSlugs={[currentSlug, ...compareSlugs]} />
-    </select>
-  )
-}
-
-function CompareChips({
-  compareSlugs,
-  onRemove,
-}: {
-  compareSlugs: string[]
-  onRemove: (slug: string) => void
-}) {
-  const selected = compareSlugs.flatMap((slug) => getStationGroup(slug) ?? [])
-
-  return selected.map((group) => (
-    <span key={group.slug} className={chipClass}>
-      {group.displayName}
-      <button
-        type="button"
-        aria-label={`Remove ${group.displayName}`}
-        onClick={() => onRemove(group.slug)}
-        className="text-muted-foreground hover:text-foreground"
-      >
-        <X className="h-3.5 w-3.5" />
-      </button>
-    </span>
-  ))
 }
 
 function HiddenChartChips({
@@ -211,29 +138,6 @@ function PresetChart({
   return <EChart option={option} group="station-graphs" />
 }
 
-function GraphsChipRow({
-  compareSlugs,
-  onCompareChange,
-  hiddenPresets,
-  onShow,
-}: {
-  compareSlugs: string[]
-  onCompareChange: (slugs: string[]) => void
-  hiddenPresets: GraphPreset[]
-  onShow: (key: string) => void
-}) {
-  if (compareSlugs.length === 0 && hiddenPresets.length === 0) return null
-  return (
-    <div className="flex flex-wrap items-center gap-2">
-      <CompareChips
-        compareSlugs={compareSlugs}
-        onRemove={(slug) => onCompareChange(compareSlugs.filter((s) => s !== slug))}
-      />
-      <HiddenChartChips presets={hiddenPresets} onShow={onShow} />
-    </div>
-  )
-}
-
 function emptyPresetKeys(data: GraphData | null, presets: GraphPreset[]): Set<string> {
   if (!data) return new Set()
   const reported = new Set(data.series.map((s) => s.variable))
@@ -283,49 +187,17 @@ function GraphsCharts({
   )
 }
 
-function GraphsToolbar({
-  graphPeriod,
-  onPeriodChange,
-  unitSystem,
-  onUnitChange,
-  currentSlug,
-  compareSlugs,
-  onCompareChange,
-  arrangement,
-  emptyKeys,
-}: {
-  graphPeriod: StationPeriod
-  onPeriodChange: (period: StationPeriod) => void
-  unitSystem: UnitSystem
-  onUnitChange: (system: UnitSystem) => void
-  currentSlug: string
-  compareSlugs: string[]
-  onCompareChange: (slugs: string[]) => void
-  arrangement: ReturnType<typeof useChartArrangement>
-  emptyKeys: ReadonlySet<string>
-}) {
+function GraphsToolbar(props: EditViewProps) {
+  const { graphPeriod, compareSlugs, arrangement } = props
+  const compareNames = compareSlugs.flatMap((slug) => getStationGroup(slug)?.displayName ?? [])
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <PeriodPicker active={graphPeriod} onChange={onPeriodChange} />
-        <CompareStationPicker
-          currentSlug={currentSlug}
-          compareSlugs={compareSlugs}
-          onAdd={(slug) => onCompareChange([...compareSlugs, slug])}
-        />
-        <EditViewDialog
-          arrangement={arrangement}
-          emptyKeys={emptyKeys}
-          unitSystem={unitSystem}
-          onUnitChange={onUnitChange}
-        />
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+        <span>{graphPeriod.label}</span>
+        {compareNames.length > 0 && <span>· vs {compareNames.join(', ')}</span>}
+        <HiddenChartChips presets={arrangement.hiddenPresets} onShow={arrangement.showChart} />
       </div>
-      <GraphsChipRow
-        compareSlugs={compareSlugs}
-        onCompareChange={onCompareChange}
-        hiddenPresets={arrangement.hiddenPresets}
-        onShow={arrangement.showChart}
-      />
+      <EditViewDialog {...props} />
     </div>
   )
 }

--- a/src/components/WeatherStations/StationPageView.tsx
+++ b/src/components/WeatherStations/StationPageView.tsx
@@ -20,7 +20,7 @@ function StationHeader({
   table: StationTable | null
 }) {
   return (
-    <div className="container flex flex-wrap items-start justify-between gap-3">
+    <div className="container flex flex-wrap items-end justify-between gap-3">
       <div>
         <p className="mb-1 text-sm text-muted-foreground">{group.region}</p>
         <div className="prose dark:prose-invert max-w-none">

--- a/src/components/WeatherStations/StationPicker.tsx
+++ b/src/components/WeatherStations/StationPicker.tsx
@@ -49,7 +49,7 @@ export function StationPicker({ current, className }: { current?: string; classN
     >
       <SelectTrigger
         aria-label="Jump to a weather station"
-        className={cn(stationSelectTriggerClass, className)}
+        className={cn(stationSelectTriggerClass, 'min-w-48', className)}
       >
         <SelectValue placeholder="Jump to a station…" />
       </SelectTrigger>

--- a/src/components/WeatherStations/StationPicker.tsx
+++ b/src/components/WeatherStations/StationPicker.tsx
@@ -1,38 +1,26 @@
 'use client'
 
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { NWAC_STATION_REGIONS, NWAC_WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
 import { cn } from '@/utilities/ui'
 import { useRouter } from 'next/navigation'
 
-// Overrides on the shadcn SelectTrigger that restore the old native-select
-// look: soft corners, subtle shadow, content-sized, no focus-ring offset.
-export const stationSelectTriggerClass =
-  'h-auto w-auto gap-2 rounded-md text-sm shadow-sm focus:ring-offset-0'
+export const stationSelectClass =
+  'rounded-md border border-input bg-background text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring'
 
-export function StationSelectGroups({ excludeSlugs = [] }: { excludeSlugs?: string[] }) {
+export function StationOptGroups({ excludeSlugs = [] }: { excludeSlugs?: string[] }) {
   return NWAC_STATION_REGIONS.map((region) => {
     const groups = NWAC_WEATHER_STATION_GROUPS.filter(
       (group) => group.region === region && !excludeSlugs.includes(group.slug),
     )
     if (groups.length === 0) return null
     return (
-      <SelectGroup key={region}>
-        <SelectLabel>{region}</SelectLabel>
+      <optgroup key={region} label={region}>
         {groups.map((group) => (
-          <SelectItem key={group.slug} value={group.slug}>
+          <option key={group.slug} value={group.slug}>
             {group.displayName}
-          </SelectItem>
+          </option>
         ))}
-      </SelectGroup>
+      </optgroup>
     )
   })
 }
@@ -43,19 +31,20 @@ export function StationPicker({ current, className }: { current?: string; classN
   const router = useRouter()
 
   return (
-    <Select
-      value={current ?? ''}
-      onValueChange={(slug) => router.push(`/weather/stations/${slug}`)}
-    >
-      <SelectTrigger
-        aria-label="Jump to a weather station"
-        className={cn(stationSelectTriggerClass, className)}
+    <label className={cn('inline-flex items-center gap-2 text-sm', className)}>
+      <span className="sr-only">Jump to a weather station</span>
+      <select
+        value={current ?? ''}
+        onChange={(event) => {
+          if (event.target.value) router.push(`/weather/stations/${event.target.value}`)
+        }}
+        className={cn(stationSelectClass, 'px-3 py-2')}
       >
-        <SelectValue placeholder="Jump to a station…" />
-      </SelectTrigger>
-      <SelectContent>
-        <StationSelectGroups />
-      </SelectContent>
-    </Select>
+        <option value="" disabled>
+          Jump to a station…
+        </option>
+        <StationOptGroups />
+      </select>
+    </label>
   )
 }

--- a/src/components/WeatherStations/StationPicker.tsx
+++ b/src/components/WeatherStations/StationPicker.tsx
@@ -13,8 +13,7 @@ import { NWAC_STATION_REGIONS, NWAC_WEATHER_STATION_GROUPS } from '@/constants/w
 import { cn } from '@/utilities/ui'
 import { useRouter } from 'next/navigation'
 
-// Overrides on the shadcn SelectTrigger that keep the native-select look:
-// soft corners, subtle shadow, content-sized, no focus-ring offset.
+// Restores the native-select look on the shadcn SelectTrigger.
 export const stationSelectTriggerClass =
   'h-auto w-auto gap-2 rounded-md text-sm shadow-sm focus:ring-offset-0'
 
@@ -51,9 +50,7 @@ export function StationPicker({ current, className }: { current?: string; classN
         aria-label="Jump to a weather station"
         className={cn(stationSelectTriggerClass, 'min-w-48', className)}
       >
-        {/* Static label: the page already shows the station name, and long
-            names balloon the trigger. The list still checkmarks the current
-            station via the Select value. */}
+        {/* Static label — long station names balloon the trigger otherwise. */}
         <SelectValue placeholder="Jump to a station…">Jump to a station…</SelectValue>
       </SelectTrigger>
       <SelectContent position="item-aligned">

--- a/src/components/WeatherStations/StationPicker.tsx
+++ b/src/components/WeatherStations/StationPicker.tsx
@@ -1,26 +1,38 @@
 'use client'
 
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { NWAC_STATION_REGIONS, NWAC_WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
 import { cn } from '@/utilities/ui'
 import { useRouter } from 'next/navigation'
 
-export const stationSelectClass =
-  'rounded-md border border-input bg-background text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring'
+// Overrides on the shadcn SelectTrigger that restore the old native-select
+// look: soft corners, subtle shadow, content-sized, no focus-ring offset.
+export const stationSelectTriggerClass =
+  'h-auto w-auto gap-2 rounded-md text-sm shadow-sm focus:ring-offset-0'
 
-export function StationOptGroups({ excludeSlugs = [] }: { excludeSlugs?: string[] }) {
+export function StationSelectGroups({ excludeSlugs = [] }: { excludeSlugs?: string[] }) {
   return NWAC_STATION_REGIONS.map((region) => {
     const groups = NWAC_WEATHER_STATION_GROUPS.filter(
       (group) => group.region === region && !excludeSlugs.includes(group.slug),
     )
     if (groups.length === 0) return null
     return (
-      <optgroup key={region} label={region}>
+      <SelectGroup key={region}>
+        <SelectLabel>{region}</SelectLabel>
         {groups.map((group) => (
-          <option key={group.slug} value={group.slug}>
+          <SelectItem key={group.slug} value={group.slug}>
             {group.displayName}
-          </option>
+          </SelectItem>
         ))}
-      </optgroup>
+      </SelectGroup>
     )
   })
 }
@@ -31,20 +43,19 @@ export function StationPicker({ current, className }: { current?: string; classN
   const router = useRouter()
 
   return (
-    <label className={cn('inline-flex items-center gap-2 text-sm', className)}>
-      <span className="sr-only">Jump to a weather station</span>
-      <select
-        value={current ?? ''}
-        onChange={(event) => {
-          if (event.target.value) router.push(`/weather/stations/${event.target.value}`)
-        }}
-        className={cn(stationSelectClass, 'px-3 py-2')}
+    <Select
+      value={current ?? ''}
+      onValueChange={(slug) => router.push(`/weather/stations/${slug}`)}
+    >
+      <SelectTrigger
+        aria-label="Jump to a weather station"
+        className={cn(stationSelectTriggerClass, className)}
       >
-        <option value="" disabled>
-          Jump to a station…
-        </option>
-        <StationOptGroups />
-      </select>
-    </label>
+        <SelectValue placeholder="Jump to a station…" />
+      </SelectTrigger>
+      <SelectContent>
+        <StationSelectGroups />
+      </SelectContent>
+    </Select>
   )
 }

--- a/src/components/WeatherStations/StationPicker.tsx
+++ b/src/components/WeatherStations/StationPicker.tsx
@@ -1,26 +1,38 @@
 'use client'
 
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { NWAC_STATION_REGIONS, NWAC_WEATHER_STATION_GROUPS } from '@/constants/weatherStations'
 import { cn } from '@/utilities/ui'
 import { useRouter } from 'next/navigation'
 
-export const stationSelectClass =
-  'rounded-md border border-input bg-background text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring'
+// Overrides on the shadcn SelectTrigger that keep the native-select look:
+// soft corners, subtle shadow, content-sized, no focus-ring offset.
+export const stationSelectTriggerClass =
+  'h-auto w-auto gap-2 rounded-md text-sm shadow-sm focus:ring-offset-0'
 
-export function StationOptGroups({ excludeSlugs = [] }: { excludeSlugs?: string[] }) {
+export function StationSelectGroups({ excludeSlugs = [] }: { excludeSlugs?: string[] }) {
   return NWAC_STATION_REGIONS.map((region) => {
     const groups = NWAC_WEATHER_STATION_GROUPS.filter(
       (group) => group.region === region && !excludeSlugs.includes(group.slug),
     )
     if (groups.length === 0) return null
     return (
-      <optgroup key={region} label={region}>
+      <SelectGroup key={region}>
+        <SelectLabel className="pl-2 font-normal text-muted-foreground">{region}</SelectLabel>
         {groups.map((group) => (
-          <option key={group.slug} value={group.slug}>
+          <SelectItem key={group.slug} value={group.slug}>
             {group.displayName}
-          </option>
+          </SelectItem>
         ))}
-      </optgroup>
+      </SelectGroup>
     )
   })
 }
@@ -31,20 +43,19 @@ export function StationPicker({ current, className }: { current?: string; classN
   const router = useRouter()
 
   return (
-    <label className={cn('inline-flex items-center gap-2 text-sm', className)}>
-      <span className="sr-only">Jump to a weather station</span>
-      <select
-        value={current ?? ''}
-        onChange={(event) => {
-          if (event.target.value) router.push(`/weather/stations/${event.target.value}`)
-        }}
-        className={cn(stationSelectClass, 'px-3 py-2')}
+    <Select
+      value={current ?? ''}
+      onValueChange={(slug) => router.push(`/weather/stations/${slug}`)}
+    >
+      <SelectTrigger
+        aria-label="Jump to a weather station"
+        className={cn(stationSelectTriggerClass, className)}
       >
-        <option value="" disabled>
-          Jump to a station…
-        </option>
-        <StationOptGroups />
-      </select>
-    </label>
+        <SelectValue placeholder="Jump to a station…" />
+      </SelectTrigger>
+      <SelectContent position="item-aligned">
+        <StationSelectGroups />
+      </SelectContent>
+    </Select>
   )
 }

--- a/src/components/WeatherStations/StationPicker.tsx
+++ b/src/components/WeatherStations/StationPicker.tsx
@@ -51,7 +51,10 @@ export function StationPicker({ current, className }: { current?: string; classN
         aria-label="Jump to a weather station"
         className={cn(stationSelectTriggerClass, 'min-w-48', className)}
       >
-        <SelectValue placeholder="Jump to a station…" />
+        {/* Static label: the page already shows the station name, and long
+            names balloon the trigger. The list still checkmarks the current
+            station via the Select value. */}
+        <SelectValue placeholder="Jump to a station…">Jump to a station…</SelectValue>
       </SelectTrigger>
       <SelectContent position="item-aligned">
         <StationSelectGroups />

--- a/src/components/WeatherStations/stationGraphOptions.ts
+++ b/src/components/WeatherStations/stationGraphOptions.ts
@@ -264,7 +264,7 @@ export function buildChartOption(
       ...presetAxisOverrides(preset),
     })),
     dataZoom: [
-      { type: 'inside', xAxisIndex: 0, minValueSpan },
+      { type: 'inside', xAxisIndex: 0, minValueSpan, zoomOnMouseWheel: 'ctrl' },
       { type: 'slider', xAxisIndex: 0, height: 18, bottom: 8, minValueSpan },
     ],
     series,

--- a/src/components/WeatherStations/stationGraphPrefs.ts
+++ b/src/components/WeatherStations/stationGraphPrefs.ts
@@ -54,23 +54,25 @@ export function saveChartPrefs(prefs: ChartPrefs): void {
   writeLocalStorage(STORAGE_KEY, JSON.stringify(prefs))
 }
 
-// Swaps `key` with its nearest non-skippable neighbor in `direction`;
-// returns `order` unchanged when there is none.
-export function swapWithNeighbor(
-  order: string[],
-  key: string,
-  direction: -1 | 1,
-  isSkippable: (key: string) => boolean,
-): string[] {
+// Swaps `key` with its neighbor in `direction`; returns `order` unchanged
+// when there is none.
+export function swapWithNeighbor(order: string[], key: string, direction: -1 | 1): string[] {
   const from = order.indexOf(key)
   if (from === -1) return order
-  let to = from + direction
-  while (to >= 0 && to < order.length && isSkippable(order[to])) {
-    to += direction
-  }
+  const to = from + direction
   if (to < 0 || to >= order.length) return order
   const next = [...order]
   next[from] = order[to]
   next[to] = order[from]
+  return next
+}
+
+// Moves `key` to `overKey`'s position, shifting the keys between them.
+export function moveToKey(order: string[], key: string, overKey: string): string[] {
+  const from = order.indexOf(key)
+  const to = order.indexOf(overKey)
+  if (from === -1 || to === -1 || from === to) return order
+  const next = [...order]
+  next.splice(to, 0, ...next.splice(from, 1))
   return next
 }

--- a/src/components/WeatherStations/useChartArrangement.ts
+++ b/src/components/WeatherStations/useChartArrangement.ts
@@ -5,6 +5,7 @@ import type { ChartPrefs } from './stationGraphPrefs'
 import {
   defaultChartPrefs,
   loadChartPrefs,
+  moveToKey,
   saveChartPrefs,
   swapWithNeighbor,
 } from './stationGraphPrefs'
@@ -32,24 +33,24 @@ export function useChartArrangement(presets: GraphPreset[], emptyKeys: ReadonlyS
     [prefs.order, presetByKey],
   )
 
-  const isSkippable = (key: string) => prefs.hidden.includes(key) || emptyKeys.has(key)
-
   return {
+    orderedPresets,
     visiblePresets: orderedPresets.filter(
       (p) => !prefs.hidden.includes(p.key) && !emptyKeys.has(p.key),
     ),
     hiddenPresets: orderedPresets.filter(
       (p) => prefs.hidden.includes(p.key) && !emptyKeys.has(p.key),
     ),
+    isHidden: (key: string) => prefs.hidden.includes(key),
     canMove: (key: string, direction: -1 | 1) =>
-      swapWithNeighbor(prefs.order, key, direction, isSkippable) !== prefs.order,
+      swapWithNeighbor(prefs.order, key, direction) !== prefs.order,
     moveChart: (key: string, direction: -1 | 1) =>
-      setPrefs((prev) => ({
-        ...prev,
-        order: swapWithNeighbor(prev.order, key, direction, isSkippable),
-      })),
+      setPrefs((prev) => ({ ...prev, order: swapWithNeighbor(prev.order, key, direction) })),
+    reorderChart: (key: string, overKey: string) =>
+      setPrefs((prev) => ({ ...prev, order: moveToKey(prev.order, key, overKey) })),
     hideChart: (key: string) => setPrefs((prev) => ({ ...prev, hidden: [...prev.hidden, key] })),
     showChart: (key: string) =>
       setPrefs((prev) => ({ ...prev, hidden: prev.hidden.filter((k) => k !== key) })),
+    resetArrangement: () => setPrefs(defaultChartPrefs(presetKeys)),
   }
 }


### PR DESCRIPTION
## Description

Reworks the weather station pages' controls. The graphs tab gets a single-row toolbar with inline controls in the old site's style — add-station on the left with removable chips, period / units / "Edit graphs" on the right — and a modal that handles only graph reordering and show/hide. All station dropdowns are now shadcn Selects styled to feel like native selects.

## Related Issues

n/a

## Key Changes

- **Toolbar (graphs tab)**: add-station select + selected-station chips on the left; period select, Imperial/Metric toggle, and "Edit graphs" button on the right
- **Edit graphs modal**: drag-and-drop reordering (new deps: `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`) with ↑ ↓ button fallback, visibility checkboxes, grayed-out "No data" rows for sensors the station lacks, and "Reset to defaults" (order + visibility; units untouched)
- **Hidden-graph indicator**: a count badge on the "Edit graphs" button replaces the old hidden-chips row; graphs are restored from the modal
- **shadcn Selects with native-style popups**: station picker, add-station, and period dropdowns use `ui/select` with `position="item-aligned"` (list opens over the trigger like a native select), muted region labels with stations indented beneath, and triggers restyled to the old native look
- **Station picker**: always reads "Jump to a station…" (long station names no longer balloon the trigger); the open list checkmarks the current station; detail-page header is bottom-aligned
- **Prefs plumbing**: `useChartArrangement`/`stationGraphPrefs` extended with full-list ordering, drag reorder (`moveToKey`), `isHidden`, and reset; unit toggle and prefs still persist to localStorage as before
- **Mobile**: the toolbar collapses to just the Edit graphs button; the dialog gains mobile-only Date range / Units / Compare stations sections above the graph list
- Table view is unchanged (keeps its inline unit toggle and shared units setting)

## How to test

1. Open a station's Graphs tab (`/weather/stations/<station>?range=graphs`)
2. Add compare stations from the left dropdown — chips appear beside it; remove via chip ×
3. Change period and units inline; both apply immediately (units persist per browser)
4. Click "Edit graphs": drag rows (or use ↑ ↓) to reorder, uncheck to hide — charts update live behind the dialog and survive reload; hidden count shows as a badge on the button
5. Pick a station missing a sensor (e.g. no solar) — its row is grayed out with "No data"
6. "Reset to defaults" restores order/visibility but not units
7. Open the station picker on index and detail pages — native-style popup, region groups, current station checkmarked
8. `pnpm test` — suites drive the dialog and Radix selects directly

## Screenshots / Demo video
<img width="3380" height="1902" alt="Alpental-Ski-Area-Northwest-Avalanche-Center-08-07-2026_11_58_AM" src="https://github.com/user-attachments/assets/108895d2-c61b-45b4-a643-0a27a1f8f42c" />

<img width="504" height="637" alt="Screenshot 2026-08-07 at 11 58 48" src="https://github.com/user-attachments/assets/e933761f-fd18-47d3-84f2-ad6fba0563f9" />


## Migration Explanation

No schema/migration changes.

## Future enhancements / Questions

- Should the Table view eventually share the same edit-view affordance?
- History note: the branch includes a shadcn → native → shadcn round-trip on the dropdowns from design iteration; happy to squash before merge if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
