### PR TITLE
Give the Gallery lightbox the whole screen through a shared shell

### DIFF
--- a/__tests__/client/blocks/Gallery.client.test.tsx
+++ b/__tests__/client/blocks/Gallery.client.test.tsx
@@ -23,6 +23,10 @@ jest.mock('../../../src/components/ui/dialog', () => ({
     open ? <div data-testid="dialog">{children}</div> : null,
   DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogClose: ({ children, ...props }: { children: React.ReactNode }) => (
+    <button {...props}>{children}</button>
+  ),
 }))
 
 // Passthrough carousel so lightbox slides render in tests.

--- a/__tests__/client/components/Lightbox.client.test.tsx
+++ b/__tests__/client/components/Lightbox.client.test.tsx
@@ -1,6 +1,6 @@
-import { Lightbox, LightboxSlide } from '@/components/Lightbox'
+import { Lightbox, LightboxSlide, useLightboxCarousel } from '@/components/Lightbox'
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react'
 import { createRef } from 'react'
 import type { ReactZoomPanPinchRef } from 'react-zoom-pan-pinch'
 
@@ -100,5 +100,34 @@ describe('LightboxSlide', () => {
     const { container } = render(<LightboxSlide>media</LightboxSlide>)
     // The media area is the slide's only child, so nothing takes height from the image.
     expect(container.firstElementChild?.children).toHaveLength(1)
+  })
+})
+
+describe('useLightboxCarousel', () => {
+  // Only the four methods the hook touches; `Object.create(null)` keeps this assignable to the
+  // full embla api without a cast.
+  const carouselAt = (snap: number) =>
+    Object.assign(Object.create(null), {
+      scrollTo: jest.fn(),
+      selectedScrollSnap: () => snap,
+      on: jest.fn(),
+      off: jest.fn(),
+    })
+
+  it('opens on the slide it was asked for, ignoring the carousel from the last open', () => {
+    const { result, rerender } = renderHook(
+      ({ startIndex, open }) => useLightboxCarousel(startIndex, open),
+      { initialProps: { startIndex: 4, open: true } },
+    )
+
+    // Embla hands its api up once it boots, reporting the slide it landed on.
+    act(() => result.current.setApi(carouselAt(4)))
+    expect(result.current.index).toBe(4)
+
+    // The carousel unmounts with the lightbox but never clears that api, so reopening from a
+    // different thumbnail must not read the old slide back out of the destroyed instance.
+    rerender({ startIndex: 4, open: false })
+    rerender({ startIndex: 0, open: true })
+    expect(result.current.index).toBe(0)
   })
 })

