### PR TITLE
Replace the release commenter with a batched script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,11 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm
@@ -41,11 +41,11 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm
@@ -74,11 +74,11 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm
@@ -119,11 +119,11 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm
@@ -138,11 +138,11 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm
@@ -161,13 +161,13 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Need full history for --changed-since origin/main
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm
@@ -193,11 +193,11 @@ jobs:
       LOCAL_FLAG_ENABLE_LOCAL_PRODUCTION_BUILDS: 'true'
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm
@@ -222,7 +222,7 @@ jobs:
       - name: 🧪 Run E2E tests
         run: pnpm test:e2e
       - name: 📤 Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
@@ -234,11 +234,11 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm
@@ -271,13 +271,13 @@ jobs:
       pull-requests: write
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Need full history to compare with base branch
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm
@@ -332,14 +332,14 @@ jobs:
       - name: Find existing migration safety comment
         if: steps.check-migrations.outputs.has_issues == 'true' && github.event_name == 'pull_request'
         id: find-comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: '### Migration Safety Check'
       - name: Create or update PR comment
         if: steps.check-migrations.outputs.has_issues == 'true' && github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Check authorization
         id: auth-check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           result-encoding: string
@@ -48,7 +48,7 @@ jobs:
 
       - name: Post unauthorized comment
         if: steps.auth-check.outputs.result == 'unauthorized'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/dependabot-auto-format.yml
+++ b/.github/workflows/dependabot-auto-format.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.x'
           cache: 'pnpm'
@@ -39,7 +39,7 @@ jobs:
 
       - name: Import GPG key
         id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -47,7 +47,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'style: run prettify and lint:fix'
           commit_author: ${{ steps.import-gpg.outputs.name }} <${{ steps.import-gpg.outputs.email }}>

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -42,11 +42,11 @@ jobs:
         env:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,16 +3,78 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to comment for (backfill a past release, e.g. v1.13.0)
+        required: true
+        type: string
 
 jobs:
   post_release:
     permissions:
