### PR TITLE
Show state next to location in public Courses UI

### DIFF
--- a/src/components/CoursePreviewSmallRow.tsx
+++ b/src/components/CoursePreviewSmallRow.tsx
@@ -47,12 +47,11 @@ export const CoursePreviewSmallRow = (props: {
     ? courseTypesData.find((ct) => ct.value === courseType)?.label
     : null
 
-  // Build location display text with fallbacks
+  // Build location display text with fallbacks, appending state when present
   const getLocationText = () => {
     if (!location) return null
-    if (location.placeName) return location.placeName
-    if (location.city && location.state) return `${location.city}, ${location.state}`
-    if (location.city) return location.city
+    const place = location.placeName || location.city
+    if (place) return location.state ? `${place}, ${location.state}` : place
     if (location.state) return location.state
     return 'Location'
   }


### PR DESCRIPTION
## Description

The public Courses listing (rendered via `CoursePreviewSmallRow`) shows a single location string next to the map-pin icon. Because a Course's `location.placeName` is a required field, the previous helper always returned `placeName` on its own and the `state` value was effectively never displayed. This change appends the location's two-letter `state` abbreviation to the displayed text when it is set (e.g. `Bellingham Ski Shop, WA`), for both the `placeName` and `city` branches. When no `state` is present, the display is unchanged.

## Related Issues

Fixes #1193

## Key Changes

- `src/components/CoursePreviewSmallRow.tsx`: Reworked the `getLocationText()` helper so that when `location.state` is present it appends `, {state}` to whichever of `placeName`/`city` is shown. Behavior is unchanged when there is no state (no trailing comma/space), when only a state is set, and when there is no location.

## How to test

1. Run the public Courses embed (A3 course list) for a tenant with course data.
2. A course whose location has a `placeName` and a `state` shows `{placeName}, {state}` (e.g. `Bellingham Ski Shop, WA`).
3. A course with a `city` and a `state` (no `placeName`) shows `{city}, {state}`.
4. A course with a `placeName` but no `state` shows just `{placeName}` (no trailing comma/space).
5. A course with only a `state` shows the state alone; a course with no location renders no location line.
6. `pnpm tsc` and `pnpm lint` both pass.

## Screenshots / Demo video

N/A — text-only location tweak (appends the state abbreviation to the existing location line; no styling or icon changes).

## Migration Explanation

N/A — no schema changes.

## Future enhancements / Questions

- Could optionally display the full spelled-out state name instead of the abbreviation, but that is out of scope here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6dNLcBLhKetQwKErRNefe)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789678852&installation_model_id=426131&pr_number=1194&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1194&signature=0ec4b7cdb3206970d4b04797bf4c80c15fa726899762d38b7a0a3cfc7b4f8aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->