--- a/__tests__/client/components/Lightbox.client.test.tsx
+++ b/__tests__/client/components/Lightbox.client.test.tsx
@@ -1,0 +1,104 @@
+import { Lightbox, LightboxSlide } from '@/components/Lightbox'
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { createRef } from 'react'
+import type { ReactZoomPanPinchRef } from 'react-zoom-pan-pinch'
+
+const noop = () => {}
+
+function renderLightbox(props: Partial<React.ComponentProps<typeof Lightbox>> = {}) {
+  return render(
+    <Lightbox
+      open
+      onOpenChange={noop}
+      title="Media viewer"
+      index={1}
+      count={5}
+      onPrev={noop}
+      onNext={noop}
+      {...props}
+    >
+      <div>slide</div>
+    </Lightbox>,
+  )
+}
+
+describe('Lightbox', () => {
+  it('shows the slide counter and edge arrows for a multi-item lightbox', () => {
+    renderLightbox()
+    expect(screen.getByText('2 / 5')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument()
+  })
+
+  it('drops the counter and arrows when there is only one item to view', () => {
+    renderLightbox({ index: 0, count: 1 })
+    expect(screen.queryByText('1 / 1')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument()
+    // Close is still the way out of a single-item lightbox.
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+  })
+
+  it('navigates on the arrow keys, from anywhere on the page', () => {
+    const onPrev = jest.fn()
+    const onNext = jest.fn()
+    renderLightbox({ onPrev, onNext })
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' })
+    fireEvent.keyDown(window, { key: 'ArrowLeft' })
+
+    expect(onNext).toHaveBeenCalledTimes(1)
+    expect(onPrev).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens with focus on the dialog, not on the first control', async () => {
+    const zoomRef = createRef<ReactZoomPanPinchRef>()
+    renderLightbox({ zoomRef })
+
+    // Radix moves focus in an effect, so wait for it to settle.
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('dialog')))
+    expect(document.activeElement).not.toBe(screen.getByRole('button', { name: 'Zoom in' }))
+  })
+
+  it('offers zoom controls only when the active slide can zoom', () => {
+    const { unmount } = renderLightbox()
+    expect(screen.queryByRole('button', { name: 'Zoom in' })).not.toBeInTheDocument()
+    unmount()
+
+    const zoomRef = createRef<ReactZoomPanPinchRef>()
+    renderLightbox({ zoomRef })
+    expect(screen.getByRole('button', { name: 'Zoom in' })).toBeInTheDocument()
+  })
+
+  it('drives the zoom surface through the ref it was handed', () => {
+    const zoomIn = jest.fn()
+    const zoomOut = jest.fn()
+    const resetTransform = jest.fn()
+    // Only the three methods the controls call are needed; the rest of the library ref isn't.
+    const zoomRef: React.RefObject<ReactZoomPanPinchRef | null> = {
+      current: Object.assign(Object.create(null), { zoomIn, zoomOut, resetTransform }),
+    }
+
+    renderLightbox({ zoomRef })
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom out' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Reset zoom' }))
+
+    expect(zoomIn).toHaveBeenCalledTimes(1)
+    expect(zoomOut).toHaveBeenCalledTimes(1)
+    expect(resetTransform).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('LightboxSlide', () => {
+  it('renders a caption when there is one', () => {
+    render(<LightboxSlide caption={<p>A photo</p>}>media</LightboxSlide>)
+    expect(screen.getByText('A photo')).toBeInTheDocument()
+  })
+
+  it('gives the whole slide to the media when there is no caption', () => {
+    const { container } = render(<LightboxSlide>media</LightboxSlide>)
+    // The media area is the slide's only child, so nothing takes height from the image.
+    expect(container.firstElementChild?.children).toHaveLength(1)
+  })
+})

--- a/src/blocks/Gallery/GalleryLightbox.tsx
+++ b/src/blocks/Gallery/GalleryLightbox.tsx
@@ -1,18 +1,17 @@
 'use client'
 
+import { Lightbox, LightboxSlide, useLightboxCarousel } from '@/components/Lightbox'
 import { ImageMedia } from '@/components/Media/ImageMedia'
 import { VideoMedia } from '@/components/Media/VideoMedia'
-import { Button } from '@/components/ui/button'
-import { Carousel, CarouselContent, CarouselItem, type CarouselApi } from '@/components/ui/carousel'
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { Carousel, CarouselContent, CarouselItem } from '@/components/ui/carousel'
 import {
   getVideoEmbedUrl,
   getVideoThumbnail,
   parseVideoUrl,
   videoProviderLabels,
+  type ParsedVideo,
 } from '@/utilities/videoEmbed'
-import { ChevronLeft, ChevronRight, RotateCcw, ZoomIn, ZoomOut } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useRef } from 'react'
 import { type ReactZoomPanPinchRef } from 'react-zoom-pan-pinch'
 import { ZoomableImage } from './ZoomableImage'
 import { isVideoResource, type GalleryItem } from './shared'
@@ -24,202 +23,135 @@ type Props = {
   startIndex: number
 }
 
