### PR TITLE
Add the PAC theme

### DIFF
--- a/drift.lock
+++ b/drift.lock
@@ -468,12 +468,12 @@ sig = "68597c16ef37fc12"
 [[bindings]]
 doc = "docs/onboarding.md"
 target = "src/app/(frontend)/colors.css"
-sig = "15e0c2130028a5ab"
+sig = "a7a704bdd1a14052"
 
 [[bindings]]
 doc = "docs/onboarding.md"
 target = "src/app/api/[center]/og/centerColorMap.ts"
-sig = "73076591cf7c80aa"
+sig = "c62d9aedb3a11293"
 
 [[bindings]]
 doc = "docs/onboarding.md"

--- a/src/app/(frontend)/colors.css
+++ b/src/app/(frontend)/colors.css
@@ -198,46 +198,48 @@
   --nav-underline: var(--callout);
 }
 
-/* Payette Avalanche Center */
+/* Payette Avalanche Center — Deep Lake */
 .pac {
-  /* PAC BRAND COLORS */
-  --teal: hsl(178 83% 35%); /* rgb(15 166 162) - primary accent from links/logo */
-  --slate: hsl(210 9% 14%); /* rgb(32 35 38) - body text / dark */
-  --slate-gray: hsl(0 0% 22%); /* rgb(55 55 55) - footer */
-  /*--------------------------*/
+  --brand-50: hsl(199 55% 97%);
+  --brand-100: hsl(199 55% 94%);
+  --brand-200: hsl(199 55% 88%);
+  --brand-300: hsl(199 55% 76%);
+  --brand-400: hsl(199 55% 62%);
+  --brand-500: hsl(199 55% 48%);
+  --brand-600: hsl(199 55% 38%);
+  --brand-700: hsl(199 55% 29%);
+  --brand-800: hsl(199 55% 20%);
+  --brand-900: hsl(199 55% 13%);
+  --brand-950: hsl(199 55% 8%);
 
-  --brand-50: hsl(178 60% 96%);
-  --brand-100: hsl(178 64% 90%);
-  --brand-200: hsl(178 68% 78%);
-  --brand-300: hsl(178 73% 60%);
-  --brand-400: hsl(178 79% 44%);
-  --brand-500: var(--teal);
-  --brand-600: hsl(178 83% 29%);
-  --brand-700: hsl(181 58% 22%);
-  --brand-800: hsl(198 22% 18%);
-  --brand-900: var(--slate);
-  --brand-950: hsl(210 12% 10%);
+  --brand-foreground-50: hsl(240 10% 3.9%);
+  --brand-foreground-100: hsl(240 10% 3.9%);
+  --brand-foreground-200: hsl(240 10% 3.9%);
+  --brand-foreground-300: hsl(240 10% 3.9%);
+  --brand-foreground-400: hsl(240 10% 3.9%);
+  --brand-foreground-500: hsl(0 0% 100%);
+  --brand-foreground-600: hsl(0 0% 100%);
+  --brand-foreground-700: hsl(0 0% 100%);
+  --brand-foreground-800: hsl(0 0% 100%);
+  --brand-foreground-900: hsl(0 0% 100%);
+  --brand-foreground-950: hsl(0 0% 100%);
 
-  --primary: var(--teal);
-  --primary-hover: hsla(178 83% 35% / 0.85);
-
-  --secondary: var(--slate);
-  --secondary-hover: hsla(210 9% 14% / 0.85);
-  --secondary-foreground: hsl(0 0% 98%);
-
-  --header: hsl(0 0% 100%);
-  --header-foreground: var(--slate);
-  --header-foreground-highlight: var(--brand-700);
-
-  --footer: var(--slate-gray);
+  --primary: hsl(199 70% 20%);
+  --primary-hover: hsla(199 70% 20% / 0.85);
+  --primary-foreground: hsl(0 0% 100%);
+  --secondary: hsl(193 55% 45%);
+  --secondary-hover: hsla(193 55% 45% / 0.85);
+  --secondary-foreground: hsl(0 0% 100%);
+  --header: hsl(199 70% 16%);
+  --header-foreground: hsl(193 45% 77%);
+  --header-foreground-highlight: hsl(0 0% 100%);
+  --footer: hsl(199 70% 12%);
   --footer-foreground: hsl(0 0% 100%);
-  --header-foreground-highlight: var(--brand-700);
-
-  --callout: var(--teal);
-  --callout-hover: hsla(178 83% 35% / 0.85);
-  --callout-foreground: hsl(0 0% 100%);
-
-  --nav-underline: var(--teal);
+  --footer-foreground-highlight: hsl(0 0% 100%);
+  --callout: hsl(43 96% 50%);
+  --callout-hover: hsla(43 96% 50% / 0.85);
+  --callout-foreground: hsl(200 60% 10%);
+  --nav-underline: hsl(43 96% 50%);
 }
 
 .a3 {

--- a/src/app/api/[center]/og/centerColorMap.ts
+++ b/src/app/api/[center]/og/centerColorMap.ts
@@ -18,8 +18,8 @@ export const centerColorMap = {
     headerForeground: 'hsl(240 10% 3.9%)',
   },
   pac: {
-    header: 'hsl(0 0% 100%)',
-    headerForeground: 'hsl(210 9% 14%)',
+    header: 'hsl(199 70% 16%)',
+    headerForeground: 'hsl(193 45% 77%)',
   },
   default: {
     header: 'hsl(0 0% 100%)',


### PR DESCRIPTION
## Description

Restyles the Payette Avalanche Center theme from the teal palette added in `ab0d77e6` to a deep blue "Deep Lake" palette, with an amber callout.

The most visible change: **PAC's header flips from white to dark navy**, so header text goes from dark-on-white to light-on-navy. The footer deepens to match.

## Related Issues

Follow up for #767 

## Key Changes

- **`.pac` in `src/app/(frontend)/colors.css`** — new brand ramp on hue 199 (was hue 178 teal), navy `--header` / `--footer`, and an amber `--callout` + `--nav-underline` (`hsl(43 96% 50%)`) replacing the teal-on-teal callout.
- **`--brand-foreground-*` are now set explicitly.** The old block overrode `--brand-*` but inherited foregrounds from `:root`. The new ramp is lighter through the midtones, so the dark/light flip is pinned at 500 rather than left to the default.
- **Dropped the `--teal` / `--slate` / `--slate-gray` aliases.** Verified nothing outside the `.pac` block referenced them.
- **`centerColorMap.ts`** — PAC's OG-image header colors updated to match the new `--header` / `--header-foreground`. These are hand-copied from `colors.css` because CSS variables don't resolve in OG image generation, so they have to move together or social previews keep the old white header.
- **`drift.lock`** — re-signed the two `docs/onboarding.md` bindings. The doc describes the *process* for theming a center (which variables to override, `.dvac` as the example) and is unaffected by restyling an existing one, so this is a `--doc-is-still-accurate` re-confirm, not a doc edit.

### Drive-by fix

The old block had `--header-foreground-highlight` twice — once in the header group, once where `--footer-foreground-highlight` was clearly intended:

```css
  --footer: var(--slate-gray);
  --footer-foreground: hsl(0 0% 100%);
  --header-foreground-highlight: var(--brand-700);  /* ← meant to be --footer- */
```

So PAC's footer highlight was silently falling back to the `:root` gray. The new block sets it correctly.

## How to test
View PAC tenant

## Screenshots / Demo video
<img width="1581" height="1731" alt="Payette-Avalanche-Center-08-26-2026_01_50_PM" src="https://github.com/user-attachments/assets/aaaf74f1-6116-4530-875d-aeceef605bb9" />


## Migration Explanation

None needed — no schema changes.

## Future enhancements / Questions

- **Contrast worth a check before merge:** `--callout-foreground` is `hsl(200 60% 10%)` on the amber `--callout`, which is comfortably dark-on-light, but `--header-foreground` `hsl(193 45% 77%)` on `--header` `hsl(199 70% 16%)` is the pair most likely to matter for AA on small text. `snfac`'s button color was adjusted for exactly this reason in `25ce9e8c`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NWACus/codesmith/web/pr/1233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790367851&installation_model_id=426131&pr_number=1233&repository=NWACus%2Fweb&return_to=https%3A%2F%2Fgithub.com%2FNWACus%2Fweb%2Fpull%2F1233&signature=3a18bde78fec9afcc9cf75f949ba58554efea75c53a64b67bd4c80acf5db2943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->