### PR TITLE
Keep the mobile header and announcements pinned while the page scrolls

### DIFF
--- a/__tests__/client/components/announcements.client.test.ts
+++ b/__tests__/client/components/announcements.client.test.ts
@@ -1,5 +1,6 @@
 import { matchesPage, shouldShow } from '@/components/Announcements/announcementUtils'
 import { isExpired } from '@/components/Announcements/isExpired'
+import { scrollAnnouncementsIntoView } from '@/components/Announcements/scrollAnnouncementsIntoView'
 import type { Announcement } from '@/payload-types'
 
 function makeAnnouncement(overrides: Partial<Announcement> = {}): Announcement {
@@ -101,5 +102,53 @@ describe('shouldShow', () => {
     expect(shouldShow(popup, 1)).toBe(false)
     expect(shouldShow(popup, 2)).toBe(false)
     expect(shouldShow(popup, 3)).toBe(true)
+  })
+})
+
+describe('scrollAnnouncementsIntoView', () => {
+  const scrollTo = jest.fn()
+  let reducedMotion = false
+
+  beforeEach(() => {
+    scrollTo.mockClear()
+    reducedMotion = false
+
+    Object.defineProperty(window, 'scrollTo', { value: scrollTo, writable: true })
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query.includes('prefers-reduced-motion') && reducedMotion,
+        media: query,
+      }),
+    })
+  })
+
+  function setScrollY(value: number) {
+    Object.defineProperty(window, 'scrollY', { value, writable: true })
+  }
+
+  it('does nothing when the page is already at the top', () => {
+    setScrollY(0)
+
+    scrollAnnouncementsIntoView()
+
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('scrolls back to the banners when the page is scrolled away from them', () => {
+    setScrollY(1200)
+
+    scrollAnnouncementsIntoView()
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' })
+  })
+
+  it('jumps without animating when the reader prefers reduced motion', () => {
+    setScrollY(1200)
+    reducedMotion = true
+
+    scrollAnnouncementsIntoView()
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'auto' })
   })
 })

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -117,7 +117,12 @@ export default async function RootLayout({ children }: Args) {
   const { isEnabled } = await draftMode()
 
   return (
-    <html className={cn(lato.variable)} lang="en" suppressHydrationWarning>
+    // Anchor targets need to clear the sticky mobile header, which only exists below lg.
+    <html
+      className={cn(lato.variable, 'scroll-pt-16 lg:scroll-pt-0')}
+      lang="en"
+      suppressHydrationWarning
+    >
       <body>
         <PostHogProvider>
           <NuqsAdapter>

--- a/src/components/AdminBar/index.tsx
+++ b/src/components/AdminBar/index.tsx
@@ -16,6 +16,8 @@ const baseClass = 'admin-bar'
 
 const Title = () => <span>AvyFx Admin Panel</span>
 
+const ADMIN_BAR_HEIGHT = 36
+
 export const AdminBar = (props: { adminBarProps?: PayloadAdminBarProps }) => {
   const { adminBarProps } = props || {}
   const [show, setShow] = useState(false)
@@ -24,6 +26,17 @@ export const AdminBar = (props: { adminBarProps?: PayloadAdminBarProps }) => {
   const onAuthChange = React.useCallback((user: PayloadMeUser) => {
     setShow(!!user?.id)
   }, [])
+
+  // The sticky mobile header reads this to park itself below the admin bar instead of under it.
+  React.useEffect(() => {
+    const root = document.documentElement
+
+    root.style.setProperty('--admin-bar-height', show ? `${ADMIN_BAR_HEIGHT}px` : '0px')
+
+    return () => {
+      root.style.removeProperty('--admin-bar-height')
+    }
+  }, [show])
 
   const pathname = usePathname()
   const { tenant } = useTenant()
@@ -69,12 +82,13 @@ export const AdminBar = (props: { adminBarProps?: PayloadAdminBarProps }) => {
           />
         </div>
       </div>
-      {/* content padding for mobile nav */}
+      {/* content padding since the admin bar is position: fixed */}
       <div
-        className={cn('h-[36px] bg-background', {
+        className={cn('bg-background', {
           block: show,
           hidden: !show,
         })}
+        style={{ height: ADMIN_BAR_HEIGHT }}
       />
     </>
   )

--- a/src/components/Announcements/AnnouncementBanners.client.tsx
+++ b/src/components/Announcements/AnnouncementBanners.client.tsx
@@ -106,8 +106,10 @@ export function AnnouncementBanners({ banners }: AnnouncementBannersProps) {
 
   return (
     <>
+      {/* Capped below lg because the banners are pinned there: a long announcement would otherwise
+          take the whole phone screen and leave nowhere to read the page. Past the cap it scrolls. */}
       <div
-        className="overflow-hidden transition-[height] duration-300 ease-in-out"
+        className="max-h-[35dvh] overflow-x-hidden overflow-y-auto transition-[height] duration-300 ease-in-out lg:max-h-none lg:overflow-y-hidden"
         style={{ height: collapsed ? 0 : contentHeight }}
       >
         <div ref={contentRef} className="relative bg-callout" onClick={handleContentClick}>

--- a/src/components/Announcements/AnnouncementBanners.client.tsx
+++ b/src/components/Announcements/AnnouncementBanners.client.tsx
@@ -6,6 +6,7 @@ import { ChevronDown, ChevronUp } from 'lucide-react'
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import RichText from '../RichText'
 import { isExpired } from './isExpired'
+import { scrollAnnouncementsIntoView } from './scrollAnnouncementsIntoView'
 
 const STORAGE_KEY = 'announcement-banners'
 
@@ -84,6 +85,11 @@ export function AnnouncementBanners({ banners }: AnnouncementBannersProps) {
     collapse()
   }, [collapse])
 
+  const handleExpand = useCallback(() => {
+    expand()
+    scrollAnnouncementsIntoView()
+  }, [expand])
+
   const handleContentClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (
@@ -134,7 +140,7 @@ export function AnnouncementBanners({ banners }: AnnouncementBannersProps) {
       </div>
       {collapsed && (
         <button
-          onClick={expand}
+          onClick={handleExpand}
           className="hidden lg:flex fixed right-0 top-0 z-40 items-center gap-1.5 rounded-bl-md bg-callout px-4 py-1.5 text-sm font-medium text-callout-foreground shadow-md transition-colors hover:bg-callout/90"
         >
           {activeBanners.length} {activeBanners.length === 1 ? 'Announcement' : 'Announcements'}

--- a/src/components/Announcements/Announcements.tsx
+++ b/src/components/Announcements/Announcements.tsx
@@ -13,9 +13,16 @@ export async function Announcements({ center, children }: AnnouncementsProps) {
 
   return (
     <AnnouncementBannerProvider count={banners.length}>
-      {banners.length > 0 && <AnnouncementBanners banners={banners} />}
+      {/* Below lg the banners pin to the top of the viewport along with the header, so an expanded
+          announcement stays readable wherever you are on the page. This wrapper is the sticky
+          element rather than the header itself: a sticky child only stays put while its containing
+          block is in view, and neither the banners nor the header is much taller than its own box.
+          Above lg the header isn't sticky either, and the collapsed pill scrolls you back up. */}
+      <div className="sticky top-[var(--admin-bar-height,0px)] z-50 lg:static lg:z-auto">
+        {banners.length > 0 && <AnnouncementBanners banners={banners} />}
+        {children}
+      </div>
       {popups.length > 0 && <AnnouncementPopup popups={popups} center={center} />}
-      {children}
     </AnnouncementBannerProvider>
   )
 }

--- a/src/components/Announcements/scrollAnnouncementsIntoView.ts
+++ b/src/components/Announcements/scrollAnnouncementsIntoView.ts
@@ -1,0 +1,13 @@
+/**
+ * The banners sit above the header in the page flow, so expanding them from a control that stays
+ * put while the page scrolls — the sticky header's toggle, the fixed pill on desktop — grows them
+ * off the top of the screen. Scroll anchoring then holds the reader's place, so nothing appears to
+ * happen. Take them back to the top of the page, where the banners are.
+ */
+export function scrollAnnouncementsIntoView() {
+  if (window.scrollY === 0) return
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  window.scrollTo({ top: 0, behavior: prefersReducedMotion ? 'auto' : 'smooth' })
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -48,8 +48,9 @@ export async function Header({ center }: { center: string }) {
     // Below lg the header pins to the top of the viewport as the page scrolls. It has to be the
     // sticky element itself: a sticky child only stays put while its containing block is in view,
     // and the nav's containing block is this header, which is barely taller than the nav.
-    // Announcement banners sit above it in flow and scroll away, which is intended.
-    <header className="sticky top-0 z-50 bg-header lg:static lg:z-auto lg:shadow-sm lg:border-b">
+    // Announcement banners sit above it in flow and scroll away, which is intended. The admin bar
+    // is fixed to the top of the viewport for logged in users, so pin below it when it's showing.
+    <header className="sticky top-[var(--admin-bar-height,0px)] z-50 bg-header lg:static lg:z-auto lg:shadow-sm lg:border-b">
       <MobileNav topLevelNavItems={topLevelNavItems} banner={banner} usfsLogo={usfsLogo} />
 
       <div className="hidden lg:flex container pt-8 flex-col justify-center items-center gap-4">

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -45,12 +45,9 @@ export async function Header({ center }: { center: string }) {
   const { topLevelNavItems } = await getCachedTopLevelNavItems(center, draft)()
 
   return (
-    // Below lg the header pins to the top of the viewport as the page scrolls. It has to be the
-    // sticky element itself: a sticky child only stays put while its containing block is in view,
-    // and the nav's containing block is this header, which is barely taller than the nav.
-    // Announcement banners sit above it in flow and scroll away, which is intended. The admin bar
-    // is fixed to the top of the viewport for logged in users, so pin below it when it's showing.
-    <header className="sticky top-[var(--admin-bar-height,0px)] z-50 bg-header lg:static lg:z-auto lg:shadow-sm lg:border-b">
+    // Below lg this pins to the top of the viewport as the page scrolls, via the sticky wrapper it
+    // shares with the announcement banners in Announcements.tsx.
+    <header className="bg-header lg:shadow-sm lg:border-b">
       <MobileNav topLevelNavItems={topLevelNavItems} banner={banner} usfsLogo={usfsLogo} />
 
       <div className="hidden lg:flex container pt-8 flex-col justify-center items-center gap-4">

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -45,10 +45,12 @@ export async function Header({ center }: { center: string }) {
   const { topLevelNavItems } = await getCachedTopLevelNavItems(center, draft)()
 
   return (
-    <header className="bg-header lg:shadow-sm lg:border-b">
+    // Below lg the header pins to the top of the viewport as the page scrolls. It has to be the
+    // sticky element itself: a sticky child only stays put while its containing block is in view,
+    // and the nav's containing block is this header, which is barely taller than the nav.
+    // Announcement banners sit above it in flow and scroll away, which is intended.
+    <header className="sticky top-0 z-50 bg-header lg:static lg:z-auto lg:shadow-sm lg:border-b">
       <MobileNav topLevelNavItems={topLevelNavItems} banner={banner} usfsLogo={usfsLogo} />
-      {/* content padding since mobile nav is position: fixed */}
-      <div className="lg:hidden h-[64px] bg-background" />
 
       <div className="hidden lg:flex container pt-8 flex-col justify-center items-center gap-4">
         {banner && (

--- a/src/components/Header/MobileNav.client.tsx
+++ b/src/components/Header/MobileNav.client.tsx
@@ -74,8 +74,10 @@ export const MobileNav = ({
   return (
     <Dialog open={mobileNavOpen} onOpenChange={setMobileNavOpen} modal={false}>
       <div ref={headerRef} className="lg:hidden py-1.5 bg-header shadow-sm">
-        <div className="container flex justify-between items-center gap-5">
-          <DialogTrigger className="p-2">
+        {/* Three tracks so the logo stays centered whether or not the announcements toggle is
+            rendered. The outer tracks are equal by definition, empty or not. */}
+        <div className="container grid grid-cols-[1fr_auto_1fr] items-center gap-5">
+          <DialogTrigger className="col-start-1 justify-self-start p-2">
             <div className="flex w-6 h-6 flex-col items-center justify-center space-y-[5px] overflow-hidden outline-none">
               <span
                 className={`bg-header-foreground h-[2px] w-full rounded transition-all duration-300 ease-in-out ${
@@ -96,7 +98,7 @@ export const MobileNav = ({
             <span className="sr-only">Toggle menu</span>
           </DialogTrigger>
           {banner && (
-            <Link href="/" className="w-fit flex gap-4">
+            <Link href="/" className="col-start-2 justify-self-center w-fit flex gap-4">
               <ImageMedia
                 resource={banner}
                 loading="eager"
@@ -119,7 +121,7 @@ export const MobileNav = ({
             <button
               onClick={toggle}
               className={cn(
-                'relative rounded-md p-2 text-header-foreground transition-colors',
+                'col-start-3 justify-self-end relative rounded-md p-2 text-header-foreground transition-colors',
                 !collapsed && 'bg-header-foreground/20',
               )}
               aria-label={`${collapsed ? 'Expand' : 'Collapse'} ${announcementCount} ${announcementCount === 1 ? 'announcement' : 'announcements'}`}

--- a/src/components/Header/MobileNav.client.tsx
+++ b/src/components/Header/MobileNav.client.tsx
@@ -15,7 +15,6 @@ import { Megaphone, MegaphoneOff } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import invariant from 'tiny-invariant'
-import { scrollAnnouncementsIntoView } from '../Announcements/scrollAnnouncementsIntoView'
 import { ImageMedia } from '../Media/ImageMedia'
 import { Accordion } from '../ui/accordion'
 import { MobileNavItem } from './MobileNavItem'
@@ -120,11 +119,7 @@ export const MobileNav = ({
           )}
           {announcementCount > 0 && (
             <button
-              onClick={() => {
-                toggle()
-
-                if (collapsed) scrollAnnouncementsIntoView()
-              }}
+              onClick={toggle}
               className={cn(
                 'col-start-3 justify-self-end relative rounded-md p-2 text-header-foreground transition-colors',
                 !collapsed && 'bg-header-foreground/20',

--- a/src/components/Header/MobileNav.client.tsx
+++ b/src/components/Header/MobileNav.client.tsx
@@ -66,7 +66,7 @@ export const MobileNav = ({
 
   return (
     <Dialog open={mobileNavOpen} onOpenChange={setMobileNavOpen} modal={false}>
-      <div ref={headerRef} className="lg:hidden fixed z-50 inset-x-0 py-1.5 bg-header shadow-sm">
+      <div ref={headerRef} className="lg:hidden py-1.5 bg-header shadow-sm">
         <div className="container flex justify-between items-center gap-5">
           <DialogTrigger className="p-2">
             <div className="flex w-6 h-6 flex-col items-center justify-center space-y-[5px] overflow-hidden outline-none">

--- a/src/components/Header/MobileNav.client.tsx
+++ b/src/components/Header/MobileNav.client.tsx
@@ -15,6 +15,7 @@ import { Megaphone, MegaphoneOff } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import invariant from 'tiny-invariant'
+import { scrollAnnouncementsIntoView } from '../Announcements/scrollAnnouncementsIntoView'
 import { ImageMedia } from '../Media/ImageMedia'
 import { Accordion } from '../ui/accordion'
 import { MobileNavItem } from './MobileNavItem'
@@ -119,7 +120,11 @@ export const MobileNav = ({
           )}
           {announcementCount > 0 && (
             <button
-              onClick={toggle}
+              onClick={() => {
+                toggle()
+
+                if (collapsed) scrollAnnouncementsIntoView()
+              }}
               className={cn(
                 'col-start-3 justify-self-end relative rounded-md p-2 text-header-foreground transition-colors',
                 !collapsed && 'bg-header-foreground/20',

--- a/src/components/Header/MobileNav.client.tsx
+++ b/src/components/Header/MobileNav.client.tsx
@@ -44,11 +44,18 @@ export const MobileNav = ({
 
     updateHeaderHeight()
 
-    window.addEventListener('resize', updateHeaderHeight)
+    if (!mobileNavOpen) return
 
-    return () => {
-      window.removeEventListener('resize', updateHeaderHeight)
-    }
+    // The open menu hangs off the bottom of the header, so its offset has to survive anything that
+    // moves the header while it's open: an orientation change, the announcement banners animating
+    // open or closed, the sticky header pinning as the page scrolls. Measuring on a frame covers
+    // all of them, and only runs for as long as the menu is open.
+    let frame = requestAnimationFrame(function trackHeaderHeight() {
+      updateHeaderHeight()
+      frame = requestAnimationFrame(trackHeaderHeight)
+    })
+
+    return () => cancelAnimationFrame(frame)
   }, [mobileNavOpen])
 
   useEffect(
@@ -132,8 +139,8 @@ export const MobileNav = ({
           onClick={() => setMobileNavOpen(false)}
         />
         <DialogContent
-          className="lg:hidden max-h-[calc(100vh-64px)] overflow-y-auto fixed z-40 bg-header text-header-foreground pb-2 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 inset-x-0 border-b border-b-header-foreground-highlight data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top"
-          style={{ top: `${headerHeight}px` }}
+          className="lg:hidden overflow-y-auto fixed z-40 bg-header text-header-foreground pb-2 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 inset-x-0 border-b border-b-header-foreground-highlight data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top"
+          style={{ top: `${headerHeight}px`, maxHeight: `calc(100dvh - ${headerHeight}px)` }}
         >
           <DialogTitle className="sr-only">menu</DialogTitle>
           <DialogDescription className="sr-only">navigation menu</DialogDescription>


### PR DESCRIPTION
## Description

Below `lg`, the header nav did not stay pinned while scrolling — it drifted over the page content instead. Found while reviewing the native danger map, but it predates that work and affects every page, so it is split out here rather than shipped inside a large feature PR.

Fixing the header surfaced several adjacent problems, and reviewing it turned up two more mobile header bugs that were already there. Those are all in here as separate commits, since they are separable and read better on their own.

## Related Issues

None. Pre-existing; noticed incidentally.

## Key Changes

**The header pins below `lg`.** `MobileNav` was `position: fixed` with **no `top`**. A fixed element without an offset resolves to its *static* position — beneath the announcement banners — and then holds that viewport offset forever, so everything scrolled underneath it and the nav sat over the content. The `h-[64px]` spacer that reserved the space the fixed nav took out of the flow is gone with it, since a sticky element occupies its own space.

**The sticky element is a wrapper around the banners and the header, not the header itself.** A sticky element only stays put while its **containing block** is in view, and neither the nav nor the header is much taller than its own box, so either one alone would unstick almost immediately. `Announcements.tsx` now wraps the banners and the header in one sticky block. Above `lg` that wrapper is `static` and everything behaves exactly as it does on `main`.

**Announcements pin with the header.** Previously the banners sat above the header in the flow and scrolled away. Expanding one while scrolled down did nothing visible: the banner grew off the top of the screen and scroll anchoring held your place, so the only way to read it was to scroll back to the top. Now it is on screen wherever you are. Because a pinned banner is permanent screen real estate, the banners cap at `35dvh` below `lg` and scroll internally past that — a 2000px announcement renders 282px tall on an 806px viewport instead of taking the whole phone.

**The header no longer covers the admin bar.** `AdminBar` is `fixed top-0 z-50`; the header is also `z-50` and later in the DOM, so a header pinned at `top: 0` won and hid it from logged-in editors. `AdminBar` now publishes its height as `--admin-bar-height` and the sticky wrapper pins below it. Raising the admin bar's z-index instead would have put it over the hamburger button.

**The mobile menu panel tracks the header.** Its `top` and `max-height` now both derive from the same measured header bottom (in `dvh`), where the max-height was previously hardcoded against a 64px offset and could run the panel past the bottom of the viewport with no way to scroll to it. The measurement re-runs on a frame while the menu is open, so the panel follows the header when the banners animate open or closed underneath it.

**The logo is centered in the mobile header.** The row was `flex justify-between` over three children, so when a center had no active announcements the toggle did not render and the logo was pushed to the right edge. A spacer opposite the hamburger would not have fixed it either — the hamburger is 40px and the toggle is 36px, so the logo was a couple of pixels off center even when the toggle was present. It is three grid tracks with equal outer columns now.

**Anchor targets clear the pinned header** via `scroll-pt-16 lg:scroll-pt-0`. There are no in-page anchors in the app today; this is so the next one does not land underneath the header.

**Expanding from the desktop pill scrolls back to the banners.** Desktop has the same off-screen-expansion problem, and since the header is not sticky there, pinning is not the answer — the fixed pill returns you to the top instead, honoring `prefers-reduced-motion`.

## How to test

1. Open any tenant page (e.g. `nwac.localhost:3000`) at a viewport **narrower than 1024px**.
2. Scroll down. The header should pin to the top of the viewport with content passing beneath it. Before this change it drifted over the content and overlapped it.
3. With an announcement active, collapse it from the megaphone toggle, scroll down, then expand it again. The announcement should appear pinned above the header without moving you off your place on the page. Collapsing should likewise leave you where you are.
4. Open the mobile menu after scrolling. The dropdown should align flush to the bottom of the header, and should not extend past the bottom of the viewport. Collapse the announcements from the megaphone while the menu is open — the dropdown should follow the header up.
5. On a center with no active announcements (SAC in the local seed), check that the logo is centered rather than pushed right.
6. Log in and repeat at mobile widths: the admin bar should stay visible above the pinned header rather than being covered by it.
7. At `lg` and wider, everything should be unchanged — static header, banners scrolling away, and the collapsed pill scrolling you back to the top when expanded.

## Screenshots / Demo video

Demo of the original sticky-header commit: https://www.loom.com/share/49c80858169d46579c391bf6b582ec06

Note that the Loom predates the later commits — it shows the banners scrolling away before the header pins, which is no longer how it behaves. Worth re-recording before merge.

## Migration Explanation

None — presentational only.

## Future enhancements / Questions

- The `35dvh` cap on pinned announcements is a judgment call, not a researched number. Worth a look on a real device with a genuinely long announcement.
- Verified in Chrome at emulated mobile and desktop widths against the local seed, not on physical hardware. iOS Safari is the one worth a spot check, since it is the primary mobile target and `dvh` plus sticky is where it historically differs.
- The desktop header is still not sticky. That is deliberate and unchanged here, but if it should be, the wrapper is now the natural place to do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788735789&installation_model_id=426131&pr_number=1181&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1181&signature=f3a74887fd632b27afb1ec1e606c7209036c5f0c7eb67396b311f7f5e31e2d58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