+      contents: read
       issues: write
       pull-requests: write
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: apexskier/github-release-commenter@v1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          comment-template: |
-            🚀 This is included in version {release_link}
+      - name: Comment on the PRs and issues in this release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_url="https://github.com/$REPO/releases/tag/$TAG"
+          comment="🚀 This is included in version [$TAG]($release_url)"
+          owner="${REPO%/*}"
+          name="${REPO#*/}"
+
+          # The PRs in this release, straight from GitHub's own release-notes
+          # generator (it picks the previous release as the base). One request
+          # for the whole list -- the action this replaced walked every commit
+          # individually and tripped the secondary rate limit on big releases.
+          prs=$(gh api "repos/$REPO/releases/generate-notes" -f tag_name="$TAG" --jq .body \
+            | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+' | sort -un || true)
+
+          if [ -z "$prs" ]; then
+            echo "No pull requests found for $TAG."
+            exit 0
+          fi
+
+          # Comment on each PR and on the issues it closes. A number that isn't
+          # a PR resolves to null and is skipped.
+          targets=""
+          for pr in $prs; do
+            meta=$(gh api graphql -f query="
+              query {
+                repository(owner: \"$owner\", name: \"$name\") {
+                  pullRequest(number: $pr) {
+                    labels(first: 20) { nodes { name } }
+                    closingIssuesReferences(first: 20) { nodes { number } }
+                  }
+                }
+              }" --jq '.data.repository.pullRequest')
+
+            [ "$meta" = "null" ] && continue
+
+            if echo "$meta" | jq -e '.labels.nodes[] | select(.name == "dependencies")' >/dev/null; then
+              echo "Skipping #$pr (dependencies)."
+              continue
+            fi
+
+            targets="$targets $pr $(echo "$meta" | jq -r '.closingIssuesReferences.nodes[].number')"
+          done
+
+          for target in $(echo "$targets" | tr ' ' '\n' | sort -un); do
+            # Idempotent, so a re-run or a backfill can't double-comment.
+            if gh api "repos/$REPO/issues/$target/comments" --paginate --jq '.[].body' \
+              | grep -qF "$release_url"; then
+              echo "#$target already mentions $TAG."
+              continue
+            fi
+            gh api "repos/$REPO/issues/$target/comments" -f body="$comment" --silent
+            echo "Commented on #$target."
+          done

--- a/.github/workflows/pr-visual-recap.yml
+++ b/.github/workflows/pr-visual-recap.yml
@@ -48,7 +48,7 @@ jobs:
       recap: ${{ steps.decide.outputs.recap }}
     steps:
       - id: decide
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         with:
@@ -216,7 +216,7 @@ jobs:
       issues: read
       pull-requests: read
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         env:
           PLAN_RECAP_TOKEN: ${{ secrets.PLAN_RECAP_TOKEN }}
         with:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -44,11 +44,11 @@ jobs:
           name="payloadcms-preview-${ref}"
           echo "name=${name}" >> "${GITHUB_OUTPUT}"
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm
@@ -194,13 +194,13 @@ jobs:
           vercel alias --scope=nwac --token=${{ secrets.VERCEL_TOKEN }} set "${{ steps.deployment.outputs.url }}" "${{ steps.domains.outputs.wildcard_preview_alias }}"
       - name: Find existing deployment comment
         id: find-comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: 'Preview deployment:'
       - name: Create or update PR comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -37,7 +37,7 @@ jobs:
         env:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Verify release branch is up to date
@@ -48,9 +48,9 @@ jobs:
             exit 1
           fi
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm

--- a/.github/workflows/sync-prod-to-dev.yml
+++ b/.github/workflows/sync-prod-to-dev.yml
@@ -46,11 +46,11 @@ jobs:
         env:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.x
           cache: pnpm

--- a/drift.lock
+++ b/drift.lock
@@ -143,7 +143,7 @@ sig = "2433d2218a295ca5"
 [[bindings]]
 doc = "docs/claude-github-issues.md"
 target = ".github/workflows/claude.yml"
-sig = "b4cdca0cf4f354b1"
+sig = "92802f251746884e"
 
 [[bindings]]
 doc = "docs/coding-guide.md"


### PR DESCRIPTION
## Description

The `🚀 This is included in version …` comments didn't post for v1.16.0. The `post-release` job failed 5 seconds in with:

```
##[error]HttpError: You have exceeded a secondary rate limit.
```

`apexskier/github-release-commenter` walks **every commit** in a release and fires a GraphQL query per commit to find its associated PRs. v1.16.0 had 197 commits since v1.15.1, so ~200 rapid-fire queries tripped GitHub's secondary rate limit during enumeration — before it posted a single comment.

It tracks commit count, not PR count, and the only two failures in the workflow's history are our two biggest releases:

| Release | Commits | PRs | Result |
| --- | --- | --- | --- |
| v1.13.0 | 242 | 20 | ❌ |
| v1.16.0 | 197 | 23 | ❌ |
| v1.12.0 | 124 | 11 | ✅ |
| v1.15.0 | 81 | 8 | ✅ |
| v1.14.0 | 60 | 11 | ✅ |
| v1.15.1 | 24 | 5 | ✅ |

Clean break between 124 and 197, and our releases keep growing. A retry wouldn't help — the burst is the same size on every attempt. This replaces the action with a script that asks GitHub for the PR list **once**, so the request count scales with PRs (~48 calls for v1.16.0) instead of commits.

## Related Issues

None.

## Key Changes

- **Ask once instead of per-commit.** `POST /releases/generate-notes` returns every PR in the release in a single request (it picks the previous release as the base automatically).
- **Still comments on linked issues.** The old action followed each PR to the issues it closes — for v1.16.0 that's 19 PRs **+ 9 linked issues = 28 targets**. The script follows `closingIssuesReferences` so we don't silently lose those.
- **Idempotent.** Each target is checked for an existing mention of the release URL before commenting, so re-runs and backfills can't double-post. The old action had no such guard.
- **Backfillable.** Added a `workflow_dispatch` trigger with a `tag` input, so a past release can be commented after the fact. The `release: published` event only fires once and can't be replayed, which is why v1.13.0 stayed empty for four months.
- Preserves the existing `skip-label: dependencies` behavior and the comment text verbatim.

Dropping the action also drops an unmaintained dependency — `apexskier/github-release-commenter` is at v1.4.1 (Jan 2026), has no throttle or retry input, and still targets Node 20 (already warning as deprecated in our logs).

Following that Node 20 thread: a second commit bumps **every** action in `.github/workflows/` to its lowest Node 24 major (two, `peter-evans/find-comment@v2` and `create-or-update-comment@v3`, were still on Node 16), verified against the live Blacksmith runner version 2.336.0.

## How to test

The logic was verified end-to-end against both failed releases by running the step body locally:

- v1.16.0 → 19 PRs → 28 comment targets
- v1.13.0 → 20 PRs → 26 comment targets

**Both releases have already been backfilled** — those comments are live now, posted from a local run, so they're authored by @rchlfryn rather than `github-actions[bot]`. Every other release's comments stay bot-authored.

To verify the guard rails on this branch:

```bash
# extract the step body, then:
REPO=NWACus/web TAG=v1.16.0 GH_TOKEN=$(gh auth token) bash step.sh
# every line should read "#N already mentions v1.16.0." — no new comments
```

Once merged, `gh workflow run post-release.yml -f tag=<tag>` backfills any release ( `workflow_dispatch` only appears for workflows on the default branch).

## Screenshots / Demo video

N/A — CI-only change.

## Migration Explanation

None needed — no schema changes.

## Future enhancements / Questions

- **One unverified detail:** the job now needs `contents: read` for the `generate-notes` call, which the previous `permissions:` block didn't grant. GitHub's REST docs don't state the fine-grained permission for that endpoint, so if the first real run 403s, bump it to `contents: write`. Everything else in the script is proven against live data.
- The next release is the real test. If it posts clean, this is settled; if not, the failure will be loud and specific rather than a silent secondary-limit abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790362697&installation_model_id=426131&pr_number=1231&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1231&signature=fe60030051132ce146a1ce0c2118aa2c3f957151dca37a488a3c8a3195d371e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
