### PR TITLE
Preserve media embedded in forecast discussions and avalanche problems

### DIFF
--- a/__tests__/client-setup.ts
+++ b/__tests__/client-setup.ts
@@ -1,0 +1,35 @@
+/**
+ * Browser APIs jsdom does not implement, stubbed inertly for every client test.
+ *
+ * The forecast and gallery lightboxes pull in embla-carousel and react-zoom-pan-pinch, which
+ * construct observers and read `matchMedia` on mount. Without these a component test fails on the
+ * environment rather than on the component.
+ */
+class NoopObserver {
+  readonly root = null
+  readonly rootMargin = ''
+  readonly thresholds: number[] = []
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return []
+  }
+}
+
+global.ResizeObserver = NoopObserver
+global.IntersectionObserver = NoopObserver
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }),
+})

--- a/__tests__/client/components/AvalancheProblemCard.client.test.tsx
+++ b/__tests__/client/components/AvalancheProblemCard.client.test.tsx
@@ -8,7 +8,7 @@ import {
   type AvalancheProblem,
 } from '@/services/nac/types/forecastSchemas'
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
 const baseProblem: AvalancheProblem = {
   id: 1,
@@ -98,4 +98,84 @@ describe('AvalancheProblemCard', () => {
     // Only the problem icon, no media thumbnail
     expect(images).toHaveLength(1)
   })
+
+  it('opens an example photo in the lightbox rather than leaving it static', async () => {
+    render(<AvalancheProblemCard problem={withMedia(imageMedia())} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand embedded image' }))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+  })
+
+  // Real shape, from CNFAIC/SNFAC/NWAC forecasts: a YouTube id with its own poster frame. This
+  // used to render as nothing at all.
+  it('renders a problem video as its poster frame, marked playable', () => {
+    render(<AvalancheProblemCard problem={withMedia(videoMedia())} />)
+
+    expect(document.querySelector('img[src="https://example.com/medium.jpg"]')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Play embedded video' })).toBeInTheDocument()
+    expect(screen.getByText('Ben on the snowpack')).toBeInTheDocument()
+  })
+
+  it('plays a problem video in the lightbox', async () => {
+    render(<AvalancheProblemCard problem={withMedia(videoMedia())} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Play embedded video' }))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(document.querySelector('iframe')).toHaveAttribute(
+      'src',
+      expect.stringContaining('73fFkbWuMOo'),
+    )
+  })
+
+  // The other real shape (four SNFAC forecasts): the url is a bare YouTube id and there is no
+  // poster URL, so it has to come from YouTube.
+  it('falls back to YouTube’s poster when a video carries only its id', () => {
+    render(
+      <AvalancheProblemCard
+        problem={withMedia({
+          type: MediaType.Video,
+          url: '784O9k5_-fc',
+          caption: 'Chris on Avalanche Peak',
+          title: null,
+        })}
+      />,
+    )
+
+    expect(
+      document.querySelector('img[src="https://i.ytimg.com/vi/784O9k5_-fc/hqdefault.jpg"]'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Play embedded video' })).toBeInTheDocument()
+  })
+})
+
+const withMedia = (media: AvalancheProblem['media']): AvalancheProblem => ({
+  ...baseProblem,
+  media,
+})
+
+const imageMedia = (): AvalancheProblem['media'] => ({
+  type: MediaType.Image,
+  url: {
+    large: 'https://example.com/large.jpg',
+    medium: 'https://example.com/medium.jpg',
+    original: 'https://example.com/original.jpg',
+    thumbnail: 'https://example.com/thumb.jpg',
+  },
+  caption: 'Storm slab crown',
+  title: null,
+})
+
+const videoMedia = (): AvalancheProblem['media'] => ({
+  type: MediaType.Video,
+  url: {
+    large: 'https://example.com/large.jpg',
+    medium: 'https://example.com/medium.jpg',
+    original: 'https://example.com/original.jpg',
+    thumbnail: 'https://example.com/thumb.jpg',
+    video_id: '73fFkbWuMOo',
+  },
+  caption: 'Ben on the snowpack',
+  title: null,
 })

--- a/__tests__/client/components/DiscussionBody.client.test.tsx
+++ b/__tests__/client/components/DiscussionBody.client.test.tsx
@@ -3,34 +3,6 @@ import { sanitizeHtml } from '@/components/forecast/sanitizeHtml'
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen } from '@testing-library/react'
 
-// jsdom supplies none of these: react-zoom-pan-pinch (behind the lightbox's zoomable photo)
-// constructs a ResizeObserver on mount, and embla-carousel needs matchMedia and an
-// IntersectionObserver when the lightbox opens.
-beforeAll(() => {
-  class NoopObserver {
-    readonly root = null
-    readonly rootMargin = ''
-    readonly thresholds: number[] = []
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-    takeRecords(): IntersectionObserverEntry[] {
-      return []
-    }
-  }
-  global.ResizeObserver = NoopObserver
-  global.IntersectionObserver = NoopObserver
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    value: (query: string) => ({
-      matches: false,
-      media: query,
-      addEventListener: () => {},
-      removeEventListener: () => {},
-    }),
-  })
-})
-
 // Verbatim markup from the live NAC v2 API. Sources: BTAC 184960, SNFAC 109444, TAC 181191.
 const IMAGE_FIGURE =
   '<figure class="image afp-photoswipe">\n<div class="afp-image-container"><img style="width: 700px; height: auto;" src="https://media.test/snowfall-large.png" alt=""></div>\n<figcaption>Snowfall totals</figcaption>\n</figure>'

--- a/__tests__/client/components/DiscussionBody.client.test.tsx
+++ b/__tests__/client/components/DiscussionBody.client.test.tsx
@@ -1,0 +1,143 @@
+import { DiscussionBody } from '@/components/forecast/DiscussionBody'
+import { sanitizeHtml } from '@/components/forecast/sanitizeHtml'
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+// jsdom supplies none of these: react-zoom-pan-pinch (behind the lightbox's zoomable photo)
+// constructs a ResizeObserver on mount, and embla-carousel needs matchMedia and an
+// IntersectionObserver when the lightbox opens.
+beforeAll(() => {
+  class NoopObserver {
+    readonly root = null
+    readonly rootMargin = ''
+    readonly thresholds: number[] = []
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return []
+    }
+  }
+  global.ResizeObserver = NoopObserver
+  global.IntersectionObserver = NoopObserver
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  })
+})
+
+// Verbatim markup from the live NAC v2 API. Sources: BTAC 184960, SNFAC 109444, TAC 181191.
+const IMAGE_FIGURE =
+  '<figure class="image afp-photoswipe">\n<div class="afp-image-container"><img style="width: 700px; height: auto;" src="https://media.test/snowfall-large.png" alt=""></div>\n<figcaption>Snowfall totals</figcaption>\n</figure>'
+
+const VIDEO_FIGURE =
+  '<figure class="image afp-video-modal">\n<div class="afp-image-container afp-video-container"><img src="https://media.test/poster.jpg" alt="" data-video-id="p0torRf9boA" /></div>\n<figcaption>Weekly video</figcaption>\n</figure>'
+
+const YOUTUBE_IFRAME =
+  '<p><iframe title="Reactive Slab" src="https://www.youtube.com/embed/_rYvrxGpBQc" width="1062" height="597" frameborder="0" allowfullscreen="allowfullscreen"></iframe></p>'
+
+const renderDiscussion = (html: string) => render(<DiscussionBody html={sanitizeHtml(html)} />)
+
+describe('DiscussionBody', () => {
+  it('renders authored prose untouched', () => {
+    renderDiscussion('<p>Watch for wind slabs on north aspects.</p>')
+
+    expect(screen.getByText('Watch for wind slabs on north aspects.')).toBeInTheDocument()
+  })
+
+  it('renders a forecaster-embedded YouTube video rather than dropping it', () => {
+    const { container } = renderDiscussion(YOUTUBE_IFRAME)
+
+    const iframe = container.querySelector('iframe')
+    expect(iframe).toBeInTheDocument()
+    expect(iframe?.getAttribute('src')).toContain('/embed/_rYvrxGpBQc')
+  })
+
+  it('adds no controls when nothing is embedded', () => {
+    renderDiscussion('<p>Just prose.</p>')
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('makes an embedded image expandable', () => {
+    renderDiscussion(IMAGE_FIGURE)
+
+    expect(screen.getByRole('button', { name: 'Expand embedded image' })).toBeInTheDocument()
+  })
+
+  it('marks an embedded video as playable', () => {
+    renderDiscussion(VIDEO_FIGURE)
+
+    expect(screen.getByRole('button', { name: 'Play embedded video' })).toBeInTheDocument()
+  })
+
+  it('opens the lightbox on the figure that was clicked', async () => {
+    renderDiscussion(`${IMAGE_FIGURE}<p>between</p>${VIDEO_FIGURE}`)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Play embedded video' }))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByTitle('Weekly video')).toHaveAttribute(
+      'src',
+      expect.stringContaining('p0torRf9boA'),
+    )
+  })
+
+  it('opens the lightbox when the figure itself is clicked, as the legacy widget did', async () => {
+    const { container } = renderDiscussion(IMAGE_FIGURE)
+
+    const caption = container.querySelector('figcaption')
+    expect(caption).not.toBeNull()
+    if (caption) fireEvent.click(caption)
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('keeps the affordances after opening the lightbox', async () => {
+    renderDiscussion(IMAGE_FIGURE)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand embedded image' }))
+    await screen.findByRole('dialog')
+
+    // React rewrites a dangerouslySetInnerHTML subtree on any re-render, which would detach the
+    // collected figures and strand their overlays in orphaned nodes. The rendered HTML is memoized
+    // to prevent that. (The open dialog marks the page behind it hidden, hence `hidden: true`.)
+    expect(
+      screen.getByRole('button', { name: 'Expand embedded image', hidden: true }),
+    ).toBeInTheDocument()
+  })
+
+  it('re-collects when a corrected forecast replaces the discussion', () => {
+    const { rerender } = renderDiscussion(IMAGE_FIGURE)
+    expect(screen.getByRole('button', { name: 'Expand embedded image' })).toBeInTheDocument()
+
+    rerender(<DiscussionBody html={sanitizeHtml(`${IMAGE_FIGURE}${VIDEO_FIGURE}`)} />)
+
+    expect(screen.getAllByRole('button', { name: 'Expand embedded image' })).toHaveLength(1)
+    expect(screen.getByRole('button', { name: 'Play embedded video' })).toBeInTheDocument()
+  })
+
+  it('leaves the poster image itself clickable, so its context menu still works', () => {
+    const { container } = renderDiscussion(IMAGE_FIGURE)
+
+    const overlay = container.querySelector('.afp-image-container > span')
+    expect(overlay).toHaveClass('pointer-events-none')
+  })
+
+  it('lets a link inside a figure navigate instead of opening the lightbox', async () => {
+    const { container } = renderDiscussion(
+      '<figure class="afp-photoswipe"><div class="afp-image-container"><img src="/a.png"></div><figcaption>Photo: <a href="https://example.test/who">Erik</a></figcaption></figure>',
+    )
+
+    const link = container.querySelector('figcaption a')
+    expect(link).not.toBeNull()
+    if (link) fireEvent.click(link)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/__tests__/client/components/MediaSlide.client.test.tsx
+++ b/__tests__/client/components/MediaSlide.client.test.tsx
@@ -45,7 +45,7 @@ describe('MediaSlide', () => {
   it('embeds a YouTube player for a video item', () => {
     render(<MediaSlide item={youTube()} />)
     const frame = document.querySelector('iframe')
-    expect(frame).toHaveAttribute('src', 'https://www.youtube.com/embed/dQw4w9WgXcQ')
+    expect(frame).toHaveAttribute('src', 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0')
     expect(frame).toHaveAttribute('title', 'Avalanche footage')
   })
 
@@ -64,7 +64,7 @@ describe('MediaSlide', () => {
     render(<MediaSlide item={injected} />)
     expect(document.querySelector('iframe')).toHaveAttribute(
       'src',
-      'https://www.youtube.com/embed/a%20b%26c',
+      'https://www.youtube-nocookie.com/embed/a%20b%26c?rel=0',
     )
   })
 

--- a/__tests__/client/components/embeddedMedia.client.test.ts
+++ b/__tests__/client/components/embeddedMedia.client.test.ts
@@ -1,0 +1,105 @@
+import { collectEmbeddedMedia } from '@/components/forecast/embeddedMedia'
+import { sanitizeHtml } from '@/components/forecast/sanitizeHtml'
+import { MediaType } from '@/services/nac/model/forecast'
+
+// Verbatim markup from the live NAC v2 API. Sources: BTAC 184960 (image figure), SNFAC 109444
+// (video figure), SNFAC 106477 (empty figcaption), CNFAIC 185366 (figure inside a float wrapper),
+// TAC 135278 (the whole discussion wrapped in a div, so no figure is top-level).
+const IMAGE_FIGURE =
+  '<figure class="image afp-photoswipe">\n<div class="afp-image-container"><img style="width: 700px; height: auto;" src="https://media.test/snowfall-large.png" alt=""></div>\n<figcaption>4/2 - 4/15 Snowfall totals</figcaption>\n</figure>'
+
+const VIDEO_FIGURE =
+  '<figure class="image afp-video-modal" style="text-align: center;">\n<div class="afp-image-container afp-video-container"><img style="width: 700px; height: auto;" src="https://media.test/poster.jpg" alt="" data-video-id="p0torRf9boA" /></div>\n<figcaption>(3/25/2022) Join Ethan for a spin through the week.</figcaption>\n</figure>'
+
+const EMPTY_CAPTION_FIGURE =
+  '<figure class="image afp-video-modal align-center">\n<div class="afp-image-container afp-video-container"><img src="https://media.test/poster2.jpg" alt="" data-video-id="HcN_MydVTGY" /></div>\n<figcaption spellcheck="false"></figcaption>\n</figure>'
+
+/** Render sanitized HTML into a detached container, the way DiscussionBody does. */
+function mount(html: string): HTMLElement {
+  const root = document.createElement('div')
+  root.innerHTML = sanitizeHtml(html)
+  return root
+}
+
+describe('collectEmbeddedMedia', () => {
+  it('builds an image item from a photoswipe figure', () => {
+    const [entry, ...rest] = collectEmbeddedMedia(mount(IMAGE_FIGURE))
+
+    expect(rest).toHaveLength(0)
+    expect(entry.isVideo).toBe(false)
+    expect(entry.item).toEqual({
+      type: MediaType.Image,
+      caption: '4/2 - 4/15 Snowfall totals',
+      url: {
+        large: 'https://media.test/snowfall-large.png',
+        medium: 'https://media.test/snowfall-large.png',
+        original: 'https://media.test/snowfall-large.png',
+        thumbnail: 'https://media.test/snowfall-large.png',
+      },
+    })
+  })
+
+  it('builds a video item from the poster image data-video-id', () => {
+    const [entry] = collectEmbeddedMedia(mount(VIDEO_FIGURE))
+
+    expect(entry.isVideo).toBe(true)
+    expect(entry.item.type).toBe(MediaType.Video)
+    expect(entry.item).toMatchObject({
+      url: { video_id: 'p0torRf9boA', original: 'https://media.test/poster.jpg' },
+    })
+  })
+
+  it('points the icon target at the inner container, as the legacy widget did', () => {
+    const [image] = collectEmbeddedMedia(mount(IMAGE_FIGURE))
+    const [video] = collectEmbeddedMedia(mount(VIDEO_FIGURE))
+
+    expect(image.iconTarget.className).toBe('afp-image-container')
+    expect(video.iconTarget.className).toBe('afp-image-container afp-video-container')
+  })
+
+  it('keeps an empty caption as an empty string rather than failing', () => {
+    const [entry] = collectEmbeddedMedia(mount(EMPTY_CAPTION_FIGURE))
+
+    expect(entry.item.type).toBe(MediaType.Video)
+    expect(entry.item).toMatchObject({ caption: '' })
+  })
+
+  it('keeps caption markup, which the lightbox sanitizes before rendering', () => {
+    const [entry] = collectEmbeddedMedia(
+      mount(
+        '<figure class="afp-photoswipe"><div class="afp-image-container"><img src="/a.png"></div><figcaption><p>Photo: <em>Erik</em></p></figcaption></figure>',
+      ),
+    )
+
+    expect(entry.item).toMatchObject({ caption: '<p>Photo: <em>Erik</em></p>' })
+  })
+
+  it('collects in document order across nesting depths', () => {
+    // CNFAIC floats a figure inside an overflow wrapper; TAC wraps the whole discussion in a div.
+    const root = mount(
+      `<div><p>intro</p>${IMAGE_FIGURE}<div style="overflow: hidden;">${VIDEO_FIGURE}</div></div>`,
+    )
+
+    expect(collectEmbeddedMedia(root).map((entry) => entry.isVideo)).toEqual([false, true])
+  })
+
+  it('matches the older WordPress editor class names too', () => {
+    const root = mount(
+      '<figure class="image nac-photoswipe"><div class="afp-image-container"><img src="/a.png"></div><figcaption>c</figcaption></figure>',
+    )
+
+    expect(collectEmbeddedMedia(root)).toHaveLength(1)
+  })
+
+  it('skips a figure with no image rather than opening an empty lightbox slide', () => {
+    const root = mount('<figure class="afp-photoswipe"><figcaption>no image</figcaption></figure>')
+
+    expect(collectEmbeddedMedia(root)).toHaveLength(0)
+  })
+
+  it('finds nothing in a discussion with no embedded media', () => {
+    expect(collectEmbeddedMedia(mount('<p>Just prose, and an <img src="/loose.png"></p>'))).toEqual(
+      [],
+    )
+  })
+})

--- a/__tests__/server/mediaItem.server.test.ts
+++ b/__tests__/server/mediaItem.server.test.ts
@@ -2,6 +2,7 @@ import {
   displayableMedia,
   getCaption,
   getFullUrl,
+  getPosterUrl,
   getThumbnailUrl,
   getYouTubeVideoId,
   resolveMediaSlide,
@@ -101,8 +102,33 @@ describe('getYouTubeVideoId', () => {
     expect(getYouTubeVideoId(linkOnlyVideo)).toBeNull()
   })
 
+  it('reads a bare url string as the video id, as the legacy widget does', () => {
+    const bareId: MediaItem = { type: MediaType.Video, url: '784O9k5_-fc', caption: null }
+    expect(getYouTubeVideoId(bareId)).toBe('784O9k5_-fc')
+  })
+
   it('returns null for non-video kinds', () => {
     expect(getYouTubeVideoId(imageItem())).toBeNull()
+  })
+})
+
+describe('getPosterUrl', () => {
+  it('uses the medium size for an image, which is what the widget asks for inline', () => {
+    expect(getPosterUrl(imageItem())).toBe('https://example.test/medium.jpg')
+  })
+
+  it('uses the video’s own poster frame when it has one', () => {
+    expect(getPosterUrl(youTubeItem())).toBe('https://example.test/medium.jpg')
+  })
+
+  it('falls back to YouTube’s poster for a video that is only an id', () => {
+    const bareId: MediaItem = { type: MediaType.Video, url: '784O9k5_-fc', caption: null }
+    expect(getPosterUrl(bareId)).toBe('https://i.ytimg.com/vi/784O9k5_-fc/hqdefault.jpg')
+  })
+
+  it('has nothing to show for an external link or a PDF', () => {
+    expect(getPosterUrl(externalItem())).toBeNull()
+    expect(getPosterUrl(pdfItem())).toBeNull()
   })
 })
 

--- a/__tests__/server/sanitizeHtml.server.test.ts
+++ b/__tests__/server/sanitizeHtml.server.test.ts
@@ -69,6 +69,32 @@ describe('sanitizeHtml', () => {
       expect(out).toContain('src="https://player.vimeo.com/video/12345"')
     })
 
+    it('keeps a playlist a playlist', () => {
+      // `videoseries` is itself 11 characters, so it passes for a video id — without the list
+      // param carried over, the rebuilt URL asks YouTube for a video by that name.
+      const out = sanitizeHtml(
+        '<iframe src="https://www.youtube.com/embed/videoseries?list=PLabcdefghij"></iframe>',
+      )
+      expect(out).toContain('/embed/videoseries')
+      expect(out).toContain('list=PLabcdefghij')
+    })
+
+    it('keeps a start offset and a Vimeo private-video hash', () => {
+      expect(
+        sanitizeHtml('<iframe src="https://www.youtube.com/embed/_rYvrxGpBQc?start=120"></iframe>'),
+      ).toContain('start=120')
+      expect(
+        sanitizeHtml('<iframe src="https://player.vimeo.com/video/12345?h=abc123"></iframe>'),
+      ).toContain('h=abc123')
+    })
+
+    it('drops the share-tracking token', () => {
+      const out = sanitizeHtml(
+        '<iframe src="https://www.youtube.com/embed/_rYvrxGpBQc?si=TRACKME"></iframe>',
+      )
+      expect(out).not.toContain('si=')
+    })
+
     it('sizes the frame by the authored aspect ratio instead of its pixel height', () => {
       expect(sanitizeHtml(REAL_YOUTUBE_IFRAME)).toContain('aspect-ratio:1062 / 597')
       expect(sanitizeHtml(REAL_FACEBOOK_IFRAME)).toContain('aspect-ratio:267 / 476')

--- a/__tests__/server/sanitizeHtml.server.test.ts
+++ b/__tests__/server/sanitizeHtml.server.test.ts
@@ -1,5 +1,20 @@
 import { sanitizeHtml } from '@/components/forecast/sanitizeHtml'
 
+// Verbatim markup from the live NAC v2 API, so the cases below stay honest about what forecasters
+// actually author. Sources: TAC 181191 (YouTube), IPAC 98592 (Facebook), SNFAC 109444 (video
+// figure), BTAC 184960 (image figure).
+const REAL_YOUTUBE_IFRAME =
+  '<p><iframe title="Reactive Slab on top of a shallow weak faceted snowpack" src="https://www.youtube.com/embed/_rYvrxGpBQc" width="1062" height="597" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="allowfullscreen"></iframe></p>'
+
+const REAL_FACEBOOK_IFRAME =
+  '<p><iframe src="https://www.facebook.com/plugins/video.php?height=476&amp;href=https%3A%2F%2Fwww.facebook.com%2Ffriendsofipac%2Fvideos%2F231581138660558%2F&amp;show_text=false&amp;width=267" width="267" height="476" frameborder="0" allowfullscreen="true" scrolling="no"></iframe></p>'
+
+const REAL_VIDEO_FIGURE =
+  '<figure class="image afp-video-modal" style="text-align: center;">\n<div class="afp-image-container afp-video-container"><img style="width: 700px; height: auto;" src="https://avalanche-org-media.s3.us-west-2.amazonaws.com/p0torRf9boA_623df057e590f.jpg" alt="" data-video-id="p0torRf9boA" /></div>\n<figcaption>(3/25/2022) Join Ethan for a spin through the week&rsquo;s warm weather.</figcaption>\n</figure>'
+
+const REAL_IMAGE_FIGURE =
+  '<figure class="image afp-photoswipe">\n<div class="afp-image-container"><img style="width: 1228px; height: 444px;" src="https://avalanche-org-media.s3.us-west-2.amazonaws.com/Early%20April%20Snowfall%20Graph_69dfc5b63e53b-large.png" alt=""></div>\n<figcaption>4/2 - 4/15 Snowfall totals by day from Raymer Bowl at JHMR</figcaption>\n</figure>'
+
 describe('sanitizeHtml', () => {
   it('opens external (other-domain) links in a new tab with a safe rel', () => {
     const out = sanitizeHtml('<p>See <a href="https://nwac.us/foo">NWAC</a></p>')
@@ -23,5 +38,124 @@ describe('sanitizeHtml', () => {
     expect(out).not.toContain('<script')
     expect(out).toContain('<strong>text</strong>')
     expect(out).toContain('Safe')
+  })
+
+  it('strips forms', () => {
+    const out = sanitizeHtml('<form action="/x"><input name="a"></form><p>Safe</p>')
+    expect(out).not.toContain('<form')
+    expect(out).not.toContain('<input')
+    expect(out).toContain('<p>Safe</p>')
+  })
+
+  describe('embedded video', () => {
+    it('keeps a forecaster-embedded YouTube iframe', () => {
+      const out = sanitizeHtml(REAL_YOUTUBE_IFRAME)
+      expect(out).toContain('<iframe')
+      expect(out).toContain('/embed/_rYvrxGpBQc')
+      expect(out).toContain('allowfullscreen')
+      expect(out).toContain('title="Reactive Slab on top of a shallow weak faceted snowpack"')
+    })
+
+    it('keeps a forecaster-embedded Facebook video plugin', () => {
+      const out = sanitizeHtml(REAL_FACEBOOK_IFRAME)
+      expect(out).toContain('<iframe')
+      expect(out).toContain('https://www.facebook.com/plugins/video.php')
+    })
+
+    it('keeps a Vimeo player embed', () => {
+      const out = sanitizeHtml(
+        '<p><iframe src="https://player.vimeo.com/video/12345"></iframe></p>',
+      )
+      expect(out).toContain('src="https://player.vimeo.com/video/12345"')
+    })
+
+    it('sizes the frame by the authored aspect ratio instead of its pixel height', () => {
+      expect(sanitizeHtml(REAL_YOUTUBE_IFRAME)).toContain('aspect-ratio:1062 / 597')
+      expect(sanitizeHtml(REAL_FACEBOOK_IFRAME)).toContain('aspect-ratio:267 / 476')
+    })
+
+    it('falls back to 16:9 when the authored dimensions are not pixel values', () => {
+      const out = sanitizeHtml(
+        '<iframe src="https://www.youtube.com/embed/_rYvrxGpBQc" width="100%"></iframe>',
+      )
+      expect(out).toContain('aspect-ratio:16 / 9')
+    })
+
+    it('drops the authored allow/frameborder/scrolling in favor of a fixed policy', () => {
+      const out = sanitizeHtml(REAL_FACEBOOK_IFRAME)
+      expect(out).not.toContain('frameborder')
+      expect(out).not.toContain('scrolling')
+      expect(out).toContain('allow="accelerometer; autoplay;')
+    })
+
+    it('does not frame facebook.com outside its embed plugins', () => {
+      const out = sanitizeHtml('<p><iframe src="https://www.facebook.com/login.php"></iframe></p>')
+      expect(out).not.toContain('<iframe')
+    })
+
+    it('does not frame the Facebook social widgets, only its content embeds', () => {
+      const out = sanitizeHtml(
+        '<p><iframe src="https://www.facebook.com/plugins/like.php?href=x"></iframe></p>',
+      )
+      expect(out).not.toContain('<iframe')
+    })
+
+    it('does not frame an http Facebook embed, which would be blocked as mixed content', () => {
+      const out = sanitizeHtml(
+        '<p><iframe src="http://www.facebook.com/plugins/video.php?href=x"></iframe></p>',
+      )
+      expect(out).not.toContain('<iframe')
+    })
+
+    it('does not frame an unrecognized provider, but names it and leaves a link', () => {
+      const out = sanitizeHtml('<p><iframe src="https://vendor.example.com/embed/1"></iframe></p>')
+      expect(out).not.toContain('<iframe')
+      expect(out).toContain('href="https://vendor.example.com/embed/1"')
+      expect(out).toContain('Open embedded content from vendor.example.com')
+      expect(out).toContain('rel="noopener noreferrer"')
+    })
+
+    it('replaces a blocked embed’s fallback content rather than leaking it', () => {
+      const out = sanitizeHtml(
+        '<p><iframe src="javascript:alert(1)">Your browser cannot play this</iframe></p>',
+      )
+      expect(out).toBe('<p></p>')
+    })
+
+    it('drops an iframe with no linkable src', () => {
+      expect(sanitizeHtml('<p><iframe src="javascript:alert(1)"></iframe></p>')).toBe('<p></p>')
+      expect(sanitizeHtml('<p><iframe src="/local/thing"></iframe></p>')).toBe('<p></p>')
+      expect(sanitizeHtml('<p><iframe></iframe></p>')).toBe('<p></p>')
+    })
+
+    it('does not treat a bare 11-character src as a YouTube id', () => {
+      expect(sanitizeHtml('<p><iframe src="abcdefghijk"></iframe></p>')).toBe('<p></p>')
+    })
+  })
+
+  describe('embedded images', () => {
+    it('keeps the video id the embedded-media collector reads', () => {
+      const out = sanitizeHtml(REAL_VIDEO_FIGURE)
+      expect(out).toContain('data-video-id="p0torRf9boA"')
+      expect(out).toContain('class="image afp-video-modal"')
+      expect(out).toContain('class="afp-image-container afp-video-container"')
+      expect(out).toContain('<figcaption>')
+    })
+
+    it('drops the authored pixel height so a clamped image keeps its aspect ratio', () => {
+      const out = sanitizeHtml(REAL_IMAGE_FIGURE)
+      expect(out).toContain('width:1228px')
+      expect(out).not.toContain('height:444px')
+    })
+
+    it('leaves other inline styles, including ones that merely end in "height"', () => {
+      const out = sanitizeHtml('<img src="/a.png" style="line-height: 2; max-height: 10px">')
+      expect(out).toContain('line-height:2')
+      expect(out).toContain('max-height:10px')
+    })
+
+    it('drops the style attribute entirely when height was all it carried', () => {
+      expect(sanitizeHtml('<img src="/a.png" style="height: 40px">')).not.toContain('style')
+    })
   })
 })

--- a/__tests__/server/sanitizeHtml.server.test.ts
+++ b/__tests__/server/sanitizeHtml.server.test.ts
@@ -79,6 +79,15 @@ describe('sanitizeHtml', () => {
       expect(out).toContain('list=PLabcdefghij')
     })
 
+    it('keeps a channel live stream pointed at its channel', () => {
+      // `live_stream` is 11 characters too, so it passes for a video id the same way.
+      const out = sanitizeHtml(
+        '<iframe src="https://www.youtube.com/embed/live_stream?channel=UCPQi3sYr7EA0276Q3vBBhIA"></iframe>',
+      )
+      expect(out).toContain('/embed/live_stream')
+      expect(out).toContain('channel=UCPQi3sYr7EA0276Q3vBBhIA')
+    })
+
     it('keeps a start offset and a Vimeo private-video hash', () => {
       expect(
         sanitizeHtml('<iframe src="https://www.youtube.com/embed/_rYvrxGpBQc?start=120"></iframe>'),

--- a/__tests__/server/sanitizeHtml.server.test.ts
+++ b/__tests__/server/sanitizeHtml.server.test.ts
@@ -133,25 +133,41 @@ describe('sanitizeHtml', () => {
       expect(out).not.toContain('<iframe')
     })
 
-    it('does not frame an unrecognized provider, but names it and leaves a link', () => {
+    it('does not frame an unrecognized provider, but says so and names it', () => {
       const out = sanitizeHtml('<p><iframe src="https://vendor.example.com/embed/1"></iframe></p>')
-      expect(out).not.toContain('<iframe')
-      expect(out).toContain('href="https://vendor.example.com/embed/1"')
-      expect(out).toContain('Open embedded content from vendor.example.com')
-      expect(out).toContain('rel="noopener noreferrer"')
-    })
-
-    it('replaces a blocked embed’s fallback content rather than leaking it', () => {
-      const out = sanitizeHtml(
-        '<p><iframe src="javascript:alert(1)">Your browser cannot play this</iframe></p>',
+      expect(out).toBe(
+        '<p>[Embedded content from vendor.example.com could not be displayed here]</p>',
       )
-      expect(out).toBe('<p></p>')
     })
 
-    it('drops an iframe with no linkable src', () => {
-      expect(sanitizeHtml('<p><iframe src="javascript:alert(1)"></iframe></p>')).toBe('<p></p>')
+    it('does not turn a rejected embed URL into a link', () => {
+      const out = sanitizeHtml('<p><iframe src="https://vendor.example.com/embed/1"></iframe></p>')
+      expect(out).not.toContain('<a')
+      expect(out).not.toContain('href')
+    })
+
+    it('discards a blocked embed’s fallback markup instead of parsing it as content', () => {
+      // A browser never renders an iframe's children, but the parser reads them as live markup —
+      // so without this they would smuggle a figure the legacy widget would never have shown.
+      const smuggled =
+        '<p><iframe src="https://evil.example/e"><figure class="image afp-photoswipe"><div class="afp-image-container"><img src="https://attacker.example/a.jpg" data-video-id="dQw4w9WgXcQ"></div><figcaption>FAKE FORECAST UPDATE</figcaption></figure></iframe></p>'
+      const out = sanitizeHtml(smuggled)
+      expect(out).not.toContain('afp-photoswipe')
+      expect(out).not.toContain('attacker.example')
+      expect(out).not.toContain('FAKE FORECAST UPDATE')
+    })
+
+    it('drops an iframe with nothing identifiable to name', () => {
+      expect(
+        sanitizeHtml('<p><iframe src="javascript:alert(1)">Cannot play this</iframe></p>'),
+      ).toBe('<p></p>')
       expect(sanitizeHtml('<p><iframe src="/local/thing"></iframe></p>')).toBe('<p></p>')
       expect(sanitizeHtml('<p><iframe></iframe></p>')).toBe('<p></p>')
+    })
+
+    it('still drops script contents, which nonTextTags also governs', () => {
+      expect(sanitizeHtml('<script>alert(1)</script><p>Safe</p>')).toBe('<p>Safe</p>')
+      expect(sanitizeHtml('<style>body{}</style><p>Safe</p>')).toBe('<p>Safe</p>')
     })
 
     it('does not treat a bare 11-character src as a YouTube id', () => {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -141,3 +141,5 @@ Unit tests use Jest with a dual-environment setup:
 pnpm test           # Run all unit tests
 pnpm test:watch     # Run in watch mode
 ```
+
+Client tests load `__tests__/client-setup.ts` first, which stubs the browser APIs jsdom does not implement — `ResizeObserver`, `IntersectionObserver` and `matchMedia`. Carousels and zoomable images construct these on mount, so without the stubs a component test fails on the environment rather than on the component. The file sits directly under `__tests__/` rather than in `client/`, so `testMatch` doesn't collect it as a suite. Add anything else jsdom is missing there instead of re-stubbing it per file.

--- a/drift.lock
+++ b/drift.lock
@@ -88,7 +88,7 @@ sig = "d292e1dfe3736640"
 [[bindings]]
 doc = "CLAUDE.md"
 target = "docs/testing.md"
-sig = "c407c9e6ba1aa9cb"
+sig = "0edd179b4400260a"
 
 [[bindings]]
 doc = "CLAUDE.md"
@@ -183,7 +183,7 @@ sig = "b4cdca0cf4f354b1"
 [[bindings]]
 doc = "docs/coding-guide.md"
 target = "jest.config.mjs"
-sig = "b1d9736649cf9b6a"
+sig = "93856d4c3ca3e5cd"
 
 [[bindings]]
 doc = "docs/coding-guide.md"
@@ -653,7 +653,7 @@ sig = "9273f68aefc8cf17"
 [[bindings]]
 doc = "docs/testing.md"
 target = "jest.config.mjs"
-sig = "b1d9736649cf9b6a"
+sig = "93856d4c3ca3e5cd"
 
 [[bindings]]
 doc = "docs/troubleshooting.md"

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -29,6 +29,8 @@ const clientTestConfig = {
   displayName: 'client',
   testEnvironment: 'jsdom',
   clearMocks: true,
+  // Sits beside the suites rather than inside client/, so testMatch doesn't collect it as one.
+  setupFilesAfterEnv: ['<rootDir>/__tests__/client-setup.ts'],
   testMatch: ['**/__tests__/client/**/*.[jt]s?(x)'],
   testPathIgnorePatterns: ignoredPaths,
 }

--- a/src/components/forecast/AvalancheProblemCard.tsx
+++ b/src/components/forecast/AvalancheProblemCard.tsx
@@ -8,10 +8,13 @@ import {
   AvalancheProblemName,
   MediaType,
   type AvalancheProblem,
+  type MediaItem,
 } from '@/services/nac/model/forecast'
 
 import { LocatorRose } from './LocatorRose'
+import { ProblemMediaFigure } from './ProblemMediaFigure'
 import { LikelihoodSlider, SizeSlider } from './ProblemSlider'
+import { getCaption, getPosterUrl } from './mediaItem'
 import { sanitizeHtml } from './sanitizeHtml'
 
 /** Maps problem names to local icon filenames at /images/problem-icons/{name}.png */
@@ -33,19 +36,25 @@ function problemIconUrl(name: AvalancheProblemName): string {
 }
 
 /**
- * The example photo (src + optional HTML caption) for a problem's media item, or null if not
- * displayable. Uses the medium image size to fill the inline figure; handles image and photo.
+ * The example media for a problem — the still to show inline, plus what it opens as — or null if
+ * there is nothing displayable.
+ *
+ * Video counts. The AFP stores a problem video as a YouTube id with a poster frame, and the legacy
+ * widget shows that poster with a play glyph over it; returning null here, as this used to, meant
+ * a forecaster's clip vanished from the page entirely.
  */
-function problemPhoto(
+function problemMedia(
   media: AvalancheProblem['media'],
-): { src: string; caption: string | null } | null {
-  if (media.type === MediaType.Image) {
-    return { src: media.url.medium, caption: media.caption }
+): { item: MediaItem; posterSrc: string; caption: string | null; isVideo: boolean } | null {
+  const posterSrc = getPosterUrl(media)
+  if (!posterSrc) return null
+
+  return {
+    item: media,
+    posterSrc,
+    caption: getCaption(media),
+    isVideo: media.type === MediaType.Video,
   }
-  if (media.type === MediaType.Photo) {
-    return typeof media.url === 'string' ? { src: media.url, caption: media.caption } : null
-  }
-  return null
 }
 
 interface AvalancheProblemCardProps {
@@ -53,7 +62,7 @@ interface AvalancheProblemCardProps {
 }
 
 export function AvalancheProblemCard({ problem }: AvalancheProblemCardProps) {
-  const photo = problemPhoto(problem.media)
+  const media = problemMedia(problem.media)
 
   return (
     <Card>
@@ -65,8 +74,8 @@ export function AvalancheProblemCard({ problem }: AvalancheProblemCardProps) {
       <CardContent className="space-y-4">
         <ProblemAttributes problem={problem} />
 
-        {(photo || problem.discussion) && (
-          <ProblemDiscussion photo={photo} discussion={problem.discussion} />
+        {(media || problem.discussion) && (
+          <ProblemDiscussion media={media} discussion={problem.discussion} />
         )}
       </CardContent>
     </Card>
@@ -103,19 +112,26 @@ function ProblemAttributes({ problem }: { problem: AvalancheProblem }) {
 }
 
 /**
- * The discussion with the example photo floated inline to its right (wraps on md+);
- * overflow-hidden contains the float within the card.
+ * The discussion with the example media floated inline to its right (wraps on md+);
+ * overflow-hidden contains the float within the card. Sanitizing stays here on the server.
  */
 function ProblemDiscussion({
-  photo,
+  media,
   discussion,
 }: {
-  photo: { src: string; caption: string | null } | null
+  media: ReturnType<typeof problemMedia>
   discussion: string | null
 }) {
   return (
     <div className="overflow-hidden">
-      {photo && <ProblemPhoto photo={photo} />}
+      {media && (
+        <ProblemMediaFigure
+          item={media.item}
+          posterSrc={media.posterSrc}
+          captionHtml={media.caption ? sanitizeHtml(media.caption) : null}
+          isVideo={media.isVideo}
+        />
+      )}
       {discussion && (
         <div
           className="prose prose-sm max-w-none dark:prose-invert"
@@ -123,20 +139,5 @@ function ProblemDiscussion({
         />
       )}
     </div>
-  )
-}
-
-function ProblemPhoto({ photo }: { photo: { src: string; caption: string | null } }) {
-  return (
-    <figure className="mb-3 md:float-right md:mb-2 md:ml-6 md:w-1/2 lg:w-1/3">
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src={photo.src} alt="" className="w-full rounded-md" />
-      {photo.caption && (
-        <figcaption
-          className="pt-2 text-center text-sm italic text-muted-foreground"
-          dangerouslySetInnerHTML={{ __html: sanitizeHtml(photo.caption) }}
-        />
-      )}
-    </figure>
   )
 }

--- a/src/components/forecast/DiscussionBody.tsx
+++ b/src/components/forecast/DiscussionBody.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import { Expand, Play } from 'lucide-react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+import { MediaLightbox } from './MediaLightbox'
+import { collectEmbeddedMedia, type EmbeddedMedia } from './embeddedMedia'
+
+/** Marks a figure with its position in the lightbox, so a delegated click can resolve the index. */
+const MEDIA_INDEX_ATTR = 'data-embedded-media-index'
+
+interface DiscussionBodyProps {
+  /** Already-sanitized forecast HTML. Sanitizing stays on the server. */
+  html: string
+}
+
+/**
+ * Authored forecast HTML, with any media the forecaster embedded in it made openable.
+ *
+ * The HTML is rendered in one piece, exactly as it arrives, so server rendering and the no-JS
+ * rendering are unchanged. After mount the embedded figures are found in the DOM and given the
+ * legacy widget's affordances — an expand chip, and a play button on videos — and activating one
+ * opens the shared lightbox at that figure. With nothing embedded this is a plain
+ * `dangerouslySetInnerHTML` and costs nothing.
+ */
+export function DiscussionBody({ html }: DiscussionBodyProps) {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const [media, setMedia] = useState<EmbeddedMedia[]>([])
+  const [lightboxIndex, setLightboxIndex] = useState(0)
+  const [lightboxOpen, setLightboxOpen] = useState(false)
+
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+
+    // Forecast HTML is authored by hand and arrives from outside; a surprise in one figure must
+    // not take the discussion down with it, so the prose still renders and just isn't interactive.
+    let found: EmbeddedMedia[] = []
+    try {
+      found = collectEmbeddedMedia(root)
+    } catch {
+      return
+    }
+
+    found.forEach(({ figure, iconTarget }, index) => {
+      figure.setAttribute(MEDIA_INDEX_ATTR, String(index))
+      // The overlay is portaled into this container and positioned against it, which is where the
+      // legacy widget drew its icons.
+      iconTarget.classList.add('relative', 'cursor-zoom-in')
+    })
+    setMedia(found)
+  }, [html])
+
+  const openAt = useCallback((index: number) => {
+    setLightboxIndex(index)
+    setLightboxOpen(true)
+  }, [])
+
+  // Clicking anywhere on a figure opens it, as in the legacy widget — except on a link, which
+  // should navigate instead.
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      const { target } = event
+      if (!(target instanceof Element) || target.closest('a')) return
+
+      const figure = target.closest(`[${MEDIA_INDEX_ATTR}]`)
+      if (!figure) return
+
+      const index = Number(figure.getAttribute(MEDIA_INDEX_ATTR))
+      if (Number.isInteger(index)) openAt(index)
+    },
+    [openAt],
+  )
+
+  return (
+    <>
+      {/* Delegation lives out here: the figures come from innerHTML, so there is nowhere inside to
+          hang a handler, and keeping the handler off AuthoredHtml keeps that subtree from
+          re-rendering. */}
+      <div onClick={handleClick}>
+        <AuthoredHtml html={html} containerRef={rootRef} />
+      </div>
+
+      {media.map((item, index) =>
+        createPortal(
+          <EmbeddedMediaOverlay item={item} onOpen={() => openAt(index)} />,
+          item.iconTarget,
+          String(index),
+        ),
+      )}
+
+      <MediaLightbox
+        media={media.map((entry) => entry.item)}
+        initialIndex={lightboxIndex}
+        open={lightboxOpen}
+        onOpenChange={setLightboxOpen}
+      />
+    </>
+  )
+}
+
+/**
+ * The authored HTML, isolated behind `memo` so it is written to the DOM once per distinct string.
+ *
+ * React compares the `dangerouslySetInnerHTML` wrapper by identity, so re-rendering this element
+ * for any reason — opening the lightbox, say — replaces the whole subtree, detaching the figures
+ * that were collected from it and stranding their overlays in orphaned nodes. Keeping it out of the
+ * parent's update path is what makes those DOM references safe to hold.
+ */
+const AuthoredHtml = memo(function AuthoredHtml({
+  html,
+  containerRef,
+}: {
+  html: string
+  containerRef: React.RefObject<HTMLDivElement | null>
+}) {
+  return (
+    <div
+      ref={containerRef}
+      className="prose prose-sm max-w-none dark:prose-invert"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+})
+
+/**
+ * The affordances the legacy widget drew over an embedded figure: an expand chip in the bottom-left
+ * corner, and a play button centered on a video.
+ *
+ * Only the chip is a real button. That is what makes the figure reachable by keyboard — the legacy
+ * widget was click-only — while leaving the rest of the poster untouched, so right-clicking an image
+ * still opens the image's own context menu. The legacy icons were `pointer-events: none` for the
+ * same reason; mouse users reach the lightbox by clicking the figure, which the wrapper handles.
+ */
+function EmbeddedMediaOverlay({ item, onOpen }: { item: EmbeddedMedia; onOpen: () => void }) {
+  return (
+    <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
+      {item.isVideo && (
+        <span className="flex h-14 w-14 items-center justify-center rounded-full bg-black/60">
+          <Play className="h-7 w-7 fill-white text-white" />
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={item.isVideo ? 'Play embedded video' : 'Expand embedded image'}
+        className="pointer-events-auto absolute bottom-1 left-1 rounded bg-white/70 p-1 text-gray-800 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Expand className="h-4 w-4" />
+      </button>
+    </span>
+  )
+}

--- a/src/components/forecast/DiscussionBody.tsx
+++ b/src/components/forecast/DiscussionBody.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { Expand, Play } from 'lucide-react'
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 import { MediaLightbox } from './MediaLightbox'
+import { MediaOverlay } from './MediaOverlay'
 import { collectEmbeddedMedia, type EmbeddedMedia } from './embeddedMedia'
 
 /** Marks a figure with its position in the lightbox, so a delegated click can resolve the index. */
@@ -84,7 +84,7 @@ export function DiscussionBody({ html }: DiscussionBodyProps) {
 
       {media.map((item, index) =>
         createPortal(
-          <EmbeddedMediaOverlay item={item} onOpen={() => openAt(index)} />,
+          <MediaOverlay isVideo={item.isVideo} onOpen={() => openAt(index)} />,
           item.iconTarget,
           String(index),
         ),
@@ -123,32 +123,3 @@ const AuthoredHtml = memo(function AuthoredHtml({
     />
   )
 })
-
-/**
- * The affordances the legacy widget drew over an embedded figure: an expand chip in the bottom-left
- * corner, and a play button centered on a video.
- *
- * Only the chip is a real button. That is what makes the figure reachable by keyboard — the legacy
- * widget was click-only — while leaving the rest of the poster untouched, so right-clicking an image
- * still opens the image's own context menu. The legacy icons were `pointer-events: none` for the
- * same reason; mouse users reach the lightbox by clicking the figure, which the wrapper handles.
- */
-function EmbeddedMediaOverlay({ item, onOpen }: { item: EmbeddedMedia; onOpen: () => void }) {
-  return (
-    <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
-      {item.isVideo && (
-        <span className="flex h-14 w-14 items-center justify-center rounded-full bg-black/60">
-          <Play className="h-7 w-7 fill-white text-white" />
-        </span>
-      )}
-      <button
-        type="button"
-        onClick={onOpen}
-        aria-label={item.isVideo ? 'Play embedded video' : 'Expand embedded image'}
-        className="pointer-events-auto absolute bottom-1 left-1 rounded bg-white/70 p-1 text-gray-800 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      >
-        <Expand className="h-4 w-4" />
-      </button>
-    </span>
-  )
-}

--- a/src/components/forecast/ForecastDiscussion.tsx
+++ b/src/components/forecast/ForecastDiscussion.tsx
@@ -3,6 +3,7 @@
  */
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
+import { DiscussionBody } from './DiscussionBody'
 import { sanitizeHtml } from './sanitizeHtml'
 
 interface ForecastDiscussionProps {
@@ -16,10 +17,8 @@ export function ForecastDiscussion({ html }: ForecastDiscussionProps) {
         <CardTitle>Forecast Discussion</CardTitle>
       </CardHeader>
       <CardContent>
-        <div
-          className="prose prose-sm max-w-none dark:prose-invert"
-          dangerouslySetInnerHTML={{ __html: sanitizeHtml(html) }}
-        />
+        {/* Sanitizing stays on the server; the body only renders it and wires up embedded media. */}
+        <DiscussionBody html={sanitizeHtml(html)} />
       </CardContent>
     </Card>
   )

--- a/src/components/forecast/MediaOverlay.tsx
+++ b/src/components/forecast/MediaOverlay.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Expand, Play } from 'lucide-react'
+
+/**
+ * The affordances the legacy widget drew over an openable image: an expand chip in the bottom-left
+ * corner, and a play button centered on a video.
+ *
+ * Only the chip is a real button. That is what makes the media reachable by keyboard — the legacy
+ * widget was click-only — while leaving the rest of the image untouched, so right-clicking it still
+ * opens the image's own context menu. The legacy icons were `pointer-events: none` for the same
+ * reason; mouse users open the lightbox by clicking the figure.
+ *
+ * The parent must be positioned, and is expected to carry `cursor-zoom-in`.
+ */
+export function MediaOverlay({ isVideo, onOpen }: { isVideo: boolean; onOpen: () => void }) {
+  return (
+    <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
+      {isVideo && (
+        <span className="flex h-14 w-14 items-center justify-center rounded-full bg-black/60">
+          <Play className="h-7 w-7 fill-white text-white" />
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={isVideo ? 'Play embedded video' : 'Expand embedded image'}
+        className="pointer-events-auto absolute bottom-1 left-1 rounded bg-white/70 p-1 text-gray-800 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Expand className="h-4 w-4" />
+      </button>
+    </span>
+  )
+}

--- a/src/components/forecast/MediaSlide.tsx
+++ b/src/components/forecast/MediaSlide.tsx
@@ -1,4 +1,5 @@
 import { type MediaItem } from '@/services/nac/model/forecast'
+import { getVideoEmbedUrl } from '@/utilities/videoEmbed'
 
 import { ZoomablePhoto } from './ZoomablePhoto'
 import { resolveMediaSlide } from './mediaItem'
@@ -13,7 +14,9 @@ export function MediaSlide({ item }: { item: MediaItem }) {
       return (
         <div className="aspect-video w-full">
           <iframe
-            src={`https://www.youtube.com/embed/${encodeURIComponent(slide.videoId)}`}
+            // Built by the shared helper so a video embedded in the discussion frames the same way
+            // inline and in the lightbox.
+            src={getVideoEmbedUrl({ provider: 'youtube', id: encodeURIComponent(slide.videoId) })}
             className="h-full w-full rounded"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen

--- a/src/components/forecast/ProblemMediaFigure.tsx
+++ b/src/components/forecast/ProblemMediaFigure.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useState } from 'react'
+
+import { type MediaItem } from '@/services/nac/model/forecast'
+
+import { MediaLightbox } from './MediaLightbox'
+import { MediaOverlay } from './MediaOverlay'
+
+interface ProblemMediaFigureProps {
+  item: MediaItem
+  /** The still to show inline — the image itself, or a video's poster frame. */
+  posterSrc: string
+  /** Already-sanitized caption HTML, or null. */
+  captionHtml: string | null
+  isVideo: boolean
+}
+
+/**
+ * A problem's example media, floated beside the discussion and openable in the lightbox.
+ *
+ * The legacy widget renders this through its shared `Thumbnail`, which puts a red YouTube glyph
+ * over a video and an expand icon on everything, and opens the product-wide lightbox on click. A
+ * video used to render as nothing here, so a forecaster's clip attached to an avalanche problem
+ * disappeared without a trace.
+ */
+export function ProblemMediaFigure({
+  item,
+  posterSrc,
+  captionHtml,
+  isVideo,
+}: ProblemMediaFigureProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <figure className="mb-3 md:float-right md:mb-2 md:ml-6 md:w-1/2 lg:w-1/3">
+        {/* Clicking the image opens the lightbox, as in the legacy widget. The overlay's button is
+            what carries the keyboard affordance and the accessible name. */}
+        <div className="relative cursor-zoom-in" onClick={() => setOpen(true)}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={posterSrc} alt="" className="w-full rounded-md" />
+          <MediaOverlay isVideo={isVideo} onOpen={() => setOpen(true)} />
+        </div>
+        {captionHtml && (
+          <figcaption
+            className="pt-2 text-center text-sm italic text-muted-foreground"
+            dangerouslySetInnerHTML={{ __html: captionHtml }}
+          />
+        )}
+      </figure>
+
+      <MediaLightbox media={[item]} initialIndex={0} open={open} onOpenChange={setOpen} />
+    </>
+  )
+}

--- a/src/components/forecast/embeddedMedia.ts
+++ b/src/components/forecast/embeddedMedia.ts
@@ -20,7 +20,7 @@
  */
 import { MediaType, type MediaItem } from '@/services/nac/model/forecast'
 
-export const EMBEDDED_MEDIA_SELECTOR =
+const EMBEDDED_MEDIA_SELECTOR =
   '.afp-photoswipe, .nac-photoswipe, .afp-video-modal, .nac-video-modal'
 
 export interface EmbeddedMedia {

--- a/src/components/forecast/embeddedMedia.ts
+++ b/src/components/forecast/embeddedMedia.ts
@@ -1,0 +1,74 @@
+/**
+ * Media a forecaster embedded inside authored forecast HTML.
+ *
+ * The AFP editors wrap an embedded photo or video in a `figure` whose class marks it as
+ * lightbox-able, with the poster image inside and a `figcaption` alongside:
+ *
+ *     <figure class="image afp-photoswipe">
+ *       <div class="afp-image-container"><img src="…-large.jpg" alt=""></div>
+ *       <figcaption>…</figcaption>
+ *     </figure>
+ *
+ * A video is the same shape with `afp-video-modal` on the figure, `afp-video-container` added to the
+ * inner div, and the YouTube id on the image as `data-video-id`. The `nac-` class variants come from
+ * the older WordPress theme editor; the legacy widget matches both, so we do too.
+ *
+ * Collection reads the rendered DOM rather than the HTML string on purpose. These figures are not
+ * reliably top-level: one center wraps its whole discussion in a `div`, others float a figure inside
+ * a wrapper, and the editor has been known to leave a figure inside another figure's `figcaption`.
+ * A tree walk is indifferent to all of that; string splitting is not.
+ */
+import { MediaType, type MediaItem } from '@/services/nac/model/forecast'
+
+export const EMBEDDED_MEDIA_SELECTOR =
+  '.afp-photoswipe, .nac-photoswipe, .afp-video-modal, .nac-video-modal'
+
+export interface EmbeddedMedia {
+  /** The `figure` itself — the whole thing is the click target, as in the legacy widget. */
+  figure: HTMLElement
+  /** The inner container the legacy widget hangs the expand/play affordance off. */
+  iconTarget: HTMLElement
+  item: MediaItem
+  isVideo: boolean
+}
+
+/**
+ * Every embedded media figure under `root`, in document order.
+ *
+ * The item is built the way the legacy widget builds it: the first image's `src` stands in for all
+ * four url sizes, and the first `figcaption`'s inner HTML is the caption. A figure with no image has
+ * nothing to open, so it is skipped and left to render as authored.
+ */
+export function collectEmbeddedMedia(root: HTMLElement): EmbeddedMedia[] {
+  const collected: EmbeddedMedia[] = []
+
+  for (const figure of root.querySelectorAll(EMBEDDED_MEDIA_SELECTOR)) {
+    if (!(figure instanceof HTMLElement)) continue
+
+    const image = figure.querySelector('img')
+    const src = image?.getAttribute('src')
+    if (!image || !src) continue
+
+    const caption = figure.querySelector('figcaption')?.innerHTML ?? null
+    const videoId = image.getAttribute('data-video-id')
+    const container = figure.querySelector('.afp-image-container, .afp-video-container')
+
+    collected.push({
+      figure,
+      iconTarget: container instanceof HTMLElement ? container : figure,
+      item: mediaItem(src, caption, videoId),
+      isVideo: !!videoId,
+    })
+  }
+
+  return collected
+}
+
+function mediaItem(src: string, caption: string | null, videoId: string | null): MediaItem {
+  const sizes = { large: src, medium: src, original: src, thumbnail: src }
+
+  if (videoId) {
+    return { type: MediaType.Video, url: { ...sizes, video_id: videoId }, caption }
+  }
+  return { type: MediaType.Image, url: sizes, caption }
+}

--- a/src/components/forecast/mediaItem.ts
+++ b/src/components/forecast/mediaItem.ts
@@ -5,6 +5,7 @@
  * components then only render, and stay well under the complexity thresholds.
  */
 import { MediaType, type MediaItem } from '@/services/nac/model/forecast'
+import { getVideoThumbnail } from '@/utilities/videoEmbed'
 
 /** The small square shown in the thumbnail grid, or `null` if this item has no thumbnail. */
 export function getThumbnailUrl(item: MediaItem): string | null {
@@ -12,7 +13,23 @@ export function getThumbnailUrl(item: MediaItem): string | null {
   if (item.type === MediaType.Photo) return typeof item.url === 'string' ? item.url : null
   if (item.type === MediaType.Video) {
     if (typeof item.url === 'object' && 'thumbnail' in item.url) return item.url.thumbnail
-    return null
+    return youTubePoster(item)
+  }
+  return null
+}
+
+/**
+ * The mid-size still to show inline, or `null` if there isn't one.
+ *
+ * This is the size the widget asks for when it shows a problem's example media, and for a video it
+ * is the poster frame rather than the video itself.
+ */
+export function getPosterUrl(item: MediaItem): string | null {
+  if (item.type === MediaType.Image) return item.url.medium
+  if (item.type === MediaType.Photo) return typeof item.url === 'string' ? item.url : null
+  if (item.type === MediaType.Video) {
+    if (typeof item.url === 'object' && 'medium' in item.url) return item.url.medium
+    return youTubePoster(item)
   }
   return null
 }
@@ -24,11 +41,24 @@ export function getFullUrl(item: MediaItem): string | null {
   return null
 }
 
-/** Extract the YouTube `video_id` from a Video media item. */
+/**
+ * Extract the YouTube `video_id` from a Video media item.
+ *
+ * A video's `url` is usually an object carrying image sizes plus `video_id`, but the AFP also
+ * stores it as a bare string — and that string is the YouTube id, not a URL. The legacy widget
+ * reads both (`image.url?.video_id ? … : "…/embed/" + image.url`).
+ */
 export function getYouTubeVideoId(item: MediaItem): string | null {
   if (item.type !== MediaType.Video) return null
-  if (typeof item.url === 'object' && 'video_id' in item.url) return item.url.video_id
+  if (typeof item.url === 'string') return item.url || null
+  if ('video_id' in item.url) return item.url.video_id
   return null
+}
+
+/** YouTube's own poster frame, for a video item that carries no image sizes of its own. */
+function youTubePoster(item: MediaItem): string | null {
+  const id = getYouTubeVideoId(item)
+  return id ? getVideoThumbnail({ provider: 'youtube', id }) : null
 }
 
 export function getCaption(item: MediaItem): string | null {

--- a/src/components/forecast/sanitizeHtml.ts
+++ b/src/components/forecast/sanitizeHtml.ts
@@ -3,9 +3,12 @@
  *
  * Pure JS with no DOM dependency, so it runs in server components. (DOMPurify
  * would need jsdom on the server, which does not survive Next's server bundle.)
- * More restrictive than GenericEmbedBlock — no scripts, iframes, or forms.
+ * More restrictive than GenericEmbedBlock — no scripts or forms, and the only
+ * iframes that survive are video embeds from an explicit provider allowlist.
  */
-import sanitizeHtmlLib from 'sanitize-html'
+import sanitizeHtmlLib, { type Attributes, type Tag } from 'sanitize-html'
+
+import { getVideoEmbedUrl, parseVideoUrl } from '@/utilities/videoEmbed'
 
 const ALLOWED_TAGS = [
   'p',
@@ -35,14 +38,124 @@ const ALLOWED_TAGS = [
   'div',
   'sup',
   'sub',
+  'iframe',
 ]
 
 const ALLOWED_ATTR = ['href', 'src', 'alt', 'class', 'style']
 
-// Absolute (http/https) and protocol-relative URLs point off the AvyWeb tenant
-// site. All forecast HTML comes from the NAC API, so any absolute link is to
-// another domain; open those in a new tab. Relative links stay in the same tab.
+/**
+ * A tag name deliberately absent from ALLOWED_TAGS, and listed in `nonTextTags` below so its
+ * contents go with it. sanitize-html applies transformTags before checking the allowlist, so
+ * renaming an element to this is how an element gets removed outright — `allowedIframeHostnames`
+ * merely deletes the `src` and leaves an empty frame behind.
+ */
+const DROPPED = 'afp-blocked-embed'
+
+const FACEBOOK_EMBED_PATHS = ['/plugins/video.php', '/plugins/post.php']
+
+/** Absolute (http/https) and protocol-relative URLs point off the AvyWeb tenant
+ * site. All forecast HTML comes from the NAC API, so any absolute link is to
+ * another domain; open those in a new tab. Relative links stay in the same tab. */
 const isExternalUrl = (href: string | undefined): boolean => !!href && /^(https?:)?\/\//i.test(href)
+
+/** The parsed http(s) URL, or `null` if `value` is relative, unparseable or another scheme. */
+function httpUrl(value: string | undefined): URL | null {
+  if (!value) return null
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' || url.protocol === 'http:' ? url : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The embed URL to use for an authored iframe, or `null` if it isn't a recognized video embed.
+ *
+ * Forecasters paste these into the AFP dashboard's rich-text editor, and the legacy widget rendered
+ * whatever came back with `v-html`. The live API only contains YouTube `/embed/` frames and
+ * Facebook's video plugin; Vimeo comes along because it shares AvyWeb's video-URL parser. Anything
+ * else is not framed.
+ */
+function safeEmbedUrl(src: string | undefined): string | null {
+  const url = httpUrl(src)
+  // Relative or unparseable srcs are never embeddable provider URLs. (Bailing here also keeps
+  // parseVideoUrl's bare-video-id fallback from turning a relative src into a YouTube embed.)
+  if (!url) return null
+
+  const video = parseVideoUrl(url.toString())
+  if (video) return getVideoEmbedUrl(video)
+
+  // Facebook's content embeds. Named individually rather than allowing all of /plugins/*, which
+  // also serves interactive social widgets (like, comments, page) that nothing in the corpus uses.
+  // https only — an http frame is blocked as mixed content and renders as an empty box, which is
+  // the silent failure this allowlist exists to prevent.
+  if (url.protocol === 'https:' && url.hostname === 'www.facebook.com') {
+    if (FACEBOOK_EMBED_PATHS.includes(url.pathname)) return url.toString()
+  }
+
+  return null
+}
+
+/**
+ * What to render in place of an embed we won't frame.
+ *
+ * A link, not nothing: the reader can still reach what the forecaster meant to show, and the
+ * hostname is in the label so they can see where it goes before following it. Forecast HTML already
+ * carries authored links from the same source, so this grants the author no reach they didn't have.
+ * A src that isn't http(s) has nothing safe to link to, so it goes away entirely.
+ */
+function blockedEmbed(src: string | undefined): Tag {
+  const url = httpUrl(src)
+  if (!url || !src) return { tagName: DROPPED, attribs: {} }
+
+  return {
+    tagName: 'a',
+    attribs: { href: src, target: '_blank', rel: 'noopener noreferrer' },
+    text: `Open embedded content from ${url.hostname}`,
+  }
+}
+
+/** A positive integer from an authored width/height attribute, or `null` (e.g. `"100%"`). */
+function pixelDimension(value: string | undefined): number | null {
+  if (!value) return null
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+/**
+ * Size the frame by aspect ratio rather than by the authored pixel height.
+ *
+ * The authored dimensions are the forecaster's screen size (16:9 for YouTube, 267×476 for
+ * Facebook's portrait video plugin). Keeping the height as authored, which is what the legacy
+ * widget did, letterboxes or squashes the video once the column is narrower than that width.
+ */
+function embedSizing(width: string | undefined, height: string | undefined): string {
+  const w = pixelDimension(width)
+  const h = pixelDimension(height)
+  if (!w || !h) return 'aspect-ratio: 16 / 9; width: 100%; height: auto'
+  return `aspect-ratio: ${w} / ${h}; width: min(100%, ${w}px); height: auto`
+}
+
+// Matches a whole `height: …` declaration at the start of the style attribute or after a `;`.
+// The leading boundary is what keeps it off `max-height` and `line-height`.
+const INLINE_HEIGHT_DECLARATION = /(^|;)\s*height\s*:[^;]*/gi
+
+/**
+ * Drop any inline `height`, so a clamped image keeps its aspect ratio.
+ *
+ * Authored images carry `style="width: 1228px; height: 444px"`. The declared width is honored up to
+ * the column width, but a surviving pixel height then stretches the image. The legacy widget forced
+ * `height: auto !important` on every forecast image for the same reason.
+ */
+function withoutInlineHeight(style: string | undefined): string | undefined {
+  if (!style) return undefined
+  const stripped = style
+    .replace(INLINE_HEIGHT_DECLARATION, '$1')
+    .replace(/^;+|;+$/g, '')
+    .trim()
+  return stripped || undefined
+}
 
 export function sanitizeHtml(html: string): string {
   return sanitizeHtmlLib(html, {
@@ -50,12 +163,57 @@ export function sanitizeHtml(html: string): string {
     allowedAttributes: {
       '*': ALLOWED_ATTR,
       a: [...ALLOWED_ATTR, 'target', 'rel'],
+      // The AFP editor marks an embedded video by hanging the YouTube id off the poster image;
+      // the discussion's embedded-media collector reads it back out.
+      img: [...ALLOWED_ATTR, 'data-video-id'],
+      iframe: [
+        'src',
+        'title',
+        'class',
+        'style',
+        'allow',
+        'allowfullscreen',
+        'loading',
+        'referrerpolicy',
+      ],
     },
+    // Drop a blocked embed's fallback content along with the element. Without this, sanitize-html
+    // keeps the text of a discarded tag ("We want the contents but not this tag").
+    nonTextTags: ['script', 'style', 'textarea', 'option', 'noscript', DROPPED],
     transformTags: {
       a: (tagName, attribs) =>
         isExternalUrl(attribs.href)
           ? { tagName, attribs: { ...attribs, target: '_blank', rel: 'noopener noreferrer' } }
           : { tagName, attribs },
+
+      img: (tagName, attribs): Tag => {
+        const style = withoutInlineHeight(attribs.style)
+        const { style: _authoredStyle, ...rest }: Attributes = attribs
+        return { tagName, attribs: style ? { ...rest, style } : rest }
+      },
+
+      iframe: (tagName, attribs): Tag => {
+        const src = safeEmbedUrl(attribs.src)
+        if (!src) return blockedEmbed(attribs.src)
+
+        return {
+          tagName,
+          attribs: {
+            src,
+            title: attribs.title || 'Embedded video',
+            class: 'max-w-full border-0',
+            style: embedSizing(attribs.width, attribs.height),
+            // The set YouTube's own embed code asks for, and the same one the forecast lightbox
+            // and the Gallery block use. No `sandbox`: the src is one of a handful of vetted
+            // provider URLs, and a wrong sandbox flag fails as a blank frame.
+            allow:
+              'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
+            allowfullscreen: 'allowfullscreen',
+            referrerpolicy: 'strict-origin-when-cross-origin',
+            loading: 'lazy',
+          },
+        }
+      },
     },
   })
 }

--- a/src/components/forecast/sanitizeHtml.ts
+++ b/src/components/forecast/sanitizeHtml.ts
@@ -119,19 +119,24 @@ function withPreservedParams(embedUrl: string, authored: URL): string {
 /**
  * What to render in place of an embed we won't frame.
  *
- * A link, not nothing: the reader can still reach what the forecaster meant to show, and the
- * hostname is in the label so they can see where it goes before following it. Forecast HTML already
- * carries authored links from the same source, so this grants the author no reach they didn't have.
- * A src that isn't http(s) has nothing safe to link to, so it goes away entirely.
+ * A note naming the provider, so the reader can tell something was there — deleting a forecaster's
+ * content without a trace is the failure this allowlist exists to prevent. It is deliberately inert
+ * rather than a link: the URL just failed the allowlist, so it should not be one click away.
+ *
+ * The note rides on the dropped tag rather than on a real element. sanitize-html emits a
+ * transform's `text` even for a tag it discards, and because `DROPPED` is in `nonTextTags` the
+ * element's children are discarded with it. That matters: an `<iframe>`'s children are fallback
+ * content a browser never renders, but the parser reads them as live markup, so leaving them in
+ * would let authored HTML smuggle a figure past both the sanitizer and the widget's own behavior.
  */
 function blockedEmbed(src: string | undefined): Tag {
   const url = httpUrl(src)
-  if (!url || !src) return { tagName: DROPPED, attribs: {} }
+  if (!url) return { tagName: DROPPED, attribs: {} }
 
   return {
-    tagName: 'a',
-    attribs: { href: src, target: '_blank', rel: 'noopener noreferrer' },
-    text: `Open embedded content from ${url.hostname}`,
+    tagName: DROPPED,
+    attribs: {},
+    text: `[Embedded content from ${url.hostname} could not be displayed here]`,
   }
 }
 

--- a/src/components/forecast/sanitizeHtml.ts
+++ b/src/components/forecast/sanitizeHtml.ts
@@ -103,9 +103,10 @@ function safeEmbedUrl(src: string | undefined): string | null {
  * `getVideoEmbedUrl` reconstructs the URL from the video id alone. That is fine for a plain video,
  * but a YouTube playlist is `/embed/videoseries?list=…` — and `videoseries` is itself eleven
  * characters, so it passes for a video id and the rebuilt URL asks YouTube for a video by that
- * name. Same story, less visibly, for a start offset or a Vimeo private-video hash.
+ * name. A channel's live stream is `/embed/live_stream?channel=…`, eleven characters again, and
+ * fails the same way. Same story, less visibly, for a start offset or a Vimeo private-video hash.
  */
-const PRESERVED_EMBED_PARAMS = ['list', 'index', 'start', 'end', 't', 'h']
+const PRESERVED_EMBED_PARAMS = ['list', 'index', 'start', 'end', 't', 'h', 'channel']
 
 function withPreservedParams(embedUrl: string, authored: URL): string {
   const url = new URL(embedUrl)

--- a/src/components/forecast/sanitizeHtml.ts
+++ b/src/components/forecast/sanitizeHtml.ts
@@ -84,7 +84,7 @@ function safeEmbedUrl(src: string | undefined): string | null {
   if (!url) return null
 
   const video = parseVideoUrl(url.toString())
-  if (video) return getVideoEmbedUrl(video)
+  if (video) return withPreservedParams(getVideoEmbedUrl(video), url)
 
   // Facebook's content embeds. Named individually rather than allowing all of /plugins/*, which
   // also serves interactive social widgets (like, comments, page) that nothing in the corpus uses.
@@ -95,6 +95,25 @@ function safeEmbedUrl(src: string | undefined): string | null {
   }
 
   return null
+}
+
+/**
+ * Playback parameters carried from the authored URL onto the rebuilt embed URL.
+ *
+ * `getVideoEmbedUrl` reconstructs the URL from the video id alone. That is fine for a plain video,
+ * but a YouTube playlist is `/embed/videoseries?list=…` — and `videoseries` is itself eleven
+ * characters, so it passes for a video id and the rebuilt URL asks YouTube for a video by that
+ * name. Same story, less visibly, for a start offset or a Vimeo private-video hash.
+ */
+const PRESERVED_EMBED_PARAMS = ['list', 'index', 'start', 'end', 't', 'h']
+
+function withPreservedParams(embedUrl: string, authored: URL): string {
+  const url = new URL(embedUrl)
+  for (const name of PRESERVED_EMBED_PARAMS) {
+    const value = authored.searchParams.get(name)
+    if (value) url.searchParams.set(name, value)
+  }
+  return url.toString()
 }
 
 /**


### PR DESCRIPTION
## Description

Forecaster-authored HTML can embed media, and the native forecast page was dropping it: `sanitizeHtml` allowed `img` but not `iframe`, so a pasted YouTube or Facebook video was deleted with no trace, and the `data-video-id` marking an embedded-video figure went with it — leaving a poster indistinguishable from a photo. A video attached to an avalanche problem rendered as nothing at all, because `problemPhoto` returned `null` for `MediaType.Video`. This restores what the legacy widget does, on AvyWeb's design system.

I sampled 6,745 v2 products across all 29 centers' full history rather than guessing at the markup: 2,259 `afp-photoswipe` figures, 40 iframes (36 YouTube, 4 Facebook), 2 `afp-video-modal` figures, and — separately — 111 problem-level videos among the 1,836 problems that carry media, all of them YouTube.

## Related Issues

Closes #1214 — Preserve discussion-embedded media (videos and zoomable images). Inventory row D3.

Also fixes the same defect on a problem's example media, which had no issue of its own.

## Key Changes

- **Sanitizer**: `iframe` allowed behind an explicit provider allowlist (YouTube/Vimeo via the existing `videoEmbed` helpers, plus Facebook's `video.php`/`post.php` over https), sized by aspect ratio rather than the authored pixel height. `allowedIframeHostnames` isn't enough on its own — it only deletes the `src` and leaves an empty frame — so the check lives in `transformTags`.
- A blocked embed leaves an inert note naming the provider instead of vanishing, and `nonTextTags` discards its children: an `<iframe>`'s children are fallback a browser never renders, but the parser reads them as live markup.
- Inline `height` is stripped from every forecast image, matching the widget's `.tinymce-img { height: auto !important }`.
- **Discussion**: `collectEmbeddedMedia` finds embedded figures in the rendered DOM and feeds the existing `MediaLightbox`. Reading the DOM rather than splitting the HTML matters — 13 of 2,261 real figures are nested, and one center wraps its whole discussion in a `div`, so nothing there is ever top-level.
- **Problem media**: video renders its poster with a play button and opens in the lightbox; photos are zoomable rather than static. `getYouTubeVideoId` now also reads the bare-string shape, which four SNFAC forecasts use and which previously showed "Unsupported media type".

## How to test

`pnpm test` covers the sanitizer (28 cases, fixtures are verbatim markup from the live v2 API), the DOM collector, and the rendering. By hand, on a center with the native forecast flag on: an embedded photo shows an expand chip and opens zoomable; an embedded video shows a play button and plays in the lightbox; a pasted YouTube/Facebook iframe plays inline; right-clicking a poster still opens the image's own context menu, since only the small chip is a button.

## Screenshots / Demo video

All four are real markup from the live v2 API, rendered on a local tenant.

**A discussion with embedded figures.** The chart carries an expand chip in its bottom-left corner; the video below it shows a play button. Before this change both rendered as plain static images, and the video was indistinguishable from a photo — its `data-video-id` was stripped by the sanitizer, so there was no way to tell it was a video or to watch it. Sources: BTAC 184960 (chart), SNFAC 109444 (video).

<img width="2400" height="1612" alt="01-discussion-embedded-figures" src="https://github.com/user-attachments/assets/e93b139a-fd4d-4b8d-8105-93247af9fa48" />

**A pasted YouTube iframe, playing inline.** The sanitizer allowed `img` but not `iframe`, so this was deleted outright with no trace. Below it, an embed from a provider we won't frame now leaves an inert note naming the provider rather than vanishing. Source: TAC 181191.

<img width="2400" height="1612" alt="02-inline-youtube-and-blocked-embed" src="https://github.com/user-attachments/assets/e98c1cb2-cca5-4c40-881f-fb6547af46d0" />

**The same discussion video in the shared lightbox**, with its caption, matching what the legacy widget does on click. Source: SNFAC 109444.

<img width="2400" height="1612" alt="03-discussion-video-lightbox" src="https://github.com/user-attachments/assets/dfe74920-6b46-42aa-b058-facd740d8eee" />

**A video attached to an avalanche problem.** This rendered as nothing at all before — no poster, no caption, no sign a forecaster had attached one. 111 of the 1,836 problems that carry media are videos, including recent CNFAIC, SNFAC and NWAC forecasts. Source: BAC 127432.

<img width="2400" height="1612" alt="04-problem-media" src="https://github.com/user-attachments/assets/b6b27085-ecd5-4d11-abd9-cec844f78a7c" />

No console errors in any of these. They're viewport captures rather than full-page ones because Chrome blanks cross-origin iframes in full-page screenshots.


## Migration Explanation

None — no schema change.

## Future enhancements / Questions

Deliberate divergences from the widget, worth a look:

- **Each surface has its own lightbox.** The widget keeps one continuous list spanning problem media → discussion → gallery. Unifying them means hoisting lightbox state above `AvalancheProblemCard`, which would pull `sanitize-html` into the client bundle.
- **YouTube frames go to `youtube-nocookie.com` with `rel=0`**, which is what `getVideoEmbedUrl` produces and what the Gallery block already ships. This also changes `MediaSlide`; two existing assertions were updated.
- A fixed `allow` policy replaces whatever was authored (32 of the 40 real iframes authored none). No `sandbox`: the `src` is one of a handful of vetted provider URLs, and a wrong flag fails as a blank frame.

Left alone, each worth its own issue: `align-center` on a figure does nothing here (22 real figures; the widget centers them), and `WarningBanner` renders forecaster HTML that the widget escapes with `{{ }}` — pre-existing, now slightly wider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790288505&installation_model_id=426131&pr_number=1228&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1228&signature=39233ac0b2e9b91f1b220069ad0313dc6b46628a34f84af8eeb6553bf3e342db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->