### PR TITLE
Drop the repo-wide *.docx ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,3 @@ plans/
 /playwright/.cache/
 __tests__/e2e/.auth/
 .beads
-
-# Exported copies of docs that live in Google Drive
-*.docx


### PR DESCRIPTION
Removes the `*.docx` rule added alongside the architecture doc in #1224.

Wrong scope on reflection. Those `.docx` files are local exports of a doc that lives in Google Drive — one person's working copies, not something every contributor needs ignored. A blanket `*.docx` rule would also silently swallow a `.docx` someone legitimately wanted to commit.

Local-only exclusions belong in `.git/info/exclude`, which is per-clone and never committed. No behavior change for anyone else.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790115946&installation_model_id=426131&pr_number=1225&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1225&signature=06e42712d4d33158e3447f6db32ca4a4d379d59657075fcf581c30e34ce8f752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->