### PR TITLE
Add a draft-release-notes skill, and fix unreleased-prs.sh to compare remote refs

### DIFF
--- a/.claude/skills/draft-release-notes/SKILL.md
+++ b/.claude/skills/draft-release-notes/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: draft-release-notes
+description: Draft a user-friendly "What's Changed" section for the NWAC web (NWACus/web) GitHub release. Use this skill whenever the user is preparing a release for that repo, mentions drafting release notes, asks for a "what's changed" section, says "draft this release", or pastes in GitHub's auto-generated release draft asking for help. Reorganizes PRs by user impact (Features / Bug Fixes / Infra-CI / For-the-devs), translates technical PR titles into language for avalanche center admins, writes a 2-3 sentence intro paragraph naming the release themes with a hero visual callout, and produces a ranked list of where to add screenshots vs. gifs.
+---
+
+# Draft Release Notes
+
+Draft a clear, user-friendly **"What's Changed"** section for a GitHub release of the
+NWAC web app (`NWACus/web`). The audience is **avalanche center admins** (NWAC, DVAC,
+SAC, SNFAC) — non-engineers who manage content — plus the dev team. Translate technical
+PR titles into plain language about what changed for them.
+
+## When to use
+
+Trigger this skill whenever the user:
+
+- is preparing or cutting a release for `NWACus/web`,
+- mentions "draft release notes" / "what's changed" / "draft this release",
+- pastes GitHub's auto-generated release draft and asks for help cleaning it up.
+
+## Step 1 — Gather the list of changes
+
+Use whatever the user gives you first. If they paste GitHub's auto-generated draft, parse
+the PR list from it. Otherwise, collect the unreleased PRs yourself:
+
+```bash
+# From the repo root — lists PRs merged to main but not yet on the release branch,
+# with dates and clickable GitHub links.
+./unreleased-prs.sh
+```
+
+The NWAC release flow is **`release` ← `main`**: a release promotes everything currently
+on `main` that isn't yet on the `release` branch. `unreleased-prs.sh` walks
+`git log release..main --first-parent` and extracts each PR number, date, and branch name.
+
+For richer titles/labels you can also pull from GitHub:
+
+```bash
+gh pr list --repo NWACus/web --state merged --base main --limit 100 \
+  --json number,title,labels,mergedAt,author
+```
+
+Filter to PRs not yet released (merged after the last release tag) if needed:
+
+```bash
+gh release view --repo NWACus/web --json tagName,publishedAt
+```
+
+## Step 2 — Categorize every PR by user impact
+
+Sort every PR into exactly one of these four buckets, **ordered by how much an avalanche
+center admin cares**:
+
+1. **✨ Features** — new capabilities or visible improvements admins/end-users will notice.
+2. **🐛 Bug Fixes** — things that were broken and now work.
+3. **🔧 Infra & CI** — deploys, pipelines, build, monitoring, dependency bumps that keep
+   the lights on but aren't user-facing. (Dependabot PRs usually collapse into a single
+   summarized line here, e.g. "Routine dependency updates".)
+4. **🧑‍💻 For the devs** — refactors, tests, types, tooling, internal-only changes.
+
+Heuristics:
+
+- Use PR labels when present (`feature`, `bug`/`fix`, `ci`, `chore`, `dependencies`,
+  `refactor`, `test`).
+- Lean on the branch prefix from the merge message: `feat/…`, `fix/…`, `chore/…`,
+  `infra/…`, `ci/…`, `refactor/…`, `test/…`.
+- When in doubt, ask: _would a center admin notice this?_ Yes → Features/Bug Fixes.
+  No → Infra-CI / For-the-devs.
+
+## Step 3 — Rewrite each line for the audience
+
+Translate technical PR titles into outcome-focused language for non-engineers.
+
+- Lead with the user benefit, not the implementation.
+- Keep each item to one line; append the PR link/number.
+- Drop internal jargon (collection names, hook names, component names) from
+  Features/Bug Fixes lines — keep those in the For-the-devs bucket where devs read them.
+
+Examples:
+
+- `feat/forecast-og-image` → "Forecast pages now generate a rich preview image when shared
+  on social media or in messages (#1103)"
+- `fix/stabilize-admin-e2e` → move to **For the devs** as "Stabilized admin end-to-end
+  tests (#1109)" — not user-facing.
+- `Bump protobufjs from 7.5.5 to 7.5.8` → collapse into Infra & CI: "Routine dependency
+  and security updates".
+
+## Step 4 — Write the intro paragraph
+
+Open the notes with a **2–3 sentence intro** that names the release's themes (the 1–2
+threads that tie the biggest PRs together) and includes a **hero visual callout** — a
+one-line prompt telling the editor where the single most impactful screenshot/gif should
+go at the top.
+
+> **Hero visual:** _[Add a screenshot or gif of <the headline feature> here.]_
+
+## Step 5 — Rank where to add visuals
+
+End with a short, **ranked** list of where screenshots vs. gifs would most help, highest
+impact first. Recommend:
+
+- **gif** for anything with motion/interaction (new flows, animations, multi-step UI),
+- **screenshot** for static visual changes (new pages, layout, styling).
+
+Each entry: what to capture, screenshot-vs-gif, and which release line it supports.
+
+## Output format
+
+Produce a single markdown block the user can paste straight into the GitHub release body:
+
+```markdown
+<2–3 sentence intro naming the themes>
+
+> **Hero visual:** _[Add a screenshot/gif of <headline feature> here.]_
+
+## ✨ Features
+
+- <plain-language change> (#NNNN)
+
+## 🐛 Bug Fixes
+
+- <plain-language change> (#NNNN)
+
+## 🔧 Infra & CI
+
+- <change or collapsed summary> (#NNNN)
+
+## 🧑‍💻 For the devs
+
+- <change> (#NNNN)
+```
+
+Then, separately (not part of the pasteable block), output:
+
+```markdown
+### 📸 Suggested visuals (ranked)
+
+1. **[gif]** <what to capture> — supports "<release line>"
+2. **[screenshot]** <what to capture> — supports "<release line>"
+```
+
+## Notes
+
+- Always include the PR number/link on each line so the auto-generated changelog and the
+  `post-release` commenter (which comments "included in version …" on each merged PR)
+  stay traceable.
+- If a bucket is empty, omit its heading rather than printing an empty section.
+- Keep the whole "What's Changed" block skimmable — admins should grasp the release in
+  under a minute.

--- a/.claude/skills/draft-release-notes/SKILL.md
+++ b/.claude/skills/draft-release-notes/SKILL.md
@@ -98,10 +98,13 @@ go at the top.
 
 Some PRs need a human to do something outside the deploy: add or delete an environment
 variable, run a migration, flip a flag, update DNS. Those cannot live in a bullet halfway
-down the notes — surface them in a GitHub alert directly under the intro:
+down the notes — surface them in a GitHub alert directly under the intro. The marker has to stay on its
+own line — prettier will fold it into the next one unless the block is ignored:
 
+<!-- prettier-ignore -->
 ```markdown
-> [!IMPORTANT] > **Before deploying:** add `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY`
+> [!IMPORTANT]
+> **Before deploying:** add `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY`
 > to Vercel (Production and Preview). `SNOWOBS_TOKEN` and the `*_RECAPTCHA_*` pair can be
 > deleted afterwards. (#1227)
 ```
@@ -133,12 +136,14 @@ Each entry: what to capture, screenshot-vs-gif, and which release line it suppor
 
 Produce a single markdown block the user can paste straight into the GitHub release body:
 
+<!-- prettier-ignore -->
 ```markdown
 <2–3 sentence intro naming the themes>
 
 > **Hero visual:** _[Add a screenshot/gif of <headline feature> here.]_
 
-> [!IMPORTANT] > **Before deploying:** <config, env var, migration or manual step> (#NNNN)
+> [!IMPORTANT]
+> **Before deploying:** <config, env var, migration or manual step> (#NNNN)
 
 ## ✨ Features
 

--- a/.claude/skills/draft-release-notes/SKILL.md
+++ b/.claude/skills/draft-release-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: draft-release-notes
-description: Draft a user-friendly "What's Changed" section for the NWAC web (NWACus/web) GitHub release. Use this skill whenever the user is preparing a release for that repo, mentions drafting release notes, asks for a "what's changed" section, says "draft this release", or pastes in GitHub's auto-generated release draft asking for help. Reorganizes PRs by user impact (Features / Bug Fixes / Infra-CI / For-the-devs), translates technical PR titles into language for avalanche center admins, writes a 2-3 sentence intro paragraph naming the release themes with a hero visual callout, and produces a ranked list of where to add screenshots vs. gifs.
+description: Draft a user-friendly "What's Changed" section for the NWAC web (NWACus/web) GitHub release. Use this skill whenever the user is preparing a release for that repo, mentions drafting release notes, asks for a "what's changed" section, says "draft this release", or pastes in GitHub's auto-generated release draft asking for help. Reorganizes PRs by user impact (Features / Bug Fixes / Infra-CI / For-the-devs), translates technical PR titles into language for avalanche center admins, writes a 2-3 sentence intro paragraph naming the release themes with a hero visual callout, surfaces any env-var/migration/manual deploy steps in an alert, and produces a ranked list of where to add screenshots vs. gifs.
 ---
 
 # Draft Release Notes
@@ -33,11 +33,11 @@ The NWAC release flow is **`release` ← `main`**: a release promotes everything
 on `main` that isn't yet on the `release` branch. `unreleased-prs.sh` walks
 `git log release..main --first-parent` and extracts each PR number, date, and branch name.
 
-For richer titles/labels you can also pull from GitHub:
+For fuller titles than the branch names in the merge commits, pull from GitHub:
 
 ```bash
 gh pr list --repo NWACus/web --state merged --base main --limit 100 \
-  --json number,title,labels,mergedAt,author
+  --json number,title,mergedAt,author
 ```
 
 Filter to PRs not yet released (merged after the last release tag) if needed:
@@ -60,10 +60,10 @@ center admin cares**:
 
 Heuristics:
 
-- Use PR labels when present (`feature`, `bug`/`fix`, `ci`, `chore`, `dependencies`,
-  `refactor`, `test`).
 - Lean on the branch prefix from the merge message: `feat/…`, `fix/…`, `chore/…`,
   `infra/…`, `ci/…`, `refactor/…`, `test/…`.
+- Read the PR title, and the body when the title is ambiguous. PRs here are rarely
+  labelled, so do not wait for labels to tell you where something belongs.
 - When in doubt, ask: _would a center admin notice this?_ Yes → Features/Bug Fixes.
   No → Infra-CI / For-the-devs.
 
@@ -94,7 +94,32 @@ go at the top.
 
 > **Hero visual:** _[Add a screenshot or gif of <the headline feature> here.]_
 
-## Step 5 — Rank where to add visuals
+## Step 5 — Call out deploy steps
+
+Some PRs need a human to do something outside the deploy: add or delete an environment
+variable, run a migration, flip a flag, update DNS. Those cannot live in a bullet halfway
+down the notes — surface them in a GitHub alert directly under the intro:
+
+```markdown
+> [!IMPORTANT] > **Before deploying:** add `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY`
+> to Vercel (Production and Preview). `SNOWOBS_TOKEN` and the `*_RECAPTCHA_*` pair can be
+> deleted afterwards. (#1227)
+```
+
+To find them, scan the PR bodies of everything in the release — the template's
+**Migration Explanation** and **Future enhancements / Questions** sections are where
+these usually surface:
+
+```bash
+gh pr view <number> --repo NWACus/web --json body \
+  --jq '.body' | grep -iE "env|vercel|migration|secret|key|flag|dns"
+```
+
+Look for new `.env.example` keys, files under `src/migrations/`, and anything the PR
+describes as needed "before" or "after" deploy. Omit the alert when there is nothing to
+do — an empty ceremonial callout trains people to skip real ones.
+
+## Step 6 — Rank where to add visuals
 
 End with a short, **ranked** list of where screenshots vs. gifs would most help, highest
 impact first. Recommend:
@@ -112,6 +137,8 @@ Produce a single markdown block the user can paste straight into the GitHub rele
 <2–3 sentence intro naming the themes>
 
 > **Hero visual:** _[Add a screenshot/gif of <headline feature> here.]_
+
+> [!IMPORTANT] > **Before deploying:** <config, env var, migration or manual step> (#NNNN)
 
 ## ✨ Features
 
@@ -144,6 +171,7 @@ Then, separately (not part of the pasteable block), output:
 - Always include the PR number/link on each line so the auto-generated changelog and the
   `post-release` commenter (which comments "included in version …" on each merged PR)
   stay traceable.
-- If a bucket is empty, omit its heading rather than printing an empty section.
+- If a bucket is empty, omit its heading rather than printing an empty section. The same
+  goes for the deploy alert — no manual steps, no callout.
 - Keep the whole "What's Changed" block skimmable — admins should grasp the release in
   under a minute.

--- a/unreleased-prs.sh
+++ b/unreleased-prs.sh
@@ -11,16 +11,19 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-echo -e "${YELLOW}Fetching latest release branch...${NC}"
-git fetch origin release:release 2>/dev/null || true
+echo -e "${YELLOW}Fetching latest main and release...${NC}"
+# Both, or a worktree sitting on a stale local main under-reports. Compared via the
+# remote-tracking refs so the fetch works from any worktree, including one that has
+# main or release checked out (git refuses to fetch into a checked-out branch).
+git fetch origin main release 2>/dev/null || true
 
 echo -e "\n${GREEN}PRs in main that haven't been released yet:${NC}\n"
 
 # Get the GitHub repo URL from git remote
 REPO_URL=$(git config --get remote.origin.url | sed 's/\.git$//' | sed 's/git@github.com:/https:\/\/github.com\//')
 
-# Get commits in main but not in release, with dates
-git log release..main --first-parent --pretty=tformat:"%h|%ad|%s" --date=short | while IFS='|' read -r hash date message; do
+# Get commits on main but not in release, with dates
+git log origin/release..origin/main --first-parent --pretty=tformat:"%h|%ad|%s" --date=short | while IFS='|' read -r hash date message; do
   # Extract PR number from commit message using regex
   if [[ $message =~ Merge\ pull\ request\ \#([0-9]+) ]]; then
     PR_NUMBER="${BASH_REMATCH[1]}"
@@ -37,5 +40,5 @@ git log release..main --first-parent --pretty=tformat:"%h|%ad|%s" --date=short |
   fi
 done
 
-UNRELEASED_COUNT=$(git log release..main --first-parent --oneline | wc -l | tr -d ' ')
+UNRELEASED_COUNT=$(git log origin/release..origin/main --first-parent --oneline | wc -l | tr -d ' ')
 echo -e "${YELLOW}Total unreleased PRs: ${UNRELEASED_COUNT}${NC}"


### PR DESCRIPTION
## Description

Adds a `draft-release-notes` agent skill for turning a batch of merged PRs into the "What's Changed" section of a GitHub release.

The commit was written in June on `chore/add-release-note-skill` and never opened as a PR. Its base was 292 commits behind, so it's rebased onto current `main` here — same single file, no content changes, no conflicts.

## Related Issues

None.

## Key Changes

Adds `.claude/skills/draft-release-notes/SKILL.md`, plus two fixes found by running it against the current backlog. The skill:

- collects unreleased PRs via the existing `./unreleased-prs.sh`, which walks `git log release..main --first-parent` — matching the `release` ← `main` promotion flow — or parses GitHub's auto-generated draft if one is pasted in
- sorts every PR into Features / Bug Fixes / Infra & CI / For the devs, ordered by how much an avalanche center admin cares, using labels and branch prefixes as heuristics
- rewrites technical PR titles as plain-language outcomes for center admins, keeping component and collection names in the dev bucket
- opens with a 2–3 sentence intro naming the release themes plus a hero-visual callout
- surfaces env vars, migrations and manual steps in a `> [!IMPORTANT]` alert under the intro, rather than as a bullet buried mid-notes
- closes with a ranked screenshot-vs-gif list for whoever is assembling the release

**`unreleased-prs.sh` compared stale refs.** `git fetch origin release:release` is silently refused whenever `release` is checked out in a worktree — which it always is in this layout — so the script walked whatever the local branches happened to point at. Running it produced 22 PRs when the real answer was 19: it counted five that had already shipped and missed two merged that morning. It now fetches both branches and compares `origin/release..origin/main`, which works from any worktree.

**The label heuristic is gone.** Step 2 led with "use PR labels when present"; exactly one of the 19 unreleased PRs carries a label, so the rule pointed at a signal that isn't there. Sorting is on branch prefix and PR title now.

## How to test

Run `/draft-release-notes` from inside a worktree (repo skills only load when Claude Code starts in the repo, not in the parent worktree container). It should call `./unreleased-prs.sh`, then produce a pasteable markdown block plus a separate ranked visuals list. Compare its bucketing against a recent release to see whether the Features / For-the-devs split reads right.

## Screenshots / Demo video

None — a markdown skill file.

## Migration Explanation

No migrations.

## Future enhancements / Questions

- The skill is prose-only, so its output will drift with taste. Worth revisiting after it drafts a real release to see whether the buckets and tone hold.
- It assumes PR numbers appear in merge commit subjects (`Merge pull request #NNNN`), which `unreleased-prs.sh` also relies on. Squash-merged PRs would need a different parse.