-const zoomButtonClass = 'h-8 w-8 rounded-full text-white/80 hover:bg-white/20 hover:text-white'
-
 export const GalleryLightbox = ({ items, open, onOpenChange, startIndex }: Props) => {
-  const [api, setApi] = useState<CarouselApi>()
-  const [selectedIndex, setSelectedIndex] = useState(startIndex)
+  const {
+    setApi,
+    index: selectedIndex,
+    scrollPrev,
+    scrollNext,
+  } = useLightboxCarousel(startIndex, open)
   const transformRef = useRef<ReactZoomPanPinchRef>(null)
-
-  // Mark the opened slide active before the carousel's first `select` fires, so
-  // its zoom controls render immediately.
-  useEffect(() => {
-    if (open) setSelectedIndex(startIndex)
-  }, [open, startIndex])
-
-  useEffect(() => {
-    if (!api) return
-    setSelectedIndex(api.selectedScrollSnap())
-    const onSelect = () => setSelectedIndex(api.selectedScrollSnap())
-    api.on('select', onSelect)
-    return () => {
-      api.off('select', onSelect)
-    }
-  }, [api])
-
-  // Arrow keys drive navigation (drag-to-swipe is disabled to avoid clashing
-  // with image pan). Capture + stopPropagation so the carousel's own arrow-key
-  // handler can't also fire once focus is inside it and advance twice.
-  useEffect(() => {
-    if (!open || !api) return
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft') {
-        e.stopPropagation()
-        api.scrollPrev()
-      } else if (e.key === 'ArrowRight') {
-        e.stopPropagation()
-        api.scrollNext()
-      }
-    }
-    window.addEventListener('keydown', onKeyDown, true)
-    return () => window.removeEventListener('keydown', onKeyDown, true)
-  }, [open, api])
-
-  const renderSlide = (item: GalleryItem, index: number) => {
-    if (item.type === 'video') {
-      const video = parseVideoUrl(item.videoUrl)
-      if (!video) {
-        return (
-          <a
-            href={item.videoUrl || '#'}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-white underline"
-          >
-            {item.videoTitle || 'Open video'}
-          </a>
-        )
-      }
-      // Mount the iframe only for the active slide so off-screen videos don't
-      // autoplay or load.
-      if (index === selectedIndex) {
-        return (
-          <iframe
-            className="aspect-video w-full max-w-5xl"
-            src={getVideoEmbedUrl(video, true)}
-            title={item.videoTitle || `${videoProviderLabels[video.provider]} video`}
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            allowFullScreen
-          />
-        )
-      }
-      const thumbnail = getVideoThumbnail(video)
-      return thumbnail ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={thumbnail}
-          alt={item.videoTitle || ''}
-          className="max-h-full max-w-full object-contain"
-        />
-      ) : (
-        <div className="flex flex-col items-center justify-center gap-1 text-center text-white">
-          <span className="text-xs font-medium uppercase tracking-wide text-white/70">
-            {videoProviderLabels[video.provider]}
-          </span>
-          {item.videoTitle && <span className="text-sm">{item.videoTitle}</span>}
-        </div>
-      )
-    }
-
-    if (isVideoResource(item.media)) {
-      return (
-        <VideoMedia
-          resource={item.media}
-          showVideoControls
-          videoClassName="max-h-[80vh] w-auto max-w-full"
-        />
-      )
-    }
-
-    // Only the active image is zoomable; remounting it on navigation resets zoom.
-    if (index === selectedIndex) {
-      return <ZoomableImage resource={item.media} transformRef={transformRef} />
-    }
-    return (
-      <div className="relative h-[85vh] w-full">
-        <ImageMedia resource={item.media} fill imgClassName="object-contain" />
-      </div>
-    )
-  }
 
   const activeItem = items[selectedIndex]
   const activeIsImage = activeItem?.type === 'upload' && !isVideoResource(activeItem.media)
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        className="h-[100dvh] max-w-none w-screen border-0 bg-transparent p-0 shadow-none sm:rounded-none [&>button]:z-[70] [&>button]:text-white [&>button]:opacity-80 [&>button]:hover:opacity-100 [&>button>svg]:h-7 [&>button>svg]:w-7"
-        overlayClassName="bg-black/90"
-      >
-        <DialogTitle className="sr-only">Gallery</DialogTitle>
-        {open && activeIsImage && (
-          <div className="absolute right-14 top-3 z-[70] flex items-center gap-1 rounded-full bg-black/40 p-1 backdrop-blur">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => transformRef.current?.zoomIn()}
-              aria-label="Zoom in"
-              className={zoomButtonClass}
-            >
-              <ZoomIn className="h-5 w-5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => transformRef.current?.zoomOut()}
-              aria-label="Zoom out"
-              className={zoomButtonClass}
-            >
-              <ZoomOut className="h-5 w-5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => transformRef.current?.resetTransform()}
-              aria-label="Reset zoom"
-              className={zoomButtonClass}
-            >
-              <RotateCcw className="h-5 w-5" />
-            </Button>
-          </div>
-        )}
-        {open && (
-          <Carousel opts={{ startIndex, loop: items.length > 1, watchDrag: false }} setApi={setApi}>
-            <CarouselContent>
-              {items.map((item, index) => (
-                <CarouselItem key={item.id ?? index}>
-                  <div className="flex h-[100dvh] flex-col items-center justify-center gap-3">
-                    <div className="flex w-full items-center justify-center">
-                      {renderSlide(item, index)}
-                    </div>
-                    {item.caption && (
-                      <p className="text-center text-sm text-white">{item.caption}</p>
-                    )}
-                  </div>
-                </CarouselItem>
-              ))}
-            </CarouselContent>
-            {items.length > 1 && (
-              <>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    // Blur on mouse click (detail > 0) to drop the lingering
-                    // focus ring; keep focus on keyboard activation (detail === 0).
-                    if (e.detail > 0) e.currentTarget.blur()
-                    api?.scrollPrev()
-                  }}
-                  aria-label="Previous"
-                  className="group absolute inset-y-0 left-0 z-50 flex w-[12vw] min-w-16 items-center justify-start pl-4 text-white"
+    <Lightbox
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Gallery"
+      index={selectedIndex}
+      count={items.length}
+      onPrev={scrollPrev}
+      onNext={scrollNext}
+      zoomRef={activeIsImage ? transformRef : undefined}
+    >
+      {open && (
+        <Carousel opts={{ startIndex, loop: items.length > 1, watchDrag: false }} setApi={setApi}>
+          <CarouselContent>
+            {items.map((item, index) => (
+              <CarouselItem key={item.id ?? index}>
+                <LightboxSlide
+                  caption={item.caption ? <p className="text-white">{item.caption}</p> : undefined}
                 >
-                  <ChevronLeft className="h-9 w-9 opacity-70 transition group-hover:opacity-100" />
-                </button>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    if (e.detail > 0) e.currentTarget.blur()
-                    api?.scrollNext()
-                  }}
-                  aria-label="Next"
-                  className="group absolute inset-y-0 right-0 z-50 flex w-[12vw] min-w-16 items-center justify-end pr-4 text-white"
-                >
-                  <ChevronRight className="h-9 w-9 opacity-70 transition group-hover:opacity-100" />
-                </button>
-              </>
-            )}
-          </Carousel>
-        )}
-      </DialogContent>
-    </Dialog>
+                  <Slide
+                    item={item}
+                    isActive={index === selectedIndex}
+                    transformRef={transformRef}
+                  />
+                </LightboxSlide>
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+        </Carousel>
+      )}
+    </Lightbox>
+  )
+}
+
+function Slide({
+  item,
+  isActive,
+  transformRef,
+}: {
+  item: GalleryItem
+  isActive: boolean
+  transformRef: React.Ref<ReactZoomPanPinchRef>
+}) {
+  if (item.type === 'video') {
+    const video = parseVideoUrl(item.videoUrl)
+    if (!video) {
+      return (
+        <a
+          href={item.videoUrl || '#'}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-white underline"
+        >
+          {item.videoTitle || 'Open video'}
+        </a>
+      )
+    }
+    return <EmbeddedVideoSlide video={video} title={item.videoTitle} isActive={isActive} />
+  }
+
+  if (isVideoResource(item.media)) {
+    return (
+      <VideoMedia
+        resource={item.media}
+        showVideoControls
+        videoClassName="max-h-full w-auto max-w-full"
+      />
+    )
+  }
+
+  // Only the active image is zoomable; remounting it on navigation resets zoom.
+  if (isActive) {
+    return <ZoomableImage resource={item.media} transformRef={transformRef} />
+  }
+  return (
+    <div className="relative h-full w-full">
+      <ImageMedia resource={item.media} fill imgClassName="object-contain" />
+    </div>
+  )
+}
+
+/** A third-party video (YouTube, Vimeo); off-screen slides show a still so nothing else loads. */
+function EmbeddedVideoSlide({
+  video,
+  title,
+  isActive,
+}: {
+  video: ParsedVideo
+  title?: string | null
+  isActive: boolean
+}) {
+  if (isActive) {
+    return (
+      <iframe
+        className="aspect-video max-h-full w-full max-w-5xl"
+        src={getVideoEmbedUrl(video, true)}
+        title={title || `${videoProviderLabels[video.provider]} video`}
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowFullScreen
+      />
+    )
+  }
+
+  const thumbnail = getVideoThumbnail(video)
+  if (thumbnail) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img src={thumbnail} alt={title || ''} className="max-h-full max-w-full object-contain" />
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-1 text-center text-white">
+      <span className="text-xs font-medium uppercase tracking-wide text-white/70">
+        {videoProviderLabels[video.provider]}
+      </span>
+      {title && <span className="text-sm">{title}</span>}
+    </div>
   )
 }

