### PR TITLE
Fix nacFetch/afpFetch cache options: seconds TTL and real cache tags

### DIFF
--- a/__tests__/server/nacFetchCacheOptions.server.test.ts
+++ b/__tests__/server/nacFetchCacheOptions.server.test.ts
@@ -1,0 +1,67 @@
+jest.mock('../../src/payload.config', () => ({}))
+
+jest.mock('payload', () => ({
+  getPayload: jest.fn(),
+}))
+
+import { afpFetch, nacFetch } from '@/services/nac/nac'
+
+const ONE_DAY_IN_SECONDS = 24 * 60 * 60
+
+let fetchSpy: jest.SpiedFunction<typeof globalThis.fetch>
+
+function initFor(callIndex = 0): RequestInit {
+  const init = fetchSpy.mock.calls[callIndex]?.[1]
+  if (!init) {
+    throw new Error(`fetch was not called with an init object at call ${callIndex}`)
+  }
+  return init
+}
+
+beforeEach(() => {
+  // A fresh Response per call — a single instance's body can only be read once.
+  fetchSpy = jest
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async () => new Response(JSON.stringify({ ok: true })))
+})
+
+afterEach(() => {
+  fetchSpy.mockRestore()
+})
+
+describe.each([
+  ['nacFetch', nacFetch],
+  ['afpFetch', afpFetch],
+])('services: %s cache options', (_name, doFetch) => {
+  it('defaults revalidate to one day expressed in seconds', async () => {
+    await doFetch('/v2/public/avalanche-center/NWAC')
+
+    expect(initFor().next?.revalidate).toBe(ONE_DAY_IN_SECONDS)
+  })
+
+  it('passes an explicit cachedTime through unchanged', async () => {
+    await doFetch('/v2/public/avalanche-center/NWAC', { cachedTime: 30 * 60 })
+
+    expect(initFor().next?.revalidate).toBe(30 * 60)
+  })
+
+  it('honors cachedTime: false to cache indefinitely', async () => {
+    await doFetch('/v2/public/avalanche-center/NWAC', { cachedTime: false })
+
+    expect(initFor().next?.revalidate).toBe(false)
+  })
+
+  it('sets next.tags to the tag array so revalidateTag applies', async () => {
+    await doFetch('/v2/public/avalanche-center/NWAC', { tags: ['nac-metadata', 'nwac'] })
+
+    expect(initFor().next?.tags).toEqual(['nac-metadata', 'nwac'])
+  })
+
+  it('omits tags entirely when none are given', async () => {
+    await doFetch('/v2/public/avalanche-center/NWAC')
+    await doFetch('/v2/public/avalanche-center/NWAC', { tags: [] })
+
+    expect(initFor(0).next).not.toHaveProperty('tags')
+    expect(initFor(1).next).not.toHaveProperty('tags')
+  })
+})

--- a/__tests__/server/nacFetchCacheOptions.server.test.ts
+++ b/__tests__/server/nacFetchCacheOptions.server.test.ts
@@ -64,4 +64,11 @@ describe.each([
     expect(initFor(0).next).not.toHaveProperty('tags')
     expect(initFor(1).next).not.toHaveProperty('tags')
   })
+
+  it('skips the data cache when noStore is set', async () => {
+    await doFetch('/v2/public/avalanche-center/NWAC', { noStore: true })
+
+    expect(initFor().cache).toBe('no-store')
+    expect(initFor().next).toBeUndefined()
+  })
 })

