### PR TITLE
Add two new course types to the Course Type picklist

### DIFF
--- a/src/constants/courseTypes.ts
+++ b/src/constants/courseTypes.ts
@@ -41,4 +41,12 @@ export const courseTypesData: CourseType[] = [
       'Introductory avalanche awareness sessions offered by external providers, covering basic avalanche safety concepts.',
     value: 'awareness-external',
   },
+  {
+    label: 'Intro to Avalanches Field Course',
+    value: 'intro-to-avalanches-field-course',
+  },
+  {
+    label: 'Level 1 + Rescue Combined',
+    value: 'level-1-rescue-combined',
+  },
 ]


### PR DESCRIPTION
## Description

Adds two new course types to the shared Course Type picklist:

- **Intro to Avalanches Field Course** (`intro-to-avalanches-field-course`)
- **Level 1 + Rescue Combined** (`level-1-rescue-combined`)

`courseTypesData` in `src/constants/courseTypes.ts` is the single source of truth for course types — the Courses `courseType` select, the Providers "Approved Course Types" select, the public course-type filter, the embed generator, and the provider-published email all derive their options from it. Appending the two entries there makes them available everywhere at once. The options are global to all avalanche centers (course types are not tenant-scoped), which is the intended behavior.

The new entries include `label` and `value` only — no `description`. The `description` field on `CourseType` is optional and is rendered nowhere (every consumer maps the data down to `{ label, value }`), so adding description copy would be invisible dead data.

## Related Issues

Closes #1188

## Key Changes

- Append two new entries to `courseTypesData` in `src/constants/courseTypes.ts` (existing six entries untouched).

## How to test

1. In the admin panel, create or edit a **Course** and confirm both new options are selectable as the Course Type (subject to the provider's approved-types filtering that already applies).
2. Edit a **Provider** and confirm both new options are selectable under "Approved Course Types".
3. On the public course listing, confirm the "Course Type" filter shows both new options.

## Screenshots / Demo video

N/A — picklist value addition, no visual/layout change.

## Migration Explanation

No migration required. The stored columns for these select values (`courses.course_type` and `providers_course_types.value`) are plain `text` with no enum/check constraint, so new option values are accepted without a schema change.

## Future enhancements / Questions

- `CourseType.description` is currently carried in the constant but rendered nowhere. If descriptions should ever be surfaced (admin field help text, public filter tooltips, etc.), that would be a separate change — and the two new types would need description copy at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xu99cZaGFPoaP11W3K7hB

---
_Generated by [Claude Code](https://claude.ai/code/session_012xu99cZaGFPoaP11W3K7hB)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789677743&installation_model_id=426131&pr_number=1192&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1192&signature=9666374a177623407451e825971eb44b9b39cdb4877e4851608bdb61ed7b60ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->