--- a/src/blocks/Gallery/ZoomableImage.tsx
+++ b/src/blocks/Gallery/ZoomableImage.tsx
@@ -38,8 +38,9 @@ export const ZoomableImage = ({
       {({ zoomIn, resetTransform, instance }) => (
         <TransformComponent
           // The lightbox chrome decides how much room the media gets, and only at layout time, so
-          // fill the positioned parent rather than hard-coding a viewport fraction.
-          wrapperClass="absolute inset-0"
+          // fill the parent instead of hard-coding a viewport fraction. It has to be an inline
+          // style: the library injects its own `.transform-component-module_wrapper` rule after
+          // Tailwind's stylesheet, and at equal specificity a utility class on the wrapper loses.
           wrapperStyle={{ width: '100%', height: '100%' }}
           contentStyle={{ width: '100%', height: '100%' }}
         >

--- a/src/blocks/Gallery/ZoomableImage.tsx
+++ b/src/blocks/Gallery/ZoomableImage.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-zoom-pan-pinch'
 import type { GalleryItem } from './shared'
 
-// Zoom/pan for one lightbox image; the zoom buttons live in GalleryLightbox and
+// Zoom/pan for one lightbox image; the zoom buttons live in the lightbox chrome and
 // drive this through `transformRef`.
 export const ZoomableImage = ({
   resource,
@@ -37,12 +37,15 @@ export const ZoomableImage = ({
     >
       {({ zoomIn, resetTransform, instance }) => (
         <TransformComponent
-          wrapperStyle={{ width: '100%', height: '85vh' }}
+          // The lightbox chrome decides how much room the media gets, and only at layout time, so
+          // fill the positioned parent rather than hard-coding a viewport fraction.
+          wrapperClass="absolute inset-0"
+          wrapperStyle={{ width: '100%', height: '100%' }}
           contentStyle={{ width: '100%', height: '100%' }}
         >
           <div
             className={cn(
-              'relative h-[85vh] w-full',
+              'relative h-full w-full',
               scale > 1 ? 'cursor-grab active:cursor-grabbing' : 'cursor-zoom-in',
             )}
             onPointerDown={(e) => {

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -1,0 +1,276 @@
+'use client'
+
+import { ChevronLeft, ChevronRight, RotateCcw, X, ZoomIn, ZoomOut } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import { type ReactZoomPanPinchRef } from 'react-zoom-pan-pinch'
+
+import { type CarouselApi } from '@/components/ui/carousel'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+/**
+ * The full-viewport chrome every lightbox in the site shares: a black field edge to edge, a slide
+ * counter, zoom controls, edge arrows, and a close button.
+ *
+ * This is the shape the legacy NAC widgets use, and viewers generally (PhotoSwipe, Lightbox2): the
+ * media gets the whole screen, and the chrome floats over it. Callers own the carousel and the
+ * slides — the shell only frames them — so the Gallery block can keep rendering Payload `Media`
+ * documents while a forecast renders remote URLs.
+ */
+type LightboxProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Accessible name for the dialog. */
+  title: string
+  /** Zero-based index of the slide on screen. */
+  index: number
+  count: number
+  onPrev: () => void
+  onNext: () => void
+  /**
+   * The active slide's zoom surface. Zoom controls render only when this is given, so a slide that
+   * can't zoom — a video, an outbound link — doesn't advertise buttons that do nothing.
+   */
+  zoomRef?: React.RefObject<ReactZoomPanPinchRef | null>
+  children: ReactNode
+}
+
+export function Lightbox({
+  open,
+  onOpenChange,
+  title,
+  index,
+  count,
+  onPrev,
+  onNext,
+  zoomRef,
+  children,
+}: LightboxProps) {
+  const multiple = count > 1
+  const contentRef = useRef<HTMLDivElement>(null)
+  useArrowKeyNavigation(open && multiple, onPrev, onNext)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        ref={contentRef}
+        hideClose
+        onOpenAutoFocus={(event) => {
+          // Radix focuses the first tabbable child on open, which lands on the zoom-in button and
+          // paints a focus ring on a control nobody touched. Focus the dialog itself instead — it
+          // carries `tabIndex={-1}`, so the focus trap, Escape, and Tab all still behave, and the
+          // first ring the user sees is one they caused.
+          event.preventDefault()
+          contentRef.current?.focus()
+        }}
+        // `focus:outline-none`: the dialog is only ever focused as a landing spot, never tabbed to,
+        // so it shouldn't draw a ring around the whole screen. The controls keep their own.
+        className="h-[100dvh] w-screen max-w-none border-0 bg-transparent p-0 shadow-none focus:outline-none sm:rounded-none"
+        overlayClassName="bg-black/95"
+      >
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <DialogDescription className="sr-only">
+          Viewing item {index + 1} of {count}. Use the arrow keys to move between items.
+        </DialogDescription>
+
+        {children}
+
+        <TopBar index={index} count={count} zoomRef={zoomRef} />
+        <EdgeArrows show={multiple} onPrev={onPrev} onNext={onNext} />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/**
+ * One slide's layout: the media centered in whatever height the chrome leaves it, with its caption
+ * beneath. The caption belongs to the slide rather than to the shell so it travels with the media
+ * as the carousel moves, instead of swapping under a still image mid-scroll.
+ */
+export function LightboxSlide({ caption, children }: { caption?: ReactNode; children: ReactNode }) {
+  return (
+    <div className="flex h-[100dvh] flex-col px-4 pb-5 pt-14 sm:px-20">
+      <div className="relative flex min-h-0 flex-1 items-center justify-center">{children}</div>
+      {caption && (
+        <div className="mx-auto max-h-[20vh] w-full max-w-3xl shrink-0 overflow-y-auto pt-4 text-center text-sm text-white/80">
+          {caption}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Carousel state for a lightbox: which slide is on screen, and how to move between them.
+ *
+ * The index is tracked here rather than read from the carousel on demand because the shell needs it
+ * to render (the counter, and whether the active slide can zoom). It is also set when the lightbox
+ * opens, before the carousel's first `select` fires, so the chrome is right on the first frame.
+ */
+export function useLightboxCarousel(startIndex: number, open: boolean) {
+  const [api, setApi] = useState<CarouselApi>()
+  const [index, setIndex] = useState(startIndex)
+
+  useEffect(() => {
+    if (open) setIndex(startIndex)
+  }, [open, startIndex])
+
+  useEffect(() => {
+    if (!api) return
+    // Jump without animating: this is the slide the user asked to open, not one they scrolled to.
+    api.scrollTo(startIndex, true)
+    setIndex(api.selectedScrollSnap())
+
+    const onSelect = () => setIndex(api.selectedScrollSnap())
+    api.on('select', onSelect)
+    return () => {
+      api.off('select', onSelect)
+    }
+  }, [api, startIndex])
+
+  const scrollPrev = useCallback(() => api?.scrollPrev(), [api])
+  const scrollNext = useCallback(() => api?.scrollNext(), [api])
+
+  return { setApi, index, scrollPrev, scrollNext }
+}
+
+/**
+ * Arrow keys navigate from anywhere on the page while the lightbox is open.
+ *
+ * The listener is on the window rather than on the carousel because Radix focuses the dialog
+ * container, not the carousel inside it, so the carousel's own key handler would never see them.
+ * Capture + `stopPropagation` keeps that handler from also firing once focus does land inside the
+ * carousel, which would advance two slides at a time.
+ */
+function useArrowKeyNavigation(active: boolean, onPrev: () => void, onNext: () => void) {
+  useEffect(() => {
+    if (!active) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') {
+        e.stopPropagation()
+        onPrev()
+      } else if (e.key === 'ArrowRight') {
+        e.stopPropagation()
+        onNext()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown, true)
+    return () => window.removeEventListener('keydown', onKeyDown, true)
+  }, [active, onPrev, onNext])
+}
+
+const chromeButtonClass =
+  'flex h-9 w-9 items-center justify-center rounded-full text-white/80 transition hover:bg-white/20 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60'
+
+/** The counter down one corner and the controls down the other, floating over the media. */
+function TopBar({
+  index,
+  count,
+  zoomRef,
+}: {
+  index: number
+  count: number
+  zoomRef?: React.RefObject<ReactZoomPanPinchRef | null>
+}) {
+  return (
+    <div className="pointer-events-none absolute inset-x-0 top-0 z-[70] flex items-start justify-between p-3">
+      {count > 1 ? (
+        <span className="rounded-full bg-black/40 px-3 py-1 text-sm tabular-nums text-white/80 backdrop-blur">
+          {index + 1} / {count}
+        </span>
+      ) : (
+        <span />
+      )}
+      <div className="pointer-events-auto flex items-center gap-1 rounded-full bg-black/40 p-1 backdrop-blur">
+        {zoomRef && <ZoomControls zoomRef={zoomRef} />}
+        <DialogClose className={chromeButtonClass} aria-label="Close">
+          <X className="h-5 w-5" />
+        </DialogClose>
+      </div>
+    </div>
+  )
+}
+
+function ZoomControls({ zoomRef }: { zoomRef: React.RefObject<ReactZoomPanPinchRef | null> }) {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => zoomRef.current?.zoomIn()}
+        aria-label="Zoom in"
+        className={chromeButtonClass}
+      >
+        <ZoomIn className="h-5 w-5" />
+      </button>
+      <button
+        type="button"
+        onClick={() => zoomRef.current?.zoomOut()}
+        aria-label="Zoom out"
+        className={chromeButtonClass}
+      >
+        <ZoomOut className="h-5 w-5" />
+      </button>
+      <button
+        type="button"
+        onClick={() => zoomRef.current?.resetTransform()}
+        aria-label="Reset zoom"
+        className={chromeButtonClass}
+      >
+        <RotateCcw className="h-5 w-5" />
+      </button>
+    </>
+  )
+}
+
+function EdgeArrows({
+  show,
+  onPrev,
+  onNext,
+}: {
+  show: boolean
+  onPrev: () => void
+  onNext: () => void
+}) {
+  if (!show) return null
+
+  return (
+    <>
+      <EdgeArrow direction="prev" onClick={onPrev} />
+      <EdgeArrow direction="next" onClick={onNext} />
+    </>
+  )
+}
+
+/**
+ * A full-height strip down one edge of the screen, so the whole margin beside the media advances
+ * the carousel rather than just the glyph.
+ */
+function EdgeArrow({ direction, onClick }: { direction: 'prev' | 'next'; onClick: () => void }) {
+  const isPrev = direction === 'prev'
+  const Icon = isPrev ? ChevronLeft : ChevronRight
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        // Blur on mouse click (detail > 0) to drop the lingering focus ring; keep focus on
+        // keyboard activation (detail === 0).
+        if (e.detail > 0) e.currentTarget.blur()
+        onClick()
+      }}
+      aria-label={isPrev ? 'Previous' : 'Next'}
+      className={`group absolute inset-y-0 z-[60] flex w-[10vw] min-w-14 items-center focus:outline-none ${
+        isPrev ? 'left-0 justify-start pl-2 sm:pl-4' : 'right-0 justify-end pr-2 sm:pr-4'
+      }`}
+    >
+      <span className="flex h-11 w-11 items-center justify-center rounded-md bg-white/10 text-white opacity-70 backdrop-blur transition group-hover:bg-white/20 group-hover:opacity-100 group-focus-visible:ring-2 group-focus-visible:ring-white/60">
+        <Icon className="h-6 w-6" />
+      </span>
+    </button>
+  )
+}

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -118,6 +118,10 @@ export function useLightboxCarousel(startIndex: number, open: boolean) {
 
   useEffect(() => {
     if (open) setIndex(startIndex)
+    // The carousel unmounts with the lightbox but never hands back a cleared api, so drop the
+    // destroyed instance here. Otherwise the next open re-runs the effect below against it: the
+    // scroll is a no-op and the index read comes back as the previously viewed slide.
+    else setApi(undefined)
   }, [open, startIndex])
 
   useEffect(() => {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -33,8 +33,10 @@ const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     overlayClassName?: string
+    /** Drop the built-in corner close button, for dialogs that render their own. */
+    hideClose?: boolean
   }
->(({ className, children, overlayClassName, ...props }, ref) => (
+>(({ className, children, overlayClassName, hideClose, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay className={overlayClassName} />
     <DialogPrimitive.Content
@@ -46,10 +48,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {!hideClose && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ))


### PR DESCRIPTION
## Description

The Gallery block's lightbox already ran full-bleed, but its chrome — slide counter, zoom buttons, edge arrows, caption — was wired directly into the block. The forecast view (on `native-product-pages`) has a second lightbox that opens as a boxed `max-w-4xl` card, and the legacy NAC widget it replaces hands the media the entire viewport. A photo of a crown line is the point of opening it; a card with the page showing around the edges is not.

This PR extracts the Gallery block's chrome into a shared `Lightbox` shell so the forecast lightbox can adopt the same shape. It is the first of two: this one lands on `main` and only touches the Gallery block; a follow-up on `native-product-pages` wires the forecast lightbox through the same shell.

The shell deliberately takes a `zoomRef` rather than a zoom surface, so it has no dependency on how a caller renders its media — the Gallery block keeps rendering Payload `Media` documents, and a forecast can render remote URLs through the same frame.

## Related Issues

None.

## Key Changes

- **New `src/components/Lightbox.tsx`** — the full-viewport chrome: black field edge to edge, slide counter in one corner, zoom and close in the other, full-height arrow strips down each edge, caption beneath the media. Exports `Lightbox`, `LightboxSlide`, and `useLightboxCarousel`.
- **`GalleryLightbox` renders through the shell**, shedding ~200 lines of inline chrome.
- **Arrow keys move to a window listener.** Radix focuses the dialog container rather than the carousel inside it, so the carousel's own key handler never saw them. Capture + `stopPropagation` keeps it from also firing once focus does land inside, which would advance two slides at a time.
- **Focus lands on the dialog on open, not the first tabbable child**, which was painting a focus ring on a zoom button nobody had touched.
- **Off-screen slides no longer mount their video player or zoom surface** — a non-active video slide shows a still instead of an `autoplay=1` iframe.
- **`DialogContent` grows a `hideClose` prop** for dialogs that render their own close button.
- **`ZoomableImage` fills its parent** (`height: 100%`) instead of hard-coding `85vh`, since the chrome decides how much room the media gets and only at layout time.

The second commit addresses two findings from reviewing the extracted shell on its own — see its message for details. Both are covered by tests.

## How to test

1. `pnpm dev`, then open `/blocks` on any tenant (e.g. `nwac.localhost:3000/blocks`) and scroll to the **Gallery** heading. The seeded gallery has three images, a YouTube item, and a Vimeo item.
2. Click a thumbnail. The lightbox should fill the viewport: counter top-left, zoom + close top-right, arrows down each edge, caption underneath.
3. Arrow keys move one slide at a time, from anywhere on the page. Escape closes.
4. On the YouTube/Vimeo slides the zoom controls should be **absent** — only the close button.
5. Zoom in on an image; it should fill the space the chrome leaves rather than a fixed 85vh. Reset returns it.
6. Open the last thumbnail, close, then open the first. It should open on slide 1 — not flash slide 5 first.
7. Narrow the window to ~500px; the chrome should still fit.

`pnpm tsc`, `pnpm lint`, `pnpm test` (656 passing, 9 of them new for the shell), `pnpm drift:check`, and `pnpm fallow:audit` are all clean.

## Screenshots / Demo video

Same page, same seeded gallery (three images, a YouTube item, a Vimeo item), same viewport — the "before" column is the three Gallery-facing files checked back out to `main`.

| | Before (`main`) | After |
| --- | --- | --- |
| **Image slide, 1440×900** | <img alt="before: image slide" src="https://github.com/user-attachments/assets/736f5a50-20b9-4727-9811-e9cd986677a0" /> | <img alt="after: image slide" src="https://github.com/user-attachments/assets/830dd28d-d902-45f7-811b-2a32e979b5ce" /> |
| **Zoomed 2×** | <img alt="before: zoomed" src="https://github.com/user-attachments/assets/17fdeffd-4ec6-4810-b507-b234c7682bc0" /> | <img alt="after: zoomed" src="https://github.com/user-attachments/assets/7ce3d8ad-8d46-4eba-a4b5-b6b4108ab7ca" /> |
| **YouTube slide** | <img alt="before: video slide" src="https://github.com/user-attachments/assets/ec537ac2-2074-419f-97e0-a59db6d0b578" /> | <img alt="after: video slide" src="https://github.com/user-attachments/assets/d21d6f09-65e3-4826-838d-f9a5f860dc1c" /> |
| **500px minimum width** | <img alt="before: narrow viewport" src="https://github.com/user-attachments/assets/d38a8bad-abed-4145-bd9e-bb86a15b397a" /> | <img alt="after: narrow viewport" src="https://github.com/user-attachments/assets/23acc262-ede4-4ed7-986f-99d4b1c5f6b3" /> |

What changes, reading down the columns: the new `1 / 5` slide counter; zoom and close merged into one control pill instead of a floating trio sitting next to Radix's own corner X; rounded arrow buttons in place of bare chevrons; a darker overlay (`black/95` vs `black/90`, so noticeably less page bleeding through); and the media getting more room now that it fills the space the chrome leaves rather than a fixed `85vh`. On the YouTube slide the zoom controls are absent in both — that behaviour is preserved, not new.

### Demo

https://github.com/user-attachments/assets/2a8bf75c-961d-4e39-a33e-8f35a594c7fc

Open from a thumbnail → step through with the edge arrows as the counter tracks → land on the YouTube slide and watch the zoom controls drop away → `ArrowLeft` back with no click → zoom in twice and reset through the chrome → close → reopen from a *different* thumbnail and land on `2 / 5`, which is the stale-carousel bug the second commit fixes → Escape.

## Migration Explanation

N/A — no schema changes.

## Future enhancements / Questions

- **Follow-up PR against `native-product-pages`** wires the forecast lightbox (`MediaLightbox`, `MediaSlide`, `ZoomablePhoto`) through this shell. It lands after this reaches that branch via the usual merge-from-main.
- **Focus is not restored to the trigger when the lightbox closes** — it lands on `<body>`. This is pre-existing (A/B tested with and without the new `onOpenAutoFocus` handler; identical either way) and is most likely Radix's `aria-hidden` treatment blurring the trigger. Out of scope here; worth its own issue.
- **The edge arrow strips (`w-[10vw]`) overrun the gutter `LightboxSlide` reserves** above ~800px viewport width, so they sit over the image at `z-[60]`. A press-drag starting near either edge of a *zoomed* image navigates instead of panning. This is pre-existing — `main` used wider `w-[12vw] min-w-16` strips — and the wide hit target is deliberate, but it's worth revisiting whether the strips should stop at the media's edge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790366349&installation_model_id=426131&pr_number=1232&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1232&signature=d45e042adec924077e4476986ef8bee81705621ce19ca92a039ef777b0890fe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