--- a/src/services/nac/nac.ts
+++ b/src/services/nac/nac.ts
@@ -29,6 +29,26 @@ type Options = {
   tags?: string[]
   // Seconds, matching Next's `next.revalidate`.
   cachedTime?: number | false
+  // Skip Next's fetch-level data cache entirely (cache: 'no-store'). Use for responses too
+  // large for the 2MB data cache, which are cached one layer up after being trimmed down.
+  noStore?: boolean
+}
+
+const DEFAULT_CACHED_TIME_SECONDS = 24 * 60 * 60
+
+function fetchInit(options: Options): RequestInit {
+  if (options.noStore) {
+    return { cache: 'no-store' }
+  }
+
+  return {
+    next: {
+      revalidate: options.cachedTime ?? DEFAULT_CACHED_TIME_SECONDS,
+      // Spread as `{ tags }`; spreading the bare array sets numeric keys, leaving the fetch
+      // untagged and revalidateTag a silent no-op.
+      ...(options.tags && options.tags.length > 0 ? { tags: options.tags } : {}),
+    },
+  }
 }
 
 export async function nacFetch(path: string, options: Options = {}) {
@@ -36,14 +56,7 @@ export async function nacFetch(path: string, options: Options = {}) {
   const url = `${host}/${normalizedPath}`
 
   try {
-    const res = await fetch(url, {
-      next: {
-        revalidate: options?.cachedTime ?? 24 * 60 * 60, // hold on to this cached data for a day (in seconds)
-        // Spread as `{ tags }`; spreading the bare array sets numeric keys, leaving the fetch
-        // untagged and revalidateTag a silent no-op.
-        ...(options?.tags && options.tags.length > 0 ? { tags: options.tags } : {}),
-      },
-    })
+    const res = await fetch(url, fetchInit(options))
 
     if (!res.ok) {
       throw new NACError(`NAC API request failed with status ${res.status}`, null, {
@@ -80,14 +93,7 @@ export async function afpFetch(path: string, options: Options = {}) {
   const url = `${wordpressHost}?${querystring}`
 
   try {
-    const res = await fetch(url, {
-      next: {
-        revalidate: options?.cachedTime ?? 24 * 60 * 60, // hold on to this cached data for a day (in seconds)
-        // Spread as `{ tags }`; spreading the bare array sets numeric keys, leaving the fetch
-        // untagged and revalidateTag a silent no-op.
-        ...(options?.tags && options.tags.length > 0 ? { tags: options.tags } : {}),
-      },
-    })
+    const res = await fetch(url, fetchInit(options))
 
     if (!res.ok) {
       let errorData

--- a/src/services/nac/nac.ts
+++ b/src/services/nac/nac.ts
@@ -27,6 +27,7 @@ export class NACError extends Error {
 
 type Options = {
   tags?: string[]
+  // Seconds, matching Next's `next.revalidate`.
   cachedTime?: number | false
 }
 
@@ -37,8 +38,10 @@ export async function nacFetch(path: string, options: Options = {}) {
   try {
     const res = await fetch(url, {
       next: {
-        revalidate: options?.cachedTime ?? 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
-        ...(options?.tags && options.tags.length > 0 ? options.tags : []),
+        revalidate: options?.cachedTime ?? 24 * 60 * 60, // hold on to this cached data for a day (in seconds)
+        // Spread as `{ tags }`; spreading the bare array sets numeric keys, leaving the fetch
+        // untagged and revalidateTag a silent no-op.
+        ...(options?.tags && options.tags.length > 0 ? { tags: options.tags } : {}),
       },
     })
 
@@ -79,8 +82,10 @@ export async function afpFetch(path: string, options: Options = {}) {
   try {
     const res = await fetch(url, {
       next: {
-        revalidate: options?.cachedTime ?? 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
-        ...(options?.tags && options.tags.length > 0 ? options.tags : []),
+        revalidate: options?.cachedTime ?? 24 * 60 * 60, // hold on to this cached data for a day (in seconds)
+        // Spread as `{ tags }`; spreading the bare array sets numeric keys, leaving the fetch
+        // untagged and revalidateTag a silent no-op.
+        ...(options?.tags && options.tags.length > 0 ? { tags: options.tags } : {}),
       },
     })
 


### PR DESCRIPTION
## Description

`nacFetch` and `afpFetch` defaulted `next.revalidate` to `24 * 60 * 60 * 1000`, but Next reads that field in seconds — that's ~1000 days, not the one day the comment claimed, so upstream NAC data was effectively pinned until the next deploy. They also spread `tags` into the `next` object as a bare array, which sets numeric keys (`{ 0: 'tag' }`) rather than `tags`, leaving every fetch untagged and `revalidateTag` a silent no-op. Both bugs existed in two near-identical inline copies, so this also extracts the shared `fetchInit` helper that made them possible.

## Related Issues

Fixes #1185

## Key Changes

- `revalidate` now defaults to `24 * 60 * 60` (seconds) in both functions. This is what unsticks `getAvalancheCenterMetadata` (zones, timezone, widget config) and `getAllAvalancheCenterCapabilities` — a forecaster who adds or renames a zone, or changes widget config in the NAC dashboard, no longer has to wait for a redeploy to see it.
- `tags` is spread as `{ tags: options.tags }`, so `revalidateTag` actually applies. Latent today (no caller passes `tags`), but it fails silently for whoever adds the first one.
- Extracted `fetchInit(options)`, shared by both functions, and added `noStore` to both for responses too large for the 2MB data cache. No caller needs `noStore` yet; it belongs in the shared helper rather than being bolted onto one of the pair later.
- Commits are split: [`7cafd29`](https://github.com/NWACus/web/commit/7cafd29c) is the bug fix alone, [`230919c`](https://github.com/NWACus/web/commit/230919cf) is the refactor.

## How to test

`pnpm test` — new `__tests__/server/nacFetchCacheOptions.server.test.ts` runs as a `describe.each` over both functions so they can't drift again, covering default TTL in seconds, explicit `cachedTime` passthrough, `cachedTime: false`, `next.tags` populated, tags omitted when absent/empty, and `noStore` → `cache: 'no-store'`. These are load-bearing: temporarily reverting the fix fails 4 of them. Full suite passes (71 suites / 627 tests), along with `pnpm tsc`, `pnpm lint`, `pnpm drift:check`, and `pnpm fallow:audit`.

## Screenshots / Demo video

N/A — no user-visible UI change.

## Migration Explanation

N/A — no schema or migration changes.

## Future enhancements / Questions

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789154067&installation_model_id=426131&pr_number=1186&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1186&signature=1872e0530f30319e0156b9cd487f6dd727474c9b5670e6b1faa534cd8859f69a